### PR TITLE
ci: update workflow triggers and Docker tag strategy

### DIFF
--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -3,7 +3,6 @@ on:
   push: 
     branches:
       - main
-      - dev
     paths-ignore:
       - 'docker/**'
 

--- a/.github/workflows/app_build.yml
+++ b/.github/workflows/app_build.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
       - dev
+    paths-ignore:
+      - 'docker/**'
+
 jobs:
   deploy:
     runs-on: self-hosted

--- a/.github/workflows/code_quality.yml
+++ b/.github/workflows/code_quality.yml
@@ -2,7 +2,11 @@ name: Code quality
 
 on:
   push:
+    paths-ignore:
+      - 'docker/**'
   pull_request:
+    paths-ignore:
+      - 'docker/**'
 
 jobs:
   check:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,13 +1,14 @@
 name: Build and Push Docker Images
 
 on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
   pull_request:
     branches:
       - main
-      - dev
-  release:
-    types:
-      - published
   workflow_dispatch:
     inputs:
       push:
@@ -56,7 +57,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=edge,branch=main
 
       - name: Build and push ${{ matrix.image }} image
         uses: docker/build-push-action@v6


### PR DESCRIPTION
This stops the `app_build` and `code_quality` workflows being triggered by changes to anything in `docker/`, since these changes are irrelevant to both workflows.

When all the path names in a commit match `docker/**`, the workflows will not run. If any path names do not match this, even if some path names do match, the workflow will run.

In preparation for the removal of the dev branch, it also:
* Removes the dev branch from the push trigger in the `app_build` and `docker` workflows
* Updates the `docker` workflow:
	* Replaces the "release published" trigger with a `tags` trigger, restricted to tags prefixed with `v`
	* Pushes images with versioned (e.g. `1`, `1.2`, `1.2.3`) and `latest` tags when triggered by a new git tag
	* Pushes images with `edge` tag for builds on main - This is different from the agreed `rolling` tag, but it's much easier to implement as it's a native feature of one of the actions we're using and, IMO, is even clearer about what it is than `rolling`.