### PR TITLE
Fixed docker agent for the 1.3.0 release

### DIFF
--- a/agents/patchmon-docker-agent.sh
+++ b/agents/patchmon-docker-agent.sh
@@ -68,8 +68,7 @@ check_docker() {
 # This function is crucial as yq is a dependency.
 check_yq_installed() {
     if ! command -v yq &> /dev/null; then
-        error "yq (YAML processor) is not installed. Please install it to parse YAML files."
-        echo "Refer to https://github.com/mikefarah/yq for installation instructions." >&2
+        error "yq (YAML processor) is not installed, but is required to run this agent."
     fi
 }
 


### PR DESCRIPTION
Docker agent does not work with the yaml format used by the 1.3.0 agent, this PR fixes https://github.com/PatchMon/PatchMon/issues/215 for now