### PR TITLE
Update timeout and maxWait times in hostRoutes.js

### DIFF
--- a/backend/src/routes/hostRoutes.js
+++ b/backend/src/routes/hostRoutes.js
@@ -536,6 +536,9 @@ router.post(
 						status: "success",
 					},
 				});
+			}, {
+				maxWait: 5000, // default: 2000
+				timeout: 10000 // default: 5000
 			});
 
 			// Agent auto-update is now handled client-side by the agent itself


### PR DESCRIPTION
Fix to allow slower systems to update successfully by increasing timeout to 10 seconds from 5 and maxWait to 5 seconds from 2.

I found that my Proxmox hosts were unable to successfully update their statuses with the default timeouts.  This tweak allows more time to account for slower systems.  Ideally in the future this would be a configurable variable rather than hardcoded.