### PR TITLE
Enable listen IPv6 for port 3000

### DIFF
--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -1,5 +1,6 @@
 server {
     listen 3000;
+	listen [::]:3000;
     server_name localhost;
     root /usr/share/nginx/html;
     index index.html;


### PR DESCRIPTION
Added IPv6 listening on port 3000 for MACVlan configurations in Docker with IPv6.