### PR TITLE
fix: oidc login/logout loop when auto redirect to oidc is enabled

### DIFF
--- a/backend/src/routes/oidcRoutes.js
+++ b/backend/src/routes/oidcRoutes.js
@@ -450,7 +450,8 @@ router.get("/callback", async (req, res) => {
 		const isProduction = process.env.NODE_ENV === "production";
 		// Only use secure cookies if actually using HTTPS
 		const useSecureCookies = isSecure && isProduction;
-		const sameSiteValue = isProduction ? "strict" : "lax";
+		// Strict would block cookies on the redirect from IdP back to our app
+		const sameSiteValue = "lax";
 
 		logger.debug(
 			`OIDC: setting cookies - Secure: ${useSecureCookies}, SameSite: ${sameSiteValue}, IsHTTPS: ${isSecure}`,

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -242,6 +242,7 @@ export const AuthProvider = ({ children }) => {
 
 	const logout = async () => {
 		try {
+			sessionStorage.setItem("explicit_logout", "true");
 			// Logout via API - server will clear httpOnly cookies
 			await fetch("/api/v1/auth/logout", {
 				method: "POST",


### PR DESCRIPTION
# Fix OIDC Infinite Login/Logout Loop

## Problem
When OIDC authentication was enabled with local auth disabled, users experienced an infinite login/logout loop:

1. User logs out → redirected to `/login`
2. Login page auto-redirects to OIDC provider
3. OIDC provider authenticates (session still active)
4. User logged back in automatically
5. Loop continues until rate limit error: "Too many authentication requests"

Additionally, after successful OIDC login, users were stuck in a redirect loop between `/login?oidc=success` and `/`.

## Root Causes

### 1. Auto-redirect After Logout
The login page automatically redirected to OIDC when `disableLocalAuth` was enabled, without checking if the user had just logged out intentionally.

### 2. SameSite Cookie Policy
Production environment used `SameSite=Strict` for cookies, which prevented cookies from being sent during the redirect from the OIDC provider back to the application (cross-site navigation).

### 3. OIDC Callback Processing Loop
The OIDC callback useEffect was re-running multiple times due to:
- Dependencies on `navigate` and `setAuthState` functions that changed on every render
- URL parameter `?oidc=success` not being cleared before async operations
- State synchronization issues between Login page and AuthContext

## Changes

### Backend (`backend/src/routes/oidcRoutes.js`)
- **Changed `SameSite` cookie attribute from `strict` to `lax` for OIDC authentication cookies**
  - `SameSite=Lax` allows cookies to be sent on top-level navigation from external sites (like OIDC provider redirects)
  - `SameSite=Strict` was blocking cookies during the redirect from IdP → our app
  - This ensures authentication cookies are available immediately after OIDC redirect

### Frontend (`frontend/src/contexts/AuthContext.jsx`)
- **Added `explicit_logout` flag in sessionStorage when user logs out**
  - Prevents auto-redirect to OIDC immediately after logout
  - Allows users to see the login page after intentionally logging out

### Frontend (`frontend/src/pages/Login.jsx`)

#### 1. Prevent Auto-redirect After Logout
- Check for `explicit_logout` sessionStorage flag before auto-redirecting to OIDC
- If flag exists, show login page instead of auto-redirecting

#### 2. Clear Logout Flag on Manual Login
- Remove `explicit_logout` flag when user manually clicks "Login with SSO" button
- Allows user to log back in when ready

#### 3. Fix OIDC Callback Loop
- Added `oidcProcessed` state to prevent duplicate processing
- Changed useEffect dependencies from `[navigate, setAuthState]` to `[]` (run once on mount)
- Simplified callback handling: just redirect to `/` using `window.location.href`
- Let AuthContext's `validateSession` handle authentication state (avoids race conditions)
- Clear `explicit_logout` flag on successful OIDC callback

## Impact on Internal Login (Non-OIDC)

**No impact on regular username/password authentication:**

1. Regular login flow unchanged - still uses `handleSubmit` → `login()` → `navigate("/")`
2. The `explicit_logout` flag only affects OIDC auto-redirect behavior
3. Local auth forms are still shown when `disableLocalAuth` is false
4. Backend cookie changes only affect OIDC routes, not `/api/v1/auth/login`
5. All existing authentication mechanisms (TFA, remember me, etc.) continue to work

The changes are isolated to:
- OIDC-specific cookie settings in `oidcRoutes.js`
- Auto-redirect logic that only runs when `oidcConfig.enabled && oidcConfig.disableLocalAuth`
- Logout behavior to set a flag (doesn't affect login functionality)
