### PR TITLE
fix: optimize dashboard for screens with 21:9

### DIFF
--- a/COMPLIANCE_CLEANUP_PR.md
+++ b/COMPLIANCE_CLEANUP_PR.md
@@ -1,0 +1,28 @@
+# Automatic Compliance Scan Cleanup
+
+## Summary
+Adds automated cleanup for stalled compliance scans that have been running for more than 3 hours.
+
+## What's New
+
+### Backend
+- **New Automation Service**: `ComplianceScanCleanup` automatically terminates scans running over 3 hours
+- **Schedule**: Runs daily at 1 AM
+- **Manual Trigger**: New endpoint `POST /api/v1/compliance/scans/cleanup` for on-demand cleanup
+- **Monitoring**: New endpoint `GET /api/v1/compliance/scans/stalled` to view stuck scans without cleaning them
+
+### Frontend
+- **Automation Page**: Compliance Scan Cleanup now appears in the Automation Management page
+- **Manual Trigger**: Users can manually trigger cleanup via the "Run Now" button
+- **Schedule Display**: Added support for "Daily at 1 AM" schedule display
+
+## Changes
+- Compliance scans running over 3 hours are automatically marked as failed
+- Cleanup runs daily at 1 AM (configurable)
+- Manual cleanup can be triggered from the Automation page
+- Detailed logging of terminated scans with runtime information
+
+## Benefits
+- Prevents database bloat from stuck compliance scans
+- Improves system performance by cleaning up long-running processes
+- Provides visibility into scan health through the stalled scans endpoint

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.2/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.3/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",

--- a/frontend/src/pages/Hosts.jsx
+++ b/frontend/src/pages/Hosts.jsx
@@ -1879,10 +1879,7 @@ const Hosts = () => {
 
 												{/* Desktop Table Layout */}
 												<div className="hidden md:block">
-													<table
-														className="min-w-full divide-y divide-secondary-200 dark:divide-secondary-600"
-														style={{ minWidth: "max-content" }}
-													>
+													<table className="w-full divide-y divide-secondary-200 dark:divide-secondary-600">
 														<thead className="bg-secondary-50 dark:bg-secondary-700">
 															<tr>
 																{visibleColumns.map((column) => (


### PR DESCRIPTION
# Fix: Hosts Table Layout on Ultrawide Monitors

## Changes

- Changed hosts table from `min-w-full` to `w-full` to properly fill available horizontal space
- Removed `minWidth: "max-content"` inline style constraint
- Table now expands to fill the full width of its container on ultrawide (21:9) displays

## Issue

On 21:9 monitors, the hosts table was leaving empty space on the right side while working perfectly on 16:9 displays. The table was only expanding to its minimum required width rather than filling the available space.
<img width="1466" height="659" alt="image" src="https://github.com/user-attachments/assets/725e0740-344e-4eec-b614-3d0373800ba5" />

## Solution

Updated the table className in `/frontend/src/pages/Hosts.jsx` (line ~1883) to use `w-full` instead of `min-w-full`, ensuring the table utilizes all available horizontal space across different screen aspect ratios.
<img width="1466" height="659" alt="image" src="https://github.com/user-attachments/assets/f323dc91-f69f-435b-9d95-dd65bfb50e5e" />
