### PR TITLE
feat(api): add include=stats parameter to GET /hosts endpoint

### DIFF
--- a/backend/src/routes/apiHostsRoutes.js
+++ b/backend/src/routes/apiHostsRoutes.js
@@ -750,6 +750,10 @@ router.get(
 
 // GET /api/v1/api/hosts/:id/packages - Paketliste fuer einen Host
 // Optional: ?updates_only=true - nur Pakete mit verfuegbaren Updates
+/* #swagger.tags = ['Hosts'] */
+/* #swagger.summary = 'Get host packages' */
+/* #swagger.description = 'Retrieve the list of packages installed on a specific host. Use the optional query parameter ?updates_only=true to return only packages with available updates. Requires Basic Auth with scoped credentials (host:get permission).' */
+/* #swagger.security = [{ "basicAuth": [] }] */
 router.get(
 	"/hosts/:id/packages",
 	authenticateApiToken("api"),
@@ -817,7 +821,7 @@ router.get(
 				total: formattedPackages.length,
 			});
 		} catch (error) {
-			console.error("Error fetching host packages:", error);
+			logger.error("Error fetching host packages:", error);
 			res.status(500).json({ error: "Failed to fetch host packages" });
 		}
 	},


### PR DESCRIPTION
Extends the GET /api/v1/api/hosts endpoint with an optional ?include=stats parameter and adds a new GET /api/v1/api/hosts/:id/packages endpoint for per-host package details.

1. GET /api/v1/api/hosts?include=stats
Without ?include=stats — behavior unchanged, fully backward-compatible.

With ?include=stats — each host object includes additional fields:

updates_count — number of outdated packages
security_updates_count — number of security updates
total_packages — total installed packages
needs_reboot — whether a reboot is required
os_type / os_version — OS information
last_update — timestamp of last package scan
status — host status
2. GET /api/v1/api/hosts/:id/packages (NEW)
Returns detailed package information for a specific host.

Optional query parameter: ?updates_only=true — only return packages with available updates.

Response fields per package:

name — package name
description / category — package metadata
current_version — currently installed version
available_version — available update version
needs_update — boolean
is_security_update — boolean
last_checked — timestamp
Motivation
Currently, to get update statistics for all hosts, a client must call GET /hosts and then GET /hosts/:id/stats for each host individually (N+1 problem). And there's no API to get the actual package list with version details at all.

These additions enable:

Dashboard views showing update counts in a single request
Detailed package views showing exactly which packages need updating
Monitoring integrations without N+1 query overhead
Implementation
Uses Prisma groupBy queries for batch stats aggregation (same pattern as the existing dashboard)
Packages endpoint uses Prisma relations for efficient joins
Only runs extra queries when explicitly requested
Zero impact on existing API consumers
No new dependencies
Test plan
 GET /api/v1/api/hosts returns hosts without stats fields (backward-compatible)
 GET /api/v1/api/hosts?include=stats returns hosts with all stats fields
 Stats values match per-host /hosts/:id/stats endpoint
 GET /api/v1/api/hosts/:id/packages returns all packages for a host
 GET /api/v1/api/hosts/:id/packages?updates_only=true returns only updatable packages
 Security updates are sorted first
 404 for non-existent host ID