### PR TITLE
Update outdated nginx logic

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1379,8 +1379,7 @@ server {
 
 # HTTPS server block
 server {
-    listen 443 ssl;
-    http2 on;
+    listen 443 ssl http2;
     server_name $fqdn;
     
     # SSL Configuration


### PR DESCRIPTION
Fixed an issue with the installer where it uses `http2 on;` instead of putting it beside the ssl thing