### PR TITLE
fix(auth): JWT_SECRET is required

### DIFF
--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -18,10 +18,10 @@ const authenticateToken = async (req, res, next) => {
 		}
 
 		// Verify token
-		const decoded = jwt.verify(
-			token,
-			process.env.JWT_SECRET || "your-secret-key",
-		);
+		if (!process.env.JWT_SECRET) {
+			throw new Error("JWT_SECRET environment variable is required");
+		}
+		const decoded = jwt.verify(token, process.env.JWT_SECRET);
 
 		// Validate session and check inactivity timeout
 		const validation = await validate_session(decoded.sessionId, token);
@@ -85,10 +85,10 @@ const optionalAuth = async (req, _res, next) => {
 		const token = authHeader?.split(" ")[1];
 
 		if (token) {
-			const decoded = jwt.verify(
-				token,
-				process.env.JWT_SECRET || "your-secret-key",
-			);
+			if (!process.env.JWT_SECRET) {
+				throw new Error("JWT_SECRET environment variable is required");
+			}
+			const decoded = jwt.verify(token, process.env.JWT_SECRET);
 			const user = await prisma.users.findUnique({
 				where: { id: decoded.userId },
 				select: {

--- a/backend/src/routes/authRoutes.js
+++ b/backend/src/routes/authRoutes.js
@@ -156,7 +156,10 @@ router.post(
 
 // Generate JWT token
 const generateToken = (userId) => {
-	return jwt.sign({ userId }, process.env.JWT_SECRET || "your-secret-key", {
+	if (!process.env.JWT_SECRET) {
+		throw new Error("JWT_SECRET environment variable is required");
+	}
+	return jwt.sign({ userId }, process.env.JWT_SECRET, {
 		expiresIn: process.env.JWT_EXPIRES_IN || "24h",
 	});
 };

--- a/backend/src/utils/session_manager.js
+++ b/backend/src/utils/session_manager.js
@@ -9,7 +9,10 @@ const prisma = new PrismaClient();
  */
 
 // Configuration
-const JWT_SECRET = process.env.JWT_SECRET || "your-secret-key";
+if (!process.env.JWT_SECRET) {
+	throw new Error("JWT_SECRET environment variable is required");
+}
+const JWT_SECRET = process.env.JWT_SECRET;
 const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || "1h";
 const JWT_REFRESH_EXPIRES_IN = process.env.JWT_REFRESH_EXPIRES_IN || "7d";
 const INACTIVITY_TIMEOUT_MINUTES = parseInt(


### PR DESCRIPTION
Remove all fallback default values for `env.JWT_SECRET` and just error out if secret is missing.

This is safer than using a default, and missing env should already be caught at startup anyway.