### PR TITLE
Ignore lost+found folder during copy of agent scripts (backend)

### DIFF
--- a/docker/backend.docker-entrypoint.sh
+++ b/docker/backend.docker-entrypoint.sh
@@ -9,7 +9,7 @@ log() {
 }
 
 # Copy files from agents_backup to agents if agents directory is empty
-if [ -d "/app/agents" ] && [ -z "$(ls -A /app/agents 2>/dev/null)" ]; then
+if [ -d "/app/agents" ] && [ -z "$(find /app/agents -mindepth 1 -not -name 'lost+found' | head -n 1)" ]; then
     if [ -d "/app/agents_backup" ]; then
         log "Agents directory is empty, copying from backup..."
         cp -r /app/agents_backup/* /app/agents/


### PR DESCRIPTION
When block storage is formatted with EXT4, there is automatically a lost+found directory created. For example when creating pvc's in kubernetes.
The entrypoint.sh script will not import agent files into the volume because it thinks the volume is not empty. 

This change ignores this folder.

There might be better ways to solve this, this is just a suggestion 😄 