### PR TITLE
fix: persist Docker integration state to database

### DIFF
--- a/backend/prisma/migrations/20251202000000_add_docker_enabled_to_hosts/migration.sql
+++ b/backend/prisma/migrations/20251202000000_add_docker_enabled_to_hosts/migration.sql
@@ -1,0 +1,5 @@
+-- Add docker_enabled field to hosts table
+-- This field persists the Docker integration enabled state across container restarts
+-- Fixes GitHub issue #352
+
+ALTER TABLE "hosts" ADD COLUMN "docker_enabled" BOOLEAN NOT NULL DEFAULT false;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -112,6 +112,7 @@ model hosts {
   system_uptime           String?
   notes                   String?
   needs_reboot            Boolean?                  @default(false)
+  docker_enabled          Boolean                   @default(false)
   host_packages           host_packages[]
   host_repositories       host_repositories[]
   host_group_memberships  host_group_memberships[]


### PR DESCRIPTION
Previously, Docker integration enabled/disabled state was stored only in an in-memory cache (Map), which caused the setting to be lost whenever the backend container restarted.

Changes:
- Add docker_enabled boolean field to hosts table in Prisma schema
- Add database migration to add the column
- Update GET /hosts/:hostId/integrations to read from database
- Update POST /hosts/:hostId/integrations/:name/toggle to persist to database
- Keep in-memory cache for quick WebSocket lookups

Fixes #352