### PR TITLE
Add OpenBSD Agent Support

### DIFF
--- a/agent-source-code/Makefile
+++ b/agent-source-code/Makefile
@@ -55,11 +55,20 @@ build-windows:
 	@GOOS=windows GOARCH=amd64 CGO_ENABLED=0 $(GO_CMD) build $(BUILD_FLAGS) $(LDFLAGS) -o $(GOBIN)/$(BINARY_NAME)-windows-amd64.exe ./cmd/patchmon-agent
 	@GOOS=windows GOARCH=arm64 CGO_ENABLED=0 $(GO_CMD) build $(BUILD_FLAGS) $(LDFLAGS) -o $(GOBIN)/$(BINARY_NAME)-windows-arm64.exe ./cmd/patchmon-agent
 
-# Build all (Linux + FreeBSD + Windows) and copy to backend serve dirs
+# Build OpenBSD binaries only (amd64, arm64)
+.PHONY: build-openbsd
+build-openbsd:
+	@mkdir -p $(BUILD_DIR)
+	@GOOS=openbsd GOARCH=amd64 CGO_ENABLED=0 $(GO_CMD) build $(BUILD_FLAGS) $(LDFLAGS) -o $(GOBIN)/$(BINARY_NAME)-openbsd-amd64 ./cmd/patchmon-agent
+	@GOOS=openbsd GOARCH=386 CGO_ENABLED=0 $(GO_CMD) build $(BUILD_FLAGS) $(LDFLAGS) -o $(GOBIN)/$(BINARY_NAME)-openbsd-386 ./cmd/patchmon-agent
+	@GOOS=openbsd GOARCH=arm64 CGO_ENABLED=0 $(GO_CMD) build $(BUILD_FLAGS) $(LDFLAGS) -o $(GOBIN)/$(BINARY_NAME)-openbsd-arm64 ./cmd/patchmon-agent
+	@GOOS=openbsd GOARCH=arm GOARM=6 CGO_ENABLED=0 $(GO_CMD) build $(BUILD_FLAGS) $(LDFLAGS) -o $(GOBIN)/$(BINARY_NAME)-openbsd-arm ./cmd/patchmon-agent
+
+# Build all (Linux + FreeBSD + OpenBSD + Windows) and copy to backend serve dirs
 .PHONY: build-all
-build-all: build-linux build-freebsd build-windows
+build-all: build-linux build-freebsd build-openbsd build-windows
 	@mkdir -p $(AGENTS_REPO) $(AGENTS_DOCKER)
-	@for f in $(GOBIN)/$(BINARY_NAME)-linux-* $(GOBIN)/$(BINARY_NAME)-freebsd-* $(GOBIN)/$(BINARY_NAME)-windows-*.exe; do \
+	@for f in $(GOBIN)/$(BINARY_NAME)-linux-* $(GOBIN)/$(BINARY_NAME)-freebsd-* $(GOBIN)/$(BINARY_NAME)-openbsd-* $(GOBIN)/$(BINARY_NAME)-windows-*.exe; do \
 		[ -f "$$f" ] && cp "$$f" $(AGENTS_REPO)/ && cp "$$f" $(AGENTS_DOCKER)/; \
 	done
 	@echo "Done. agents/ and docker/compose_dev_data/agents/ updated."
@@ -69,7 +78,7 @@ build-all: build-linux build-freebsd build-windows
 build-all-for-docker:
 	@mkdir -p ../agents-prebuilt
 	@$(MAKE) build-all
-	@cp $(BUILD_DIR)/$(BINARY_NAME)-linux-* $(BUILD_DIR)/$(BINARY_NAME)-freebsd-* $(BUILD_DIR)/$(BINARY_NAME)-windows-*.exe ../agents-prebuilt/ 2>/dev/null || true
+	@cp $(BUILD_DIR)/$(BINARY_NAME)-linux-* $(BUILD_DIR)/$(BINARY_NAME)-freebsd-* $(BUILD_DIR)/$(BINARY_NAME)-openbsd-* $(BUILD_DIR)/$(BINARY_NAME)-windows-*.exe ../agents-prebuilt/ 2>/dev/null || true
 	@echo "Agent binaries copied to agents-prebuilt/"
 
 # Install dependencies
@@ -141,8 +150,9 @@ help:
 	@echo "  build         Build the application"
 	@echo "  build-linux   Build Linux binaries (amd64, 386, arm64, arm)"
 	@echo "  build-freebsd Build FreeBSD binaries (amd64, 386, arm64, arm)"
+	@echo "  build-openbsd Build OpenBSD binaries (amd64, 386, arm64, arm)"
 	@echo "  build-windows Build Windows binaries (amd64, arm64)"
-	@echo "  build-all     Build Linux + FreeBSD + Windows and copy to agents/"
+	@echo "  build-all     Build Linux + FreeBSD + OpenBSD + Windows and copy to agents/"
 	@echo "  build-all-for-docker  Build all binaries into agents-prebuilt/ for local Docker build"
 	@echo "  deps          Install dependencies"
 	@echo "  test          Run tests"

--- a/agent-source-code/Makefile
+++ b/agent-source-code/Makefile
@@ -69,11 +69,20 @@ build-windows:
 	@GOOS=windows GOARCH=amd64 CGO_ENABLED=0 $(GO_CMD) build $(BUILD_FLAGS) $(LDFLAGS) -o $(GOBIN)/$(BINARY_NAME)-windows-amd64.exe ./cmd/patchmon-agent
 	@GOOS=windows GOARCH=arm64 CGO_ENABLED=0 $(GO_CMD) build $(BUILD_FLAGS) $(LDFLAGS) -o $(GOBIN)/$(BINARY_NAME)-windows-arm64.exe ./cmd/patchmon-agent
 
-# Build all (Linux + FreeBSD + Windows) and copy to backend serve dirs
+# Build OpenBSD binaries only (amd64, arm64)
+.PHONY: build-openbsd
+build-openbsd:
+	@mkdir -p $(BUILD_DIR)
+	@GOOS=openbsd GOARCH=amd64 CGO_ENABLED=0 $(GO_CMD) build $(BUILD_FLAGS) $(LDFLAGS) -o $(GOBIN)/$(BINARY_NAME)-openbsd-amd64 ./cmd/patchmon-agent
+	@GOOS=openbsd GOARCH=386 CGO_ENABLED=0 $(GO_CMD) build $(BUILD_FLAGS) $(LDFLAGS) -o $(GOBIN)/$(BINARY_NAME)-openbsd-386 ./cmd/patchmon-agent
+	@GOOS=openbsd GOARCH=arm64 CGO_ENABLED=0 $(GO_CMD) build $(BUILD_FLAGS) $(LDFLAGS) -o $(GOBIN)/$(BINARY_NAME)-openbsd-arm64 ./cmd/patchmon-agent
+	@GOOS=openbsd GOARCH=arm GOARM=6 CGO_ENABLED=0 $(GO_CMD) build $(BUILD_FLAGS) $(LDFLAGS) -o $(GOBIN)/$(BINARY_NAME)-openbsd-arm ./cmd/patchmon-agent
+
+# Build all (Linux + FreeBSD + OpenBSD + Windows) and copy to backend serve dirs
 .PHONY: build-all
-build-all: build-linux build-freebsd build-windows
+build-all: build-linux build-freebsd build-openbsd build-windows
 	@mkdir -p $(AGENTS_REPO) $(AGENTS_DOCKER)
-	@for f in $(GOBIN)/$(BINARY_NAME)-linux-* $(GOBIN)/$(BINARY_NAME)-freebsd-* $(GOBIN)/$(BINARY_NAME)-windows-*.exe; do \
+	@for f in $(GOBIN)/$(BINARY_NAME)-linux-* $(GOBIN)/$(BINARY_NAME)-freebsd-* $(GOBIN)/$(BINARY_NAME)-openbsd-* $(GOBIN)/$(BINARY_NAME)-windows-*.exe; do \
 		[ -f "$$f" ] && cp "$$f" $(AGENTS_REPO)/ && cp "$$f" $(AGENTS_DOCKER)/; \
 	done
 	@echo "Done. agents/ and docker/compose_dev_data/agents/ updated."
@@ -83,7 +92,7 @@ build-all: build-linux build-freebsd build-windows
 build-all-for-docker:
 	@mkdir -p ../agents-prebuilt
 	@$(MAKE) build-all
-	@cp $(BUILD_DIR)/$(BINARY_NAME)-linux-* $(BUILD_DIR)/$(BINARY_NAME)-freebsd-* $(BUILD_DIR)/$(BINARY_NAME)-windows-*.exe ../agents-prebuilt/ 2>/dev/null || true
+	@cp $(BUILD_DIR)/$(BINARY_NAME)-linux-* $(BUILD_DIR)/$(BINARY_NAME)-freebsd-* $(BUILD_DIR)/$(BINARY_NAME)-openbsd-* $(BUILD_DIR)/$(BINARY_NAME)-windows-*.exe ../agents-prebuilt/ 2>/dev/null || true
 	@echo "Agent binaries copied to agents-prebuilt/"
 
 # Install dependencies
@@ -155,8 +164,9 @@ help:
 	@echo "  build         Build the application"
 	@echo "  build-linux   Build Linux binaries (amd64, 386, arm64, arm)"
 	@echo "  build-freebsd Build FreeBSD binaries (amd64, 386, arm64, arm)"
+	@echo "  build-openbsd Build OpenBSD binaries (amd64, 386, arm64, arm)"
 	@echo "  build-windows Build Windows binaries (amd64, arm64)"
-	@echo "  build-all     Build Linux + FreeBSD + Windows and copy to agents/"
+	@echo "  build-all     Build Linux + FreeBSD + OpenBSD + Windows and copy to agents/"
 	@echo "  build-all-for-docker  Build all binaries into agents-prebuilt/ for local Docker build"
 	@echo "  deps          Install dependencies"
 	@echo "  test          Run tests"

--- a/agent-source-code/cmd/patchmon-agent/commands/serve.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/serve.go
@@ -2028,6 +2028,22 @@ func freeBSDUpdateOutputHasPendingUpdates(output string) bool {
 	return strings.Contains(output, "will be updated") || strings.Contains(output, "will be installed")
 }
 
+// isOpenBSDSyspatchID reports whether name refers to a syspatch entry.
+// This covers both the canonical single-entry name "syspatch" and any full
+// patch ID in the form "NNN_component" (e.g. "015_tmppath") for forward compatibility.
+func isOpenBSDSyspatchID(name string) bool {
+	if name == "syspatch" {
+		return true
+	}
+	// Patch IDs from syspatch -c have the form "NNN_component"
+	if len(name) < 5 || name[3] != '_' {
+		return false
+	}
+	return name[0] >= '0' && name[0] <= '9' &&
+		name[1] >= '0' && name[1] <= '9' &&
+		name[2] >= '0' && name[2] <= '9'
+}
+
 func splitFreeBSDPatchTargets(packageNames []string) ([]string, bool) {
 	filtered := make([]string, 0, len(packageNames))
 	includeBase := false
@@ -2213,7 +2229,7 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 		return runPatchWindows(ctx, httpClient, patchRunID, patchType, packageNames, dryRun)
 	}
 
-	if pkgManager != "apt" && pkgManager != "dnf" && pkgManager != "yum" && pkgManager != "pkg" && pkgManager != "pacman" {
+	if pkgManager != "apt" && pkgManager != "dnf" && pkgManager != "yum" && pkgManager != "pkg" && pkgManager != "pacman" && pkgManager != "pkg_info" {
 		errMsg := fmt.Sprintf("package manager %q not supported for patching (apt, dnf, yum, pkg, pacman required)", pkgManager)
 		_ = httpClient.SendPatchOutput(ctx, patchRunID, "failed", "", errMsg)
 		return fmt.Errorf("%s", errMsg)
@@ -2244,6 +2260,13 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 				return fmt.Errorf("freebsd-update not found: %w", err)
 			}
 		}
+	case "pkg_info":
+		// OpenBSD: pkg_add -u for binary packages, syspatch for base patches
+		if _, err := exec.LookPath("pkg_add"); err != nil {
+			_ = httpClient.SendPatchOutput(ctx, patchRunID, "failed", "", "pkg_add not found: not an OpenBSD system")
+			return fmt.Errorf("pkg_add not found: %w", err)
+		}
+		upgradeBin = "pkg_add"
 	case "pacman":
 		if _, err := exec.LookPath("pacman"); err != nil {
 			_ = httpClient.SendPatchOutput(ctx, patchRunID, "failed", "", "pacman not found: Arch Linux package manager not installed")
@@ -2286,6 +2309,37 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 		return fmt.Errorf(errFmt, err), true
 	}
 
+	// runSyspatch runs syspatch and handles exit code 2, which means syspatch
+	// updated itself and must be re-run to install remaining patches.
+	// Returns (error, shouldAbort).
+	runSyspatch := func(args ...string) (error, bool) {
+		sink.WriteString(formatCmd("syspatch", args...))
+		sink.Flush()
+		err := runStreamingPatchStep(ctx, sink, env, "syspatch", args...)
+		if err == nil {
+			return nil, false
+		}
+		// Exit code 2: syspatch updated itself — re-run to install remaining patches
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 2 {
+			sink.WriteString("\n[syspatch] Updated itself, re-running to install remaining patches...\n")
+			sink.Flush()
+			sink.WriteString(formatCmd("syspatch", args...))
+			sink.Flush()
+			err2 := runStreamingPatchStep(ctx, sink, env, "syspatch", args...)
+			if err2 == nil {
+				return nil, false
+			}
+			logger.WithError(err2).Warn("syspatch (re-run) failed")
+			sink.WriteString(fmt.Sprintf("\n[syspatch error] %s\n", err2.Error()))
+			sink.Flush()
+			return fmt.Errorf("syspatch failed: %w", err2), true
+		}
+		logger.WithError(err).Warn("syspatch failed")
+		sink.WriteString(fmt.Sprintf("\n[syspatch error] %s\n", err.Error()))
+		sink.Flush()
+		return fmt.Errorf("syspatch failed: %w", err), true
+	}
+
 	var stepErr error
 
 	if includeFreeBSDBase {
@@ -2316,6 +2370,8 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 			if err, abort := runStep(false, "pkg update", "pkg update failed: %w", upgradeBin, "update"); abort {
 				stepErr = err
 			}
+		case "pkg_info":
+			// OpenBSD: no separate cache update step — pkg_add fetches on demand
 		case "pacman":
 			if err, abort := runStep(false, "pacman refresh", "pacman -Sy failed: %w", "pacman", "-Sy", "--noconfirm"); abort {
 				stepErr = err
@@ -2348,6 +2404,27 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 				} else {
 					if err, abort := runStep(false, "pkg upgrade", "pkg upgrade failed: %w", upgradeBin, "upgrade", "-y"); abort {
 						stepErr = err
+					}
+				}
+			case "pkg_info":
+				// OpenBSD patch_all: run syspatch for base patches, then pkg_add -u for all binary packages
+				if dryRun {
+					if err, abort := runStep(true, "syspatch -c", "syspatch -c failed: %w", "syspatch", "-c"); abort {
+						stepErr = err
+					}
+					if stepErr == nil {
+						if err, abort := runStep(false, "pkg_add -u -n", "pkg_add -u -n failed: %w", "pkg_add", "-u", "-n"); abort {
+							stepErr = err
+						}
+					}
+				} else {
+					if err, abort := runSyspatch(); abort {
+						stepErr = err
+					}
+					if stepErr == nil {
+						if err, abort := runStep(false, "pkg_add -u", "pkg_add -u failed: %w", "pkg_add", "-u"); abort {
+							stepErr = err
+						}
 					}
 				}
 			case "pacman":
@@ -2414,6 +2491,42 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 					args := append([]string{"-S", "--noconfirm"}, packageNames...)
 					if err, abort := runStep(false, "pacman -S", "pacman -S failed: %w", "pacman", args...); abort {
 						stepErr = err
+					}
+				}
+			case "pkg_info":
+				// OpenBSD patch_package: syspatch for base patches, pkg_add -u for binary packages.
+				// Syspatch entries have Names that are patch IDs: "NNN_component" (e.g. "015_tmppath").
+				openBSDSyspatches := []string{}
+				openBSDPkgs := []string{}
+				for _, name := range packageNames {
+					if isOpenBSDSyspatchID(name) {
+						openBSDSyspatches = append(openBSDSyspatches, name)
+					} else {
+						openBSDPkgs = append(openBSDPkgs, name)
+					}
+				}
+				if len(openBSDSyspatches) > 0 {
+					if dryRun {
+						if err, abort := runStep(true, "syspatch -c", "syspatch -c failed: %w", "syspatch", "-c"); abort {
+							stepErr = err
+						}
+					} else {
+						if err, abort := runSyspatch(); abort {
+							stepErr = err
+						}
+					}
+				}
+				if stepErr == nil && len(openBSDPkgs) > 0 {
+					if dryRun {
+						args := append([]string{"-u", "-n"}, openBSDPkgs...)
+						if err, abort := runStep(false, "pkg_add -u -n", "pkg_add -u -n failed: %w", "pkg_add", args...); abort {
+							stepErr = err
+						}
+					} else {
+						args := append([]string{"-u"}, openBSDPkgs...)
+						if err, abort := runStep(false, "pkg_add -u", "pkg_add -u failed: %w", "pkg_add", args...); abort {
+							stepErr = err
+						}
 					}
 				}
 			default: // dnf, yum

--- a/agent-source-code/cmd/patchmon-agent/commands/serve.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/serve.go
@@ -2114,6 +2114,22 @@ func freeBSDUpdateOutputHasPendingUpdates(output string) bool {
 	return strings.Contains(output, "will be updated") || strings.Contains(output, "will be installed")
 }
 
+// isOpenBSDSyspatchID reports whether name refers to a syspatch entry.
+// This covers both the canonical single-entry name "syspatch" and any full
+// patch ID in the form "NNN_component" (e.g. "015_tmppath") for forward compatibility.
+func isOpenBSDSyspatchID(name string) bool {
+	if name == "syspatch" {
+		return true
+	}
+	// Patch IDs from syspatch -c have the form "NNN_component"
+	if len(name) < 5 || name[3] != '_' {
+		return false
+	}
+	return name[0] >= '0' && name[0] <= '9' &&
+		name[1] >= '0' && name[1] <= '9' &&
+		name[2] >= '0' && name[2] <= '9'
+}
+
 func splitFreeBSDPatchTargets(packageNames []string) ([]string, bool) {
 	filtered := make([]string, 0, len(packageNames))
 	includeBase := false
@@ -2342,7 +2358,7 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 		return runPatchWindows(ctx, httpClient, patchRunID, patchType, packageNames, dryRun)
 	}
 
-	if pkgManager != "apt" && pkgManager != "dnf" && pkgManager != "yum" && pkgManager != "pkg" && pkgManager != "pacman" {
+	if pkgManager != "apt" && pkgManager != "dnf" && pkgManager != "yum" && pkgManager != "pkg" && pkgManager != "pacman" && pkgManager != "pkg_info" {
 		errMsg := fmt.Sprintf("package manager %q not supported for patching (apt, dnf, yum, pkg, pacman required)", pkgManager)
 		_ = httpClient.SendPatchOutput(ctx, patchRunID, "failed", "", errMsg)
 		return fmt.Errorf("%s", errMsg)
@@ -2373,6 +2389,13 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 				return fmt.Errorf("freebsd-update not found: %w", err)
 			}
 		}
+	case "pkg_info":
+		// OpenBSD: pkg_add -u for binary packages, syspatch for base patches
+		if _, err := exec.LookPath("pkg_add"); err != nil {
+			_ = httpClient.SendPatchOutput(ctx, patchRunID, "failed", "", "pkg_add not found: not an OpenBSD system")
+			return fmt.Errorf("pkg_add not found: %w", err)
+		}
+		upgradeBin = "pkg_add"
 	case "pacman":
 		if _, err := exec.LookPath("pacman"); err != nil {
 			_ = httpClient.SendPatchOutput(ctx, patchRunID, "failed", "", "pacman not found: Arch Linux package manager not installed")
@@ -2431,6 +2454,37 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 		return fmt.Errorf(errFmt, err), true
 	}
 
+	// runSyspatch runs syspatch and handles exit code 2, which means syspatch
+	// updated itself and must be re-run to install remaining patches.
+	// Returns (error, shouldAbort).
+	runSyspatch := func(args ...string) (error, bool) {
+		sink.WriteString(formatCmd("syspatch", args...))
+		sink.Flush()
+		_, err := runStreamingPatchStep(ctx, sink, env, "syspatch", args...)
+		if err == nil {
+			return nil, false
+		}
+		// Exit code 2: syspatch updated itself — re-run to install remaining patches
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 2 {
+			sink.WriteString("\n[syspatch] Updated itself, re-running to install remaining patches...\n")
+			sink.Flush()
+			sink.WriteString(formatCmd("syspatch", args...))
+			sink.Flush()
+			_, err2 := runStreamingPatchStep(ctx, sink, env, "syspatch", args...)
+			if err2 == nil {
+				return nil, false
+			}
+			logger.WithError(err2).Warn("syspatch (re-run) failed")
+			sink.WriteString(fmt.Sprintf("\n[syspatch error] %s\n", err2.Error()))
+			sink.Flush()
+			return fmt.Errorf("syspatch failed: %w", err2), true
+		}
+		logger.WithError(err).Warn("syspatch failed")
+		sink.WriteString(fmt.Sprintf("\n[syspatch error] %s\n", err.Error()))
+		sink.Flush()
+		return fmt.Errorf("syspatch failed: %w", err), true
+	}
+
 	var stepErr error
 
 	if includeFreeBSDBase {
@@ -2456,6 +2510,8 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 			if err, abort := runStep(false, "pkg update", "pkg update failed: %w", upgradeBin, "update"); abort {
 				stepErr = err
 			}
+		case "pkg_info":
+			// OpenBSD: no separate cache update step — pkg_add fetches on demand
 		case "pacman":
 			if err, abort := runStep(false, "pacman refresh", "pacman -Sy failed: %w", "pacman", "-Sy", "--noconfirm"); abort {
 				stepErr = err
@@ -2499,6 +2555,27 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 				} else {
 					if err, abort := runStep(false, "pkg upgrade", "pkg upgrade failed: %w", upgradeBin, "upgrade", "-y"); abort {
 						stepErr = err
+					}
+				}
+			case "pkg_info":
+				// OpenBSD patch_all: run syspatch for base patches, then pkg_add -u for all binary packages
+				if dryRun {
+					if err, abort := runStep(true, "syspatch -c", "syspatch -c failed: %w", "syspatch", "-c"); abort {
+						stepErr = err
+					}
+					if stepErr == nil {
+						if err, abort := runStep(false, "pkg_add -u -n", "pkg_add -u -n failed: %w", "pkg_add", "-u", "-n"); abort {
+							stepErr = err
+						}
+					}
+				} else {
+					if err, abort := runSyspatch(); abort {
+						stepErr = err
+					}
+					if stepErr == nil {
+						if err, abort := runStep(false, "pkg_add -u", "pkg_add -u failed: %w", "pkg_add", "-u"); abort {
+							stepErr = err
+						}
 					}
 				}
 			case "pacman":
@@ -2565,6 +2642,42 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 					args := append([]string{"-S", "--noconfirm"}, packageNames...)
 					if err, abort := runStep(false, "pacman -S", "pacman -S failed: %w", "pacman", args...); abort {
 						stepErr = err
+					}
+				}
+			case "pkg_info":
+				// OpenBSD patch_package: syspatch for base patches, pkg_add -u for binary packages.
+				// Syspatch entries have Names that are patch IDs: "NNN_component" (e.g. "015_tmppath").
+				openBSDSyspatches := []string{}
+				openBSDPkgs := []string{}
+				for _, name := range packageNames {
+					if isOpenBSDSyspatchID(name) {
+						openBSDSyspatches = append(openBSDSyspatches, name)
+					} else {
+						openBSDPkgs = append(openBSDPkgs, name)
+					}
+				}
+				if len(openBSDSyspatches) > 0 {
+					if dryRun {
+						if err, abort := runStep(true, "syspatch -c", "syspatch -c failed: %w", "syspatch", "-c"); abort {
+							stepErr = err
+						}
+					} else {
+						if err, abort := runSyspatch(); abort {
+							stepErr = err
+						}
+					}
+				}
+				if stepErr == nil && len(openBSDPkgs) > 0 {
+					if dryRun {
+						args := append([]string{"-u", "-n"}, openBSDPkgs...)
+						if err, abort := runStep(false, "pkg_add -u -n", "pkg_add -u -n failed: %w", "pkg_add", args...); abort {
+							stepErr = err
+						}
+					} else {
+						args := append([]string{"-u"}, openBSDPkgs...)
+						if err, abort := runStep(false, "pkg_add -u", "pkg_add -u failed: %w", "pkg_add", args...); abort {
+							stepErr = err
+						}
 					}
 				}
 			default: // dnf, yum

--- a/agent-source-code/cmd/patchmon-agent/commands/sysproc_openbsd.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/sysproc_openbsd.go
@@ -1,0 +1,11 @@
+//go:build openbsd
+
+package commands
+
+import "syscall"
+
+// sysProcAttrForDetach returns SysProcAttr to detach a child process (new session).
+// OpenBSD: Setsid creates a new session so the child survives parent exit.
+func sysProcAttrForDetach() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setsid: true}
+}

--- a/agent-source-code/cmd/patchmon-agent/commands/version_update.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/version_update.go
@@ -596,10 +596,62 @@ func markRecentUpdate() {
 	logger.Debug("Marked recent update to prevent update loops")
 }
 
-// restartService restarts the patchmon-agent service (supports systemd, OpenRC, and FreeBSD rc.d)
+// restartService restarts the patchmon-agent service (supports systemd, OpenRC, FreeBSD rc.d, and OpenBSD rc.d)
 func restartService(_ string, _ string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
+
+	// OpenBSD: use rcctl restart
+	if runtime.GOOS == "openbsd" {
+		logger.Debug("Detected OpenBSD, scheduling service restart via helper script")
+		if err := os.MkdirAll("/etc/patchmon", 0700); err != nil {
+			logger.WithError(err).Warn("Failed to create /etc/patchmon directory, will try anyway")
+		}
+		helperScript := `#!/bin/sh
+sleep 2
+rcctl restart patchmon_agent 2>/dev/null || rcctl start patchmon_agent 2>/dev/null
+rm -f "$0"
+`
+		randomBytes := make([]byte, 8)
+		if _, err := rand.Read(randomBytes); err != nil {
+			randomBytes = []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+		}
+		helperPath := filepath.Join("/etc/patchmon", fmt.Sprintf("restart-%s.sh", hex.EncodeToString(randomBytes)))
+		dirInfo, err := os.Lstat("/etc/patchmon")
+		if err == nil && dirInfo.Mode()&os.ModeSymlink != 0 {
+			logger.Warn("Security: /etc/patchmon is a symlink, refusing to create helper script")
+			os.Exit(0)
+		}
+		file, err := os.OpenFile(helperPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0700)
+		if err != nil {
+			logger.WithError(err).Warn("Failed to create restart helper script, exiting to let rcctl auto-restart")
+			os.Exit(0)
+		}
+		if _, err := file.WriteString(helperScript); err != nil {
+			_ = file.Close()
+			_ = os.Remove(helperPath)
+			os.Exit(0)
+		}
+		_ = file.Close()
+		fileInfo, err := os.Lstat(helperPath)
+		if err != nil || fileInfo.Mode()&os.ModeSymlink != 0 {
+			_ = os.Remove(helperPath)
+			os.Exit(0)
+		}
+		cmd := exec.Command("/bin/sh", helperPath)
+		cmd.Stdout = nil
+		cmd.Stderr = nil
+		cmd.SysProcAttr = sysProcAttrForDetach()
+		if err := cmd.Start(); err != nil {
+			_ = os.Remove(helperPath)
+			logger.WithError(err).Warn("Failed to start restart helper, exiting to let rcctl handle restart")
+			os.Exit(0)
+		}
+		logger.Info("Scheduled service restart via helper script (OpenBSD), exiting now...")
+		time.Sleep(500 * time.Millisecond)
+		os.Exit(0)
+		return nil
+	}
 
 	// FreeBSD / pfSense: use service patchmon_agent restart (rc.d)
 	if runtime.GOOS == "freebsd" {

--- a/agent-source-code/cmd/patchmon-agent/commands/version_update.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/version_update.go
@@ -583,6 +583,8 @@ func getPlatform() string {
 		return "windows"
 	case "freebsd":
 		return "freebsd"
+	case "openbsd":
+		return "openbsd"
 	default:
 		return "linux"
 	}
@@ -722,7 +724,7 @@ func markRecentUpdate() {
 	logger.Debug("Marked recent update to prevent update loops")
 }
 
-// restartService restarts the patchmon-agent service (supports systemd, OpenRC, and FreeBSD rc.d)
+// restartService restarts the patchmon-agent service (supports systemd, OpenRC, FreeBSD rc.d, and OpenBSD rc.d)
 func restartService(_ string, _ string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
@@ -762,6 +764,58 @@ Remove-Item -Path $MyInvocation.MyCommand.Path -Force -ErrorAction SilentlyConti
 			return nil
 		}
 		logger.Info("Windows restart script launched, exiting...")
+		time.Sleep(500 * time.Millisecond)
+		os.Exit(0)
+		return nil
+	}
+
+	// OpenBSD: use rcctl restart
+	if runtime.GOOS == "openbsd" {
+		logger.Debug("Detected OpenBSD, scheduling service restart via helper script")
+		if err := os.MkdirAll("/etc/patchmon", 0700); err != nil {
+			logger.WithError(err).Warn("Failed to create /etc/patchmon directory, will try anyway")
+		}
+		helperScript := `#!/bin/sh
+sleep 2
+rcctl restart patchmon_agent 2>/dev/null || rcctl start patchmon_agent 2>/dev/null
+rm -f "$0"
+`
+		randomBytes := make([]byte, 8)
+		if _, err := rand.Read(randomBytes); err != nil {
+			randomBytes = []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+		}
+		helperPath := filepath.Join("/etc/patchmon", fmt.Sprintf("restart-%s.sh", hex.EncodeToString(randomBytes)))
+		dirInfo, err := os.Lstat("/etc/patchmon")
+		if err == nil && dirInfo.Mode()&os.ModeSymlink != 0 {
+			logger.Warn("Security: /etc/patchmon is a symlink, refusing to create helper script")
+			os.Exit(0)
+		}
+		file, err := os.OpenFile(helperPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0700)
+		if err != nil {
+			logger.WithError(err).Warn("Failed to create restart helper script, exiting to let rcctl auto-restart")
+			os.Exit(0)
+		}
+		if _, err := file.WriteString(helperScript); err != nil {
+			_ = file.Close()
+			_ = os.Remove(helperPath)
+			os.Exit(0)
+		}
+		_ = file.Close()
+		fileInfo, err := os.Lstat(helperPath)
+		if err != nil || fileInfo.Mode()&os.ModeSymlink != 0 {
+			_ = os.Remove(helperPath)
+			os.Exit(0)
+		}
+		cmd := exec.Command("/bin/sh", helperPath)
+		cmd.Stdout = nil
+		cmd.Stderr = nil
+		cmd.SysProcAttr = sysProcAttrForDetach()
+		if err := cmd.Start(); err != nil {
+			_ = os.Remove(helperPath)
+			logger.WithError(err).Warn("Failed to start restart helper, exiting to let rcctl handle restart")
+			os.Exit(0)
+		}
+		logger.Info("Scheduled service restart via helper script (OpenBSD), exiting now...")
 		time.Sleep(500 * time.Millisecond)
 		os.Exit(0)
 		return nil

--- a/agent-source-code/internal/constants/constants.go
+++ b/agent-source-code/internal/constants/constants.go
@@ -42,6 +42,7 @@ const (
 	RepoTypeAPK     = "apk"
 	RepoTypePacman  = "pacman"
 	RepoTypeFreeBSD = "freebsd"
+	RepoTypeOpenBSD = "openbsd"
 	RepoTypeWU      = "windows-update" // Windows Update
 	RepoTypeWSUS    = "wsus"           // Windows Server Update Services
 )

--- a/agent-source-code/internal/packages/openbsd.go
+++ b/agent-source-code/internal/packages/openbsd.go
@@ -1,0 +1,331 @@
+package packages
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+
+	"patchmon-agent/pkg/models"
+
+	"github.com/sirupsen/logrus"
+)
+
+// OpenBSDManager handles OpenBSD package information collection
+type OpenBSDManager struct {
+	logger *logrus.Logger
+}
+
+// NewOpenBSDManager creates a new OpenBSD package manager
+func NewOpenBSDManager(logger *logrus.Logger) *OpenBSDManager {
+	return &OpenBSDManager{
+		logger: logger,
+	}
+}
+
+// GetPackages gets package information for OpenBSD systems.
+// Collects from: pkg_info (binary packages) and syspatch (base system patches).
+func (m *OpenBSDManager) GetPackages() ([]models.Package, error) {
+	var allPackages []models.Package
+
+	// 1. Get pkg binary packages
+	pkgPackages, err := m.getPkgPackages()
+	if err != nil {
+		m.logger.WithError(err).Warn("Failed to get OpenBSD pkg packages")
+	} else {
+		allPackages = append(allPackages, pkgPackages...)
+	}
+
+	// 2. Get syspatch base-system update info
+	sysPackage := m.getSyspatchInfo()
+	if sysPackage != nil {
+		allPackages = append(allPackages, *sysPackage)
+	}
+
+	return allPackages, nil
+}
+
+// getPkgPackages collects installed packages via pkg_info and available upgrades
+// via pkg_add -uqn (dry-run).
+func (m *OpenBSDManager) getPkgPackages() ([]models.Package, error) {
+	// --- installed packages ---
+	m.logger.Debug("Getting installed packages with pkg_info...")
+	installedOut, err := exec.Command("pkg_info").Output()
+	installedPackages := make(map[string]models.Package)
+	if err != nil {
+		m.logger.WithError(err).Warn("Failed to get installed packages via pkg_info")
+	} else {
+		installedPackages = m.parseInstalledPackages(string(installedOut))
+		m.logger.WithField("count", len(installedPackages)).Debug("Found installed packages")
+	}
+
+	// --- upgradable packages ---
+	// pkg_add -u -v -n: dry-run upgrade with verbose output.
+	// -v is required: without it pkg_add produces no "Update candidates:" lines.
+	// CombinedOutput captures stderr too (pkg_add prints progress to stderr).
+	m.logger.Debug("Checking for package upgrades via pkg_add -u -v -n...")
+	upgradeOut, _ := exec.Command("pkg_add", "-u", "-v", "-n").CombinedOutput()
+	upgradablePackages := m.parseUpgradeOutput(string(upgradeOut))
+	m.logger.WithField("count", len(upgradablePackages)).Debug("Found upgradable packages")
+
+	packages := CombinePackageData(installedPackages, upgradablePackages)
+	return packages, nil
+}
+
+// parseInstalledPackages parses pkg_info output.
+// Format: pkgname-version    Description
+// Example: bash-5.2.15          GNU Project's Bourne Again SHell
+func (m *OpenBSDManager) parseInstalledPackages(output string) map[string]models.Package {
+	installedPackages := make(map[string]models.Package)
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 1 {
+			continue
+		}
+		// fields[0] is the full "pkgname-version" token as it appears in /var/db/pkg/
+		fullToken := fields[0]
+		pkgName, version := splitOpenBSDPackage(fullToken)
+		if pkgName != "" && version != "" {
+			description := ""
+			if len(fields) > 1 {
+				description = strings.Join(fields[1:], " ")
+			}
+			installedPackages[pkgName] = models.Package{
+				Name:             pkgName,
+				CurrentVersion:   version,
+				Description:      description,
+				SourceRepository: pkgSourceRepo(fullToken),
+				NeedsUpdate:      false,
+			}
+		}
+	}
+	return installedPackages
+}
+
+// pkgSourceRepo reads the @url line from /var/db/pkg/<fullToken>/+CONTENTS and
+// returns the mirror directory URL (everything up to and excluding the filename).
+// Returns an empty string if the file cannot be read or the @url line is absent.
+func pkgSourceRepo(fullToken string) string {
+	contents, err := os.ReadFile("/var/db/pkg/" + fullToken + "/+CONTENTS")
+	if err != nil {
+		return ""
+	}
+	scanner := bufio.NewScanner(strings.NewReader(string(contents)))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "@url ") {
+			continue
+		}
+		url := strings.TrimPrefix(line, "@url ")
+		// Strip the filename to return the mirror directory.
+		if idx := strings.LastIndex(url, "/"); idx > 0 {
+			return url[:idx]
+		}
+		return url
+	}
+	return ""
+}
+
+// parseUpgradeOutput parses pkg_add -uqn output.
+// pkg_add prints candidate lines in the form:
+//
+//	Update candidates: curl-8.7.1 -> curl-8.10.0
+func (m *OpenBSDManager) parseUpgradeOutput(output string) []models.Package {
+	var packages []models.Package
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if !strings.HasPrefix(line, "Update candidates:") {
+			continue
+		}
+		// "Update candidates: pkgold-X.Y -> pkgnew-A.B"
+		rest := strings.TrimSpace(strings.TrimPrefix(line, "Update candidates:"))
+		parts := strings.SplitN(rest, "->", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		oldPkg := strings.TrimSpace(parts[0])
+		newPkg := strings.TrimSpace(parts[1])
+
+		oldName, oldVersion := splitOpenBSDPackage(oldPkg)
+		newName, newVersion := splitOpenBSDPackage(newPkg)
+
+		if oldName == "" || oldVersion == "" || newVersion == "" {
+			continue
+		}
+		// Skip entries where the version hasn't changed (already up-to-date).
+		if oldVersion == newVersion {
+			continue
+		}
+		name := oldName
+		if newName != "" {
+			name = newName
+		}
+		packages = append(packages, models.Package{
+			Name:             name,
+			CurrentVersion:   oldVersion,
+			AvailableVersion: newVersion,
+			NeedsUpdate:      true,
+			IsSecurityUpdate: false,
+		})
+	}
+	return packages
+}
+
+// getSyspatchInfo checks for available OpenBSD base-system patches via syspatch -c.
+// Returns a single package entry summarising all pending errata, or nil when none are pending.
+//
+// syspatch only distributes security errata, so IsSecurityUpdate is always true.
+// CurrentVersion is the OS release from uname -r; AvailableVersion is the patch count.
+// Description is enriched with per-errata text fetched from openbsd.org/errataXX.html.
+// SourceRepository is read from /etc/installurl (the configured mirror).
+func (m *OpenBSDManager) getSyspatchInfo() *models.Package {
+	// OS base version
+	osVersion := "unknown"
+	if out, err := exec.Command("uname", "-r").Output(); err == nil {
+		osVersion = strings.TrimSpace(string(out))
+	}
+
+	// Configured mirror URL
+	sourceRepo := ""
+	if data, err := os.ReadFile("/etc/installurl"); err == nil {
+		sourceRepo = strings.TrimSpace(string(data))
+	}
+
+	// Use CombinedOutput so we capture stdout even when syspatch -c exits
+	// non-zero (e.g. exit 1 while a concurrent syspatch run is in progress,
+	// or when the network is briefly unreachable). We treat the run as
+	// "no patches available" only when the output is genuinely empty.
+	out, _ := exec.Command("syspatch", "-c").CombinedOutput()
+
+	var patchIDs []string
+	scanner := bufio.NewScanner(strings.NewReader(string(out)))
+	for scanner.Scan() {
+		id := strings.TrimSpace(scanner.Text())
+		if id != "" {
+			patchIDs = append(patchIDs, id)
+		}
+	}
+	if len(patchIDs) == 0 {
+		return nil
+	}
+
+	// Optionally enrich each patch ID with its errata description from openbsd.org.
+	errataDescs := m.fetchErrataDescriptions(osVersion)
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Pending security errata (%d):\n", len(patchIDs)))
+	for _, id := range patchIDs {
+		// Patch IDs have the form "NNN_component"; the number is the errata key.
+		num := ""
+		if len(id) >= 3 {
+			num = id[:3]
+		}
+		if desc, ok := errataDescs[num]; ok {
+			sb.WriteString(fmt.Sprintf("%s: %s\n", id, desc))
+		} else {
+			sb.WriteString(id + "\n")
+		}
+	}
+	description := strings.TrimRight(sb.String(), "\n")
+	availableVersion := fmt.Sprintf("%d patch(es) available", len(patchIDs))
+
+	return &models.Package{
+		Name:             "syspatch",
+		CurrentVersion:   osVersion,
+		AvailableVersion: availableVersion,
+		Description:      description,
+		SourceRepository: sourceRepo,
+		NeedsUpdate:      true,
+		IsSecurityUpdate: true,
+	}
+}
+
+// fetchErrataDescriptions fetches https://www.openbsd.org/errataXX.html (where XX
+// is the OS version without the dot, e.g. "76" for 7.6) and returns a map from
+// zero-padded errata number (e.g. "001") to a human-readable description line.
+// Returns an empty map on any network or parse failure — callers treat it as
+// optional enrichment and fall back to the bare patch ID.
+func (m *OpenBSDManager) fetchErrataDescriptions(osVersion string) map[string]string {
+	versionTag := strings.ReplaceAll(osVersion, ".", "")
+	url := "https://www.openbsd.org/errata" + versionTag + ".html"
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Get(url) //nolint:noctx
+	if err != nil {
+		m.logger.WithError(err).Debug("Could not fetch OpenBSD errata page")
+		return map[string]string{}
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		m.logger.WithField("status", resp.StatusCode).Debug("Unexpected status fetching OpenBSD errata page")
+		return map[string]string{}
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		m.logger.WithError(err).Debug("Failed to read OpenBSD errata page body")
+		return map[string]string{}
+	}
+
+	// Each errata entry in the HTML has the form:
+	//   <strong>NNN: TYPE FIX: date</strong>
+	//   &nbsp; <i>architectures</i>
+	//   <br>
+	//   Description text CVE-XXXX
+	//   <br>
+	//   <a href="...NNN_component.patch.sig">...
+	errataRe := regexp.MustCompile(
+		`(?i)<strong>(\d{3}):\s+(SECURITY|RELIABILITY)\s+FIX:\s+([^<]+)</strong>` +
+			`[\s\S]*?<br>\s*([\s\S]*?)\s*<br>\s*<a\s+href="[^"]*\.patch\.sig"`,
+	)
+	tagRe := regexp.MustCompile(`<[^>]+>`)
+	spaceRe := regexp.MustCompile(`\s+`)
+
+	result := make(map[string]string)
+	for _, match := range errataRe.FindAllStringSubmatch(string(body), -1) {
+		num := match[1]                     // "001"
+		fixType := match[2]                 // "SECURITY" or "RELIABILITY"
+		date := strings.TrimSpace(match[3]) // "October 14, 2024"
+		rawDesc := match[4]                 // HTML fragment
+
+		desc := tagRe.ReplaceAllString(rawDesc, " ")
+		desc = strings.ReplaceAll(desc, "&nbsp;", " ")
+		desc = strings.ReplaceAll(desc, "&amp;", "&")
+		desc = strings.ReplaceAll(desc, "&lt;", "<")
+		desc = strings.ReplaceAll(desc, "&gt;", ">")
+		desc = strings.ReplaceAll(desc, "&#39;", "'")
+		desc = strings.ReplaceAll(desc, "&quot;", `"`)
+		desc = spaceRe.ReplaceAllString(desc, " ")
+		desc = strings.TrimSpace(desc)
+
+		result[num] = fmt.Sprintf("%s FIX (%s): %s", fixType, date, desc)
+	}
+	return result
+}
+
+// splitOpenBSDPackage splits an OpenBSD package token "pkgname-version" into its
+// name and version components.  The version always starts with a digit.
+//
+// Examples:
+//
+//	"bash-5.2.15"           -> ("bash", "5.2.15")
+//	"py3-setuptools-68.0.0" -> ("py3-setuptools", "68.0.0")
+func splitOpenBSDPackage(s string) (name, version string) {
+	for i := len(s) - 1; i >= 1; i-- {
+		if s[i] == '-' && s[i+1] >= '0' && s[i+1] <= '9' {
+			return s[:i], s[i+1:]
+		}
+	}
+	return s, ""
+}

--- a/agent-source-code/internal/packages/packages.go
+++ b/agent-source-code/internal/packages/packages.go
@@ -26,6 +26,7 @@ type Manager struct {
 	apkManager     *APKManager
 	pacmanManager  *PacmanManager
 	freebsdManager *FreeBSDManager
+	openbsdManager *OpenBSDManager
 	winManager     *WindowsManager
 }
 
@@ -36,6 +37,7 @@ func New(logger *logrus.Logger, cacheRefresh CacheRefreshConfig) *Manager {
 	apkManager := NewAPKManager(logger)
 	pacmanManager := NewPacmanManager(logger)
 	freebsdManager := NewFreeBSDManager(logger)
+	openbsdManager := NewOpenBSDManager(logger)
 	winManager := NewWindowsManager(logger)
 
 	return &Manager{
@@ -45,6 +47,7 @@ func New(logger *logrus.Logger, cacheRefresh CacheRefreshConfig) *Manager {
 		apkManager:     apkManager,
 		pacmanManager:  pacmanManager,
 		freebsdManager: freebsdManager,
+		openbsdManager: openbsdManager,
 		winManager:     winManager,
 	}
 }
@@ -68,17 +71,25 @@ func (m *Manager) GetPackages() ([]models.Package, error) {
 		return m.pacmanManager.GetPackages()
 	case "pkg":
 		return m.freebsdManager.GetPackages()
+	case "pkg_info":
+		return m.openbsdManager.GetPackages()
 	default:
 		return nil, fmt.Errorf("unsupported package manager: %s", packageManager)
 	}
 }
 
 // DetectPackageManager detects which package manager is available on the system.
-// Returns one of: apt, dnf, yum, apk, pacman, pkg, windows, or unknown.
+// Returns one of: apt, dnf, yum, apk, pacman, pkg, pkg_info, windows, or unknown.
 func (m *Manager) DetectPackageManager() string {
 	// Check for Windows first (runtime check, no exec)
 	if runtime.GOOS == "windows" {
 		return "windows"
+	}
+	// Check for OpenBSD: pkg_info is the package tool
+	if runtime.GOOS == "openbsd" {
+		if _, err := exec.LookPath("pkg_info"); err == nil {
+			return "pkg_info"
+		}
 	}
 	// Check for FreeBSD pkg first (avoid confusion with other 'pkg' tools).
 	// When the agent runs as an rc.d service, PATH may be minimal, so also check
@@ -176,13 +187,16 @@ func CombinePackageData(installedPackages map[string]models.Package, upgradableP
 		upgradableMap[pkg.Name] = true
 	}
 
-	// Then add installed packages that are not upgradable (with full info including description)
+	// Then add installed packages that are not upgradable (with full info including description).
+	// AvailableVersion is set to CurrentVersion because if the package manager did not report an
+	// upgrade candidate, the installed version is already the latest available from the repository.
 	for packageName, installed := range installedPackages {
 		if !upgradableMap[packageName] {
 			packages = append(packages, models.Package{
 				Name:             packageName,
 				Description:      installed.Description,
 				CurrentVersion:   installed.CurrentVersion,
+				AvailableVersion: installed.CurrentVersion,
 				SourceRepository: installed.SourceRepository,
 				NeedsUpdate:      false,
 				IsSecurityUpdate: false,

--- a/agent-source-code/internal/packages/packages.go
+++ b/agent-source-code/internal/packages/packages.go
@@ -27,6 +27,7 @@ type Manager struct {
 	apkManager     *APKManager
 	pacmanManager  *PacmanManager
 	freebsdManager *FreeBSDManager
+	openbsdManager *OpenBSDManager
 	winManager     *WindowsManager
 }
 
@@ -37,6 +38,7 @@ func New(logger *logrus.Logger, cacheRefresh CacheRefreshConfig) *Manager {
 	apkManager := NewAPKManager(logger)
 	pacmanManager := NewPacmanManager(logger)
 	freebsdManager := NewFreeBSDManager(logger)
+	openbsdManager := NewOpenBSDManager(logger)
 	winManager := NewWindowsManager(logger)
 
 	return &Manager{
@@ -46,6 +48,7 @@ func New(logger *logrus.Logger, cacheRefresh CacheRefreshConfig) *Manager {
 		apkManager:     apkManager,
 		pacmanManager:  pacmanManager,
 		freebsdManager: freebsdManager,
+		openbsdManager: openbsdManager,
 		winManager:     winManager,
 	}
 }
@@ -73,6 +76,8 @@ func (m *Manager) GetPackages() ([]models.Package, error) {
 		pkgs, err = m.pacmanManager.GetPackages()
 	case "pkg":
 		pkgs, err = m.freebsdManager.GetPackages()
+	case "pkg_info":
+		pkgs, err = m.openbsdManager.GetPackages()
 	default:
 		return nil, fmt.Errorf("unsupported package manager: %s", packageManager)
 	}
@@ -85,11 +90,17 @@ func (m *Manager) GetPackages() ([]models.Package, error) {
 }
 
 // DetectPackageManager detects which package manager is available on the system.
-// Returns one of: apt, dnf, yum, apk, pacman, pkg, windows, or unknown.
+// Returns one of: apt, dnf, yum, apk, pacman, pkg, pkg_info, windows, or unknown.
 func (m *Manager) DetectPackageManager() string {
 	// Check for Windows first (runtime check, no exec)
 	if runtime.GOOS == "windows" {
 		return "windows"
+	}
+	// Check for OpenBSD: pkg_info is the package tool
+	if runtime.GOOS == "openbsd" {
+		if _, err := exec.LookPath("pkg_info"); err == nil {
+			return "pkg_info"
+		}
 	}
 	// Check for FreeBSD pkg first (avoid confusion with other 'pkg' tools).
 	// When the agent runs as an rc.d service, PATH may be minimal, so also check
@@ -197,13 +208,16 @@ func CombinePackageData(installedPackages map[string]models.Package, upgradableP
 		upgradableMap[pkg.Name] = true
 	}
 
-	// Then add installed packages that are not upgradable (with full info including description)
+	// Then add installed packages that are not upgradable (with full info including description).
+	// AvailableVersion is set to CurrentVersion because if the package manager did not report an
+	// upgrade candidate, the installed version is already the latest available from the repository.
 	for packageName, installed := range installedPackages {
 		if !upgradableMap[packageName] {
 			packages = append(packages, models.Package{
 				Name:             packageName,
 				Description:      installed.Description,
 				CurrentVersion:   installed.CurrentVersion,
+				AvailableVersion: installed.CurrentVersion,
 				SourceRepository: installed.SourceRepository,
 				NeedsUpdate:      false,
 				IsSecurityUpdate: false,

--- a/agent-source-code/internal/repositories/openbsd.go
+++ b/agent-source-code/internal/repositories/openbsd.go
@@ -1,0 +1,59 @@
+package repositories
+
+import (
+	"net/url"
+	"os"
+	"strings"
+
+	"patchmon-agent/internal/constants"
+	"patchmon-agent/pkg/models"
+
+	"github.com/sirupsen/logrus"
+)
+
+// OpenBSDManager handles OpenBSD repository information collection
+type OpenBSDManager struct {
+	logger *logrus.Logger
+}
+
+// NewOpenBSDManager creates a new OpenBSD repository manager
+func NewOpenBSDManager(logger *logrus.Logger) *OpenBSDManager {
+	return &OpenBSDManager{
+		logger: logger,
+	}
+}
+
+// GetRepositories returns the repository configured in /etc/installurl.
+// OpenBSD uses a single mirror URL stored in that file; the PKG_PATH environment
+// variable can override it at runtime, but we read the persistent file here.
+func (m *OpenBSDManager) GetRepositories() ([]models.Repository, error) {
+	data, err := os.ReadFile("/etc/installurl")
+	if err != nil {
+		m.logger.WithError(err).Warn("Failed to read /etc/installurl")
+		return []models.Repository{}, nil
+	}
+
+	mirrorURL := strings.TrimSpace(string(data))
+	if mirrorURL == "" || strings.HasPrefix(mirrorURL, "#") {
+		m.logger.Debug("No repository URL found in /etc/installurl")
+		return []models.Repository{}, nil
+	}
+
+	// Derive a human-readable name from the hostname, e.g.
+	// "https://ftp.lip6.fr/pub/OpenBSD" -> "installurl-ftp.lip6.fr"
+	repoName := "installurl"
+	if parsed, err := url.Parse(mirrorURL); err == nil && parsed.Host != "" {
+		repoName = "installurl-" + parsed.Host
+	}
+
+	repo := models.Repository{
+		Name:      repoName,
+		URL:       mirrorURL,
+		RepoType:  constants.RepoTypeOpenBSD,
+		IsEnabled: true,
+		IsSecure:  strings.HasPrefix(strings.ToLower(mirrorURL), "https://"),
+	}
+
+	m.logger.WithField("url", mirrorURL).Debug("Detected OpenBSD repository from /etc/installurl")
+	return []models.Repository{repo}, nil
+}

--- a/agent-source-code/internal/repositories/repositories.go
+++ b/agent-source-code/internal/repositories/repositories.go
@@ -19,6 +19,7 @@ type Manager struct {
 	apkManager     *APKManager
 	pacmanManager  *PacmanManager
 	freebsdManager *FreeBSDManager
+	openbsdManager *OpenBSDManager
 	winManager     *WindowsManager
 }
 
@@ -31,6 +32,7 @@ func New(logger *logrus.Logger) *Manager {
 		apkManager:     NewAPKManager(logger),
 		pacmanManager:  NewPacmanManager(logger),
 		freebsdManager: NewFreeBSDManager(logger),
+		openbsdManager: NewOpenBSDManager(logger),
 		winManager:     NewWindowsManager(logger),
 	}
 }
@@ -55,6 +57,8 @@ func (m *Manager) GetRepositories() ([]models.Repository, error) {
 		return m.pacmanManager.GetRepositories()
 	case "pkg":
 		return m.freebsdManager.GetRepositories()
+	case "pkg_info":
+		return m.openbsdManager.GetRepositories()
 	default:
 		m.logger.WithField("package_manager", packageManager).Warn("Unsupported package manager")
 		return []models.Repository{}, nil
@@ -66,6 +70,12 @@ func (m *Manager) detectPackageManager() string {
 	// Check for Windows first (runtime check, no exec)
 	if runtime.GOOS == "windows" {
 		return "windows"
+	}
+	// Check for OpenBSD: pkg_info is the package tool
+	if runtime.GOOS == "openbsd" {
+		if _, err := exec.LookPath("pkg_info"); err == nil {
+			return "pkg_info"
+		}
 	}
 	// Check for FreeBSD pkg first. When the agent runs as rc.d service, PATH may be minimal.
 	if runtime.GOOS == "freebsd" {

--- a/agent-source-code/internal/repositories/repositories.go
+++ b/agent-source-code/internal/repositories/repositories.go
@@ -20,6 +20,7 @@ type Manager struct {
 	apkManager     *APKManager
 	pacmanManager  *PacmanManager
 	freebsdManager *FreeBSDManager
+	openbsdManager *OpenBSDManager
 	winManager     *WindowsManager
 }
 
@@ -32,6 +33,7 @@ func New(logger *logrus.Logger) *Manager {
 		apkManager:     NewAPKManager(logger),
 		pacmanManager:  NewPacmanManager(logger),
 		freebsdManager: NewFreeBSDManager(logger),
+		openbsdManager: NewOpenBSDManager(logger),
 		winManager:     NewWindowsManager(logger),
 	}
 }
@@ -59,6 +61,8 @@ func (m *Manager) GetRepositories() ([]models.Repository, error) {
 		repos, err = m.pacmanManager.GetRepositories()
 	case "pkg":
 		repos, err = m.freebsdManager.GetRepositories()
+	case "pkg_info":
+		repos, err = m.openbsdManager.GetRepositories()
 	default:
 		m.logger.WithField("package_manager", packageManager).Warn("Unsupported package manager")
 		return []models.Repository{}, nil
@@ -74,6 +78,12 @@ func (m *Manager) detectPackageManager() string {
 	// Check for Windows first (runtime check, no exec)
 	if runtime.GOOS == "windows" {
 		return "windows"
+	}
+	// Check for OpenBSD: pkg_info is the package tool
+	if runtime.GOOS == "openbsd" {
+		if _, err := exec.LookPath("pkg_info"); err == nil {
+			return "pkg_info"
+		}
 	}
 	// Check for FreeBSD pkg first. When the agent runs as rc.d service, PATH may be minimal.
 	if runtime.GOOS == "freebsd" {

--- a/agent-source-code/internal/system/system.go
+++ b/agent-source-code/internal/system/system.go
@@ -97,6 +97,36 @@ func (d *Detector) parseOSRelease() (*OSReleaseInfo, error) {
 	return info, nil
 }
 
+// isOpenBSD checks if running on OpenBSD
+func (d *Detector) isOpenBSD() bool {
+	return runtime.GOOS == "openbsd"
+}
+
+// getOpenBSDInfo gets OpenBSD OS type and version
+func (d *Detector) getOpenBSDInfo() (osType, osVersion string, err error) {
+	osType = "OpenBSD"
+
+	// uname -r returns the release version (e.g. "7.5")
+	cmd := exec.Command("uname", "-r")
+	output, err := cmd.Output()
+	if err != nil {
+		d.logger.WithError(err).Warn("Failed to get OpenBSD version via uname -r")
+		return osType, "Unknown", nil
+	}
+
+	osVersion = strings.TrimSpace(string(output))
+	if osVersion == "" {
+		osVersion = "Unknown"
+	}
+
+	d.logger.WithFields(logrus.Fields{
+		"os_type":    osType,
+		"os_version": osVersion,
+	}).Debug("Detected OpenBSD system")
+
+	return osType, osVersion, nil
+}
+
 // isFreeBSD checks if running on FreeBSD using uname -s
 func (d *Detector) isFreeBSD() bool {
 	cmd := exec.Command("uname", "-s")
@@ -176,6 +206,10 @@ func (d *Detector) DetectOS() (osType, osVersion string, err error) {
 			osVer = "Unknown"
 		}
 		return "Windows", osVer, nil
+	}
+	// Check for OpenBSD first (doesn't have /etc/os-release)
+	if d.isOpenBSD() {
+		return d.getOpenBSDInfo()
 	}
 	// Check for FreeBSD first (doesn't have /etc/os-release)
 	if d.isFreeBSD() {
@@ -330,8 +364,8 @@ func (d *Detector) GetKernelVersion() string {
 
 // getSELinuxStatus gets SELinux status using file reading
 func (d *Detector) getSELinuxStatus() string {
-	// Windows and FreeBSD don't use SELinux
-	if runtime.GOOS == "windows" || d.isFreeBSD() {
+	// Windows, FreeBSD, and OpenBSD don't use SELinux
+	if runtime.GOOS == "windows" || d.isFreeBSD() || d.isOpenBSD() {
 		return constants.SELinuxDisabled
 	}
 
@@ -414,14 +448,23 @@ func (d *Detector) GetMachineID() string {
 	// Use gopsutil's HostID which reads from standard locations
 	// (/etc/machine-id, /var/lib/dbus/machine-id, etc.)
 	hostID, err := host.HostIDWithContext(ctx)
-	if err != nil {
-		d.logger.WithError(err).Warn("Failed to get host ID, using hostname as fallback")
-		// Fallback to hostname if we can't get machine ID
-		if hostname, err := os.Hostname(); err == nil {
-			return hostname
-		}
-		return "unknown"
+	if err == nil {
+		return hostID
 	}
 
-	return hostID
+	// OpenBSD: gopsutil does not implement HostID, use sysctl hw.uuid instead
+	if runtime.GOOS == "openbsd" {
+		out, sysErr := exec.CommandContext(ctx, "sysctl", "-n", "hw.uuid").Output()
+		if sysErr == nil {
+			if uuid := strings.TrimSpace(string(out)); uuid != "" {
+				return uuid
+			}
+		}
+	}
+
+	d.logger.WithError(err).Warn("Failed to get host ID, using hostname as fallback")
+	if hostname, err := os.Hostname(); err == nil {
+		return hostname
+	}
+	return "unknown"
 }

--- a/agent-source-code/internal/system/system.go
+++ b/agent-source-code/internal/system/system.go
@@ -97,6 +97,36 @@ func (d *Detector) parseOSRelease() (*OSReleaseInfo, error) {
 	return info, nil
 }
 
+// isOpenBSD checks if running on OpenBSD
+func (d *Detector) isOpenBSD() bool {
+	return runtime.GOOS == "openbsd"
+}
+
+// getOpenBSDInfo gets OpenBSD OS type and version
+func (d *Detector) getOpenBSDInfo() (osType, osVersion string, err error) {
+	osType = "OpenBSD"
+
+	// uname -r returns the release version (e.g. "7.5")
+	cmd := exec.Command("uname", "-r")
+	output, err := cmd.Output()
+	if err != nil {
+		d.logger.WithError(err).Warn("Failed to get OpenBSD version via uname -r")
+		return osType, "Unknown", nil
+	}
+
+	osVersion = strings.TrimSpace(string(output))
+	if osVersion == "" {
+		osVersion = "Unknown"
+	}
+
+	d.logger.WithFields(logrus.Fields{
+		"os_type":    osType,
+		"os_version": osVersion,
+	}).Debug("Detected OpenBSD system")
+
+	return osType, osVersion, nil
+}
+
 // isFreeBSD checks if running on FreeBSD using uname -s
 func (d *Detector) isFreeBSD() bool {
 	cmd := exec.Command("uname", "-s")
@@ -176,6 +206,10 @@ func (d *Detector) DetectOS() (osType, osVersion string, err error) {
 			osVer = "Unknown"
 		}
 		return "Windows", osVer, nil
+	}
+	// Check for OpenBSD first (doesn't have /etc/os-release)
+	if d.isOpenBSD() {
+		return d.getOpenBSDInfo()
 	}
 	// Check for FreeBSD first (doesn't have /etc/os-release)
 	if d.isFreeBSD() {
@@ -334,8 +368,8 @@ func (d *Detector) GetKernelVersion() string {
 
 // getSELinuxStatus gets SELinux status using file reading
 func (d *Detector) getSELinuxStatus() string {
-	// Windows and FreeBSD don't use SELinux
-	if runtime.GOOS == "windows" || d.isFreeBSD() {
+	// Windows, FreeBSD, and OpenBSD don't use SELinux
+	if runtime.GOOS == "windows" || d.isFreeBSD() || d.isOpenBSD() {
 		return constants.SELinuxDisabled
 	}
 
@@ -448,14 +482,23 @@ func (d *Detector) GetMachineID() string {
 	// Use gopsutil's HostID which reads from standard locations
 	// (/etc/machine-id, /var/lib/dbus/machine-id, etc.)
 	hostID, err := host.HostIDWithContext(ctx)
-	if err != nil {
-		d.logger.WithError(err).Warn("Failed to get host ID, using hostname as fallback")
-		// Fallback to hostname if we can't get machine ID
-		if hostname, err := os.Hostname(); err == nil {
-			return hostname
-		}
-		return "unknown"
+	if err == nil {
+		return hostID
 	}
 
-	return hostID
+	// OpenBSD: gopsutil does not implement HostID, use sysctl hw.uuid instead
+	if runtime.GOOS == "openbsd" {
+		out, sysErr := exec.CommandContext(ctx, "sysctl", "-n", "hw.uuid").Output()
+		if sysErr == nil {
+			if uuid := strings.TrimSpace(string(out)); uuid != "" {
+				return uuid
+			}
+		}
+	}
+
+	d.logger.WithError(err).Warn("Failed to get host ID, using hostname as fallback")
+	if hostname, err := os.Hostname(); err == nil {
+		return hostname
+	}
+	return "unknown"
 }

--- a/agents/patchmon_install.sh
+++ b/agents/patchmon_install.sh
@@ -138,6 +138,16 @@ get_machine_id() {
         echo "patchmon-freebsd-$(hostname 2>/dev/null)-$(date +%s 2>/dev/null)"
         return
     fi
+    # OpenBSD: use hw.uuid sysctl
+    if [ "$(uname -s 2>/dev/null)" = "OpenBSD" ]; then
+        _uuid=$(sysctl -n hw.uuid 2>/dev/null)
+        if [ -n "$_uuid" ]; then
+            echo "$_uuid"
+            return
+        fi
+        echo "patchmon-openbsd-$(hostname 2>/dev/null)-$(date +%s 2>/dev/null)"
+        return
+    fi
     # Linux: try multiple sources
     if [ -f /etc/machine-id ]; then
         cat /etc/machine-id
@@ -169,11 +179,19 @@ if [ -z "$ARCHITECTURE" ]; then
         "i386"|"i686")
             ARCHITECTURE="386"
             ;;
-        "aarch64"|"arm64")
+        "aarch64")
             ARCHITECTURE="arm64"
             ;;
         "armv7l"|"armv6l"|"arm")
             ARCHITECTURE="arm"
+            ;;
+        "amd64")
+            # OpenBSD and FreeBSD report uname -m as "amd64" directly
+            ARCHITECTURE="amd64"
+            ;;
+        "arm64")
+            # OpenBSD and FreeBSD report uname -m as "arm64" directly
+            ARCHITECTURE="arm64"
             ;;
         *)
             warning "Unknown architecture '$arch_raw', defaulting to amd64"
@@ -182,10 +200,10 @@ if [ -z "$ARCHITECTURE" ]; then
     esac
 fi
 
-# Validate architecture (FreeBSD supports amd64 and arm64 only)
-if [ "$PATCHMON_OS" = "freebsd" ]; then
+# Validate architecture (FreeBSD and OpenBSD support amd64 and arm64 only)
+if [ "$PATCHMON_OS" = "freebsd" ] || [ "$PATCHMON_OS" = "openbsd" ]; then
     if [ "$ARCHITECTURE" != "amd64" ] && [ "$ARCHITECTURE" != "arm64" ]; then
-        error "Invalid architecture '$ARCHITECTURE' for FreeBSD. Must be one of: amd64, arm64"
+        error "Invalid architecture '$ARCHITECTURE' for $PATCHMON_OS. Must be one of: amd64, arm64"
     fi
 else
     if [ "$ARCHITECTURE" != "amd64" ] && [ "$ARCHITECTURE" != "386" ] && [ "$ARCHITECTURE" != "arm64" ] && [ "$ARCHITECTURE" != "arm" ]; then
@@ -484,6 +502,17 @@ elif [ "$(uname -s 2>/dev/null)" = "FreeBSD" ] || [ "$PATCHMON_OS" = "freebsd" ]
         if ! command -v curl >/dev/null 2>&1; then
             warning "curl not found. On FreeBSD: pkg install curl"
             warning "On pfSense: install curl from System > Package Manager, or enable FreeBSD pkg repos."
+        fi
+    fi
+elif [ "$(uname -s 2>/dev/null)" = "OpenBSD" ] || [ "$PATCHMON_OS" = "openbsd" ]; then
+    # OpenBSD: only curl is required
+    info "Detected OpenBSD (pkg_add)"
+    echo ""
+    if ! command -v curl >/dev/null 2>&1; then
+        info "Ensuring curl is installed..."
+        pkg_add -I curl >/dev/null 2>&1 || true
+        if ! command -v curl >/dev/null 2>&1; then
+            warning "curl not found. Install manually: pkg_add curl"
         fi
     fi
 else
@@ -866,9 +895,67 @@ EOF
         success "PatchMon Agent service configured"
     fi
     SERVICE_TYPE="rc.d"
+elif [ "$(uname -s 2>/dev/null)" = "OpenBSD" ] || [ "$PATCHMON_OS" = "openbsd" ]; then
+    # OpenBSD: use rcctl / rc.d
+    info "Setting up OpenBSD rc.d service..."
+    RCD_SCRIPT="/etc/rc.d/patchmon_agent"
+    cat > "$RCD_SCRIPT" << 'EOF'
+#!/bin/ksh
+#
+# PatchMon Agent rc.d script for OpenBSD
+#
+# patchmon-agent runs in the foreground (does not self-daemonize).
+# rc_start backgrounds it inside a subshell so patchmon-agent is reparented
+# to init before rc.subr's _rc_wait_for_start fires "pkill -ALRM -P $$" to
+# rc_cmd's children.  Because the subshell has already exited, patchmon-agent
+# is never a direct child of the rc_cmd shell and the SIGALRM cannot reach it.
+# rc_start returns 0 immediately so rc.subr prints "(ok)" without timeout.
+#
+daemon="/usr/local/bin/patchmon-agent"
+daemon_flags="serve"
+daemon_user="root"
+
+. /etc/rc.d/rc.subr
+
+_PIDFILE="/var/run/patchmon_agent.pid"
+
+rc_start() {
+    ( nohup ${daemon} ${daemon_flags} >/dev/null 2>&1 & echo $! ) > ${_PIDFILE}
+}
+
+rc_check() {
+    [ -f ${_PIDFILE} ] && kill -0 "$(cat ${_PIDFILE})" 2>/dev/null
+}
+
+rc_stop() {
+    [ -f ${_PIDFILE} ] && kill -TERM "$(cat ${_PIDFILE})" 2>/dev/null
+}
+
+rc_post() {
+    rm -f ${_PIDFILE}
+}
+
+rc_cmd $1
+EOF
+    chmod +x "$RCD_SCRIPT"
+    if command -v rcctl >/dev/null 2>&1; then
+        rcctl enable patchmon_agent 2>/dev/null || true
+        rcctl start patchmon_agent
+        sleep 1
+        if rcctl check patchmon_agent 2>/dev/null | grep -q "ok"; then
+            success "PatchMon Agent service started successfully"
+            info "WebSocket connection established"
+        else
+            warning "Service may have failed to start. Check: rcctl check patchmon_agent"
+        fi
+    else
+        "$RCD_SCRIPT" start
+        success "PatchMon Agent service configured"
+    fi
+    SERVICE_TYPE="openbsd-rcd"
 else
     # No init system detected, use crontab as fallback
-    warning "No init system detected (systemd, OpenRC, or FreeBSD). Using crontab for service management."
+    warning "No init system detected (systemd, OpenRC, FreeBSD, or OpenBSD). Using crontab for service management."
     
     # Clean up old crontab entries if they exist
     if crontab -l 2>/dev/null | grep -q "patchmon-agent"; then
@@ -903,6 +990,8 @@ elif [ "$SERVICE_TYPE" = "openrc" ]; then
     echo "   • OpenRC service configured and running"
 elif [ "$SERVICE_TYPE" = "rc.d" ]; then
     echo "   • FreeBSD rc.d service configured and running"
+elif [ "$SERVICE_TYPE" = "openbsd-rcd" ]; then
+    echo "   • OpenBSD rc.d service configured and running"
 else
     echo "   • Service configured via crontab"
 fi
@@ -939,6 +1028,10 @@ elif [ "$SERVICE_TYPE" = "rc.d" ]; then
     echo "   • Service status: service patchmon_agent status"
     echo "   • Service logs: tail -f /etc/patchmon/logs/patchmon-agent.log"
     echo "   • Restart service: service patchmon_agent restart"
+elif [ "$SERVICE_TYPE" = "openbsd-rcd" ]; then
+    echo "   • Service status: rcctl check patchmon_agent"
+    echo "   • Service logs: tail -f /etc/patchmon/logs/patchmon-agent.log"
+    echo "   • Restart service: rcctl restart patchmon_agent"
 else
     echo "   • Service logs: tail -f /etc/patchmon/logs/patchmon-agent.log"
     echo "   • Restart service: pkill -f 'patchmon-agent serve' && /usr/local/bin/patchmon-agent serve &"

--- a/docker/server.Dockerfile
+++ b/docker/server.Dockerfile
@@ -1,7 +1,7 @@
 # Development stage - run with go run, source can be volume-mounted for live reload
 FROM golang:1.26-alpine AS development
 
-RUN apk add --no-cache git ca-certificates tzdata curl node npm
+RUN apk add --no-cache git ca-certificates tzdata curl nodejs npm
 
 WORKDIR /app
 
@@ -14,7 +14,7 @@ WORKDIR /app/frontend
 COPY frontend/package*.json ./
 RUN npm install --ignore-scripts --legacy-peer-deps 2>/dev/null || true
 COPY frontend/ ./
-RUN npm run build 2>/dev/null || mkdir -p dist && echo '<!DOCTYPE html><html><body>Build frontend first</body></html>' > dist/index.html
+RUN npm run build 2>/dev/null || (mkdir -p dist && echo '<!DOCTYPE html><html><body>Build frontend first</body></html>' > dist/index.html)
 
 WORKDIR /app/server
 COPY server-source-code/ ./

--- a/frontend/src/components/AddHostWizard.jsx
+++ b/frontend/src/components/AddHostWizard.jsx
@@ -2,7 +2,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { CheckCircle, Copy, Download, RefreshCw, Wifi, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { DiWindows } from "react-icons/di";
-import { SiFreebsd, SiLinux } from "react-icons/si";
+import { SiFreebsd, SiLinux, SiOpenbsd } from "react-icons/si";
 import { useNavigate } from "react-router-dom";
 import {
 	adminHostsAPI,
@@ -37,7 +37,7 @@ const hasInitialReport = (hostData) => {
 
 const AddHostWizard = ({ isOpen, onClose, onSuccess }) => {
 	const [step, setStep] = useState(1);
-	const [platform, setPlatform] = useState("linux"); // linux | freebsd | windows
+	const [platform, setPlatform] = useState("linux"); // linux | freebsd | openbsd | windows
 	const [formData, setFormData] = useState({
 		friendly_name: "",
 		hostGroupIds: [],
@@ -92,6 +92,7 @@ const AddHostWizard = ({ isOpen, onClose, onSuccess }) => {
 		const base = `${serverUrl}/api/v1/hosts/install`;
 		const params = new URLSearchParams();
 		if (platform === "freebsd") params.set("os", "freebsd");
+		if (platform === "openbsd") params.set("os", "openbsd");
 		if (platform === "windows") params.set("os", "windows");
 		if (force && platform !== "windows") params.set("force", "true");
 		const qs = params.toString();
@@ -114,7 +115,8 @@ const AddHostWizard = ({ isOpen, onClose, onSuccess }) => {
 	};
 
 	const getShellCommand = (force) => {
-		const use_sudo = platform !== "freebsd";
+		// BSDs don't ship with sudo by default
+		const use_sudo = platform !== "freebsd" && platform !== "openbsd";
 		const base = use_sudo ? "sudo sh" : "sh";
 		return force ? `${base} -s -- --force` : base;
 	};
@@ -341,11 +343,11 @@ const AddHostWizard = ({ isOpen, onClose, onSuccess }) => {
 							Select the operating system of the host you want to add. The
 							install command will match this choice.
 						</p>
-						<div className="grid grid-cols-3 gap-4">
+						<div className="grid grid-cols-4 gap-3">
 							<button
 								type="button"
 								onClick={() => setPlatform("linux")}
-								className={`flex flex-col items-center justify-center p-6 rounded-lg border-2 transition-all ${
+								className={`flex flex-col items-center justify-center p-4 rounded-lg border-2 transition-all ${
 									platform === "linux"
 										? "border-primary-500 bg-primary-50 dark:bg-primary-900/30"
 										: "border-secondary-300 dark:border-secondary-600 hover:border-primary-400"
@@ -357,7 +359,7 @@ const AddHostWizard = ({ isOpen, onClose, onSuccess }) => {
 							<button
 								type="button"
 								onClick={() => setPlatform("freebsd")}
-								className={`flex flex-col items-center justify-center p-6 rounded-lg border-2 transition-all ${
+								className={`flex flex-col items-center justify-center p-4 rounded-lg border-2 transition-all ${
 									platform === "freebsd"
 										? "border-primary-500 bg-primary-50 dark:bg-primary-900/30"
 										: "border-secondary-300 dark:border-secondary-600 hover:border-primary-400"
@@ -368,8 +370,20 @@ const AddHostWizard = ({ isOpen, onClose, onSuccess }) => {
 							</button>
 							<button
 								type="button"
+								onClick={() => setPlatform("openbsd")}
+								className={`flex flex-col items-center justify-center p-4 rounded-lg border-2 transition-all ${
+									platform === "openbsd"
+										? "border-primary-500 bg-primary-50 dark:bg-primary-900/30"
+										: "border-secondary-300 dark:border-secondary-600 hover:border-primary-400"
+								}`}
+							>
+								<SiOpenbsd className="h-12 w-12 text-secondary-700 dark:text-secondary-200 mb-2" />
+								<span className="text-sm font-medium">OpenBSD</span>
+							</button>
+							<button
+								type="button"
 								onClick={() => setPlatform("windows")}
-								className={`flex flex-col items-center justify-center p-6 rounded-lg border-2 transition-all ${
+								className={`flex flex-col items-center justify-center p-4 rounded-lg border-2 transition-all ${
 									platform === "windows"
 										? "border-primary-500 bg-primary-50 dark:bg-primary-900/30"
 										: "border-secondary-300 dark:border-secondary-600 hover:border-primary-400"
@@ -556,7 +570,9 @@ const AddHostWizard = ({ isOpen, onClose, onSuccess }) => {
 								? "Windows"
 								: platform === "freebsd"
 									? "FreeBSD"
-									: "Linux"}{" "}
+									: platform === "openbsd"
+										? "OpenBSD"
+										: "Linux"}{" "}
 							host to install the agent
 							{platform === "windows"
 								? " (run PowerShell as Administrator)"

--- a/frontend/src/components/AddHostWizard.jsx
+++ b/frontend/src/components/AddHostWizard.jsx
@@ -2,7 +2,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { CheckCircle, Copy, Download, RefreshCw, Wifi, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { DiWindows } from "react-icons/di";
-import { SiFreebsd, SiLinux } from "react-icons/si";
+import { SiFreebsd, SiLinux, SiOpenbsd } from "react-icons/si";
 import { useNavigate } from "react-router-dom";
 import {
 	adminHostsAPI,
@@ -39,7 +39,7 @@ const hasInitialReport = (hostData) => {
 
 const AddHostWizard = ({ isOpen, onClose, onSuccess }) => {
 	const [step, setStep] = useState(1);
-	const [platform, setPlatform] = useState("linux"); // linux | freebsd | windows
+	const [platform, setPlatform] = useState("linux"); // linux | freebsd | openbsd | windows
 	const [formData, setFormData] = useState({
 		friendly_name: "",
 		hostGroupIds: [],
@@ -94,6 +94,7 @@ const AddHostWizard = ({ isOpen, onClose, onSuccess }) => {
 		const base = `${serverUrl}/api/v1/hosts/install`;
 		const params = new URLSearchParams();
 		if (platform === "freebsd") params.set("os", "freebsd");
+		if (platform === "openbsd") params.set("os", "openbsd");
 		if (platform === "windows") params.set("os", "windows");
 		if (force && platform !== "windows") params.set("force", "true");
 		const qs = params.toString();
@@ -120,7 +121,8 @@ const AddHostWizard = ({ isOpen, onClose, onSuccess }) => {
 	};
 
 	const getShellCommand = (force) => {
-		const use_sudo = platform !== "freebsd";
+		// BSDs don't ship with sudo by default
+		const use_sudo = platform !== "freebsd" && platform !== "openbsd";
 		const base = use_sudo ? "sudo sh" : "sh";
 		return force ? `${base} -s -- --force` : base;
 	};
@@ -348,11 +350,11 @@ const AddHostWizard = ({ isOpen, onClose, onSuccess }) => {
 							Select the operating system of the host you want to add. The
 							install command will match this choice.
 						</p>
-						<div className="grid grid-cols-3 gap-4">
+						<div className="grid grid-cols-4 gap-3">
 							<button
 								type="button"
 								onClick={() => setPlatform("linux")}
-								className={`flex flex-col items-center justify-center p-6 rounded-lg border-2 transition-all ${
+								className={`flex flex-col items-center justify-center p-4 rounded-lg border-2 transition-all ${
 									platform === "linux"
 										? "border-primary-500 bg-primary-50 dark:bg-primary-900/30"
 										: "border-secondary-300 dark:border-secondary-600 hover:border-primary-400"
@@ -364,7 +366,7 @@ const AddHostWizard = ({ isOpen, onClose, onSuccess }) => {
 							<button
 								type="button"
 								onClick={() => setPlatform("freebsd")}
-								className={`flex flex-col items-center justify-center p-6 rounded-lg border-2 transition-all ${
+								className={`flex flex-col items-center justify-center p-4 rounded-lg border-2 transition-all ${
 									platform === "freebsd"
 										? "border-primary-500 bg-primary-50 dark:bg-primary-900/30"
 										: "border-secondary-300 dark:border-secondary-600 hover:border-primary-400"
@@ -375,8 +377,20 @@ const AddHostWizard = ({ isOpen, onClose, onSuccess }) => {
 							</button>
 							<button
 								type="button"
+								onClick={() => setPlatform("openbsd")}
+								className={`flex flex-col items-center justify-center p-4 rounded-lg border-2 transition-all ${
+									platform === "openbsd"
+										? "border-primary-500 bg-primary-50 dark:bg-primary-900/30"
+										: "border-secondary-300 dark:border-secondary-600 hover:border-primary-400"
+								}`}
+							>
+								<SiOpenbsd className="h-12 w-12 text-secondary-700 dark:text-secondary-200 mb-2" />
+								<span className="text-sm font-medium">OpenBSD</span>
+							</button>
+							<button
+								type="button"
 								onClick={() => setPlatform("windows")}
-								className={`flex flex-col items-center justify-center p-6 rounded-lg border-2 transition-all ${
+								className={`flex flex-col items-center justify-center p-4 rounded-lg border-2 transition-all ${
 									platform === "windows"
 										? "border-primary-500 bg-primary-50 dark:bg-primary-900/30"
 										: "border-secondary-300 dark:border-secondary-600 hover:border-primary-400"
@@ -563,7 +577,9 @@ const AddHostWizard = ({ isOpen, onClose, onSuccess }) => {
 								? "Windows"
 								: platform === "freebsd"
 									? "FreeBSD"
-									: "Linux"}{" "}
+									: platform === "openbsd"
+										? "OpenBSD"
+										: "Linux"}{" "}
 							host to install the agent
 							{platform === "windows"
 								? " (run PowerShell as Administrator)"

--- a/frontend/src/pages/PackageDetail.jsx
+++ b/frontend/src/pages/PackageDetail.jsx
@@ -386,7 +386,7 @@ const PackageDetail = () => {
 						</div>
 					</div>
 				</h4>
-				<p className="text-sm text-secondary-600 dark:text-white">
+				<p className="text-sm text-secondary-600 dark:text-white whitespace-pre-wrap">
 					{pkg.description || "No description available."}
 				</p>
 			</div>

--- a/frontend/src/pages/PackageDetail.jsx
+++ b/frontend/src/pages/PackageDetail.jsx
@@ -410,7 +410,7 @@ const PackageDetail = () => {
 						</div>
 					</div>
 				</h4>
-				<p className="text-sm text-secondary-600 dark:text-white">
+				<p className="text-sm text-secondary-600 dark:text-white whitespace-pre-wrap">
 					{pkg.description || "No description available."}
 				</p>
 			</div>

--- a/frontend/src/pages/hostdetail/CredentialsModal.jsx
+++ b/frontend/src/pages/hostdetail/CredentialsModal.jsx
@@ -80,6 +80,7 @@ const CredentialsModal = ({ host, isOpen, onClose, plaintextApiKey }) => {
 		const base = `${serverUrl}/api/v1/hosts/install`;
 		const params = new URLSearchParams();
 		if (host?.expected_platform === "freebsd") params.set("os", "freebsd");
+		if (host?.expected_platform === "openbsd") params.set("os", "openbsd");
 		if (host?.expected_platform === "windows" || host?.os_type === "windows")
 			params.set("os", "windows");
 		if (forceInstall && host?.expected_platform !== "windows")
@@ -90,7 +91,10 @@ const CredentialsModal = ({ host, isOpen, onClose, plaintextApiKey }) => {
 
 	// Helper function to build the shell command suffix (no sudo on FreeBSD/pfSense)
 	const getShellCommand = () => {
-		const use_sudo = host?.expected_platform !== "freebsd";
+		// BSDs don't ship with sudo by default
+		const use_sudo =
+			host?.expected_platform !== "freebsd" &&
+			host?.expected_platform !== "openbsd";
 		const base = use_sudo ? "sudo sh" : "sh";
 		return forceInstall ? `${base} -s -- --force` : base;
 	};

--- a/frontend/src/pages/hostdetail/CredentialsModal.jsx
+++ b/frontend/src/pages/hostdetail/CredentialsModal.jsx
@@ -81,6 +81,7 @@ const CredentialsModal = ({ host, isOpen, onClose, plaintextApiKey }) => {
 		const base = `${serverUrl}/api/v1/hosts/install`;
 		const params = new URLSearchParams();
 		if (host?.expected_platform === "freebsd") params.set("os", "freebsd");
+		if (host?.expected_platform === "openbsd") params.set("os", "openbsd");
 		if (host?.expected_platform === "windows" || host?.os_type === "windows")
 			params.set("os", "windows");
 		if (forceInstall && host?.expected_platform !== "windows")
@@ -91,7 +92,10 @@ const CredentialsModal = ({ host, isOpen, onClose, plaintextApiKey }) => {
 
 	// Helper function to build the shell command suffix (no sudo on FreeBSD/pfSense)
 	const getShellCommand = () => {
-		const use_sudo = host?.expected_platform !== "freebsd";
+		// BSDs don't ship with sudo by default
+		const use_sudo =
+			host?.expected_platform !== "freebsd" &&
+			host?.expected_platform !== "openbsd";
 		const base = use_sudo ? "sudo sh" : "sh";
 		return forceInstall ? `${base} -s -- --force` : base;
 	};

--- a/frontend/src/utils/osIcons.jsx
+++ b/frontend/src/utils/osIcons.jsx
@@ -17,6 +17,7 @@ import {
 	SiLinuxmint,
 	SiMacos,
 	SiManjaro,
+	SiOpenbsd,
 	SiOpensuse,
 	SiParrotsecurity,
 	SiPfsense,
@@ -115,6 +116,9 @@ export const getOSIcon = (osType) => {
 
 	// FreeBSD
 	if (os.includes("freebsd")) return SiFreebsd;
+
+	// OpenBSD
+	if (os.includes("openbsd")) return SiOpenbsd;
 
 	// Default fallback
 	return Monitor;
@@ -227,6 +231,9 @@ export const getOSDisplayName = (osType) => {
 
 	// FreeBSD
 	if (os.includes("freebsd")) return "FreeBSD";
+
+	// OpenBSD
+	if (os.includes("openbsd")) return "OpenBSD";
 
 	// Return original if no match
 	return osType;

--- a/server-source-code/internal/agents/patchmon_install.sh
+++ b/server-source-code/internal/agents/patchmon_install.sh
@@ -154,8 +154,21 @@ if [ -z "$PATCHMON_URL" ] || [ -z "$API_ID" ] || [ -z "$API_KEY" ]; then
     error "Missing required parameters. This script should be called via the PatchMon web interface."
 fi
 
-# Default PATCHMON_OS to linux if not set (backward compatibility when os param not in URL)
-PATCHMON_OS="${PATCHMON_OS:-linux}"
+# Always verify OS via uname -s to catch cases where the server defaulted to linux
+# (e.g. when ?os= was not passed in the install URL on an OpenBSD or FreeBSD host)
+os_raw=$(uname -s 2>/dev/null || echo "unknown")
+case "$os_raw" in
+    "OpenBSD")
+        PATCHMON_OS="openbsd"
+        ;;
+    "FreeBSD")
+        PATCHMON_OS="freebsd"
+        ;;
+    *)
+        # Trust the server-provided value; fall back to linux
+        PATCHMON_OS="${PATCHMON_OS:-linux}"
+        ;;
+esac
 
 # Auto-detect architecture if not explicitly set
 if [ -z "$ARCHITECTURE" ]; then
@@ -163,7 +176,7 @@ if [ -z "$ARCHITECTURE" ]; then
     
     # Map architecture to supported values
     case "$arch_raw" in
-        "x86_64")
+        "x86_64"|"amd64")
             ARCHITECTURE="amd64"
             ;;
         "i386"|"i686")

--- a/server-source-code/internal/handler/agent_version.go
+++ b/server-source-code/internal/handler/agent_version.go
@@ -200,6 +200,7 @@ func (h *AgentVersionHandler) GetVersionInfo(w http.ResponseWriter, r *http.Requ
 		"supportedArchitectures": []string{
 			"linux-amd64", "linux-arm64", "linux-386", "linux-arm",
 			"freebsd-amd64", "freebsd-arm64", "freebsd-386", "freebsd-arm",
+			"openbsd-amd64", "openbsd-arm64", "openbsd-386", "openbsd-arm",
 			"windows-amd64", "windows-arm64",
 		},
 		"status": "ready",
@@ -239,18 +240,21 @@ func (h *AgentVersionHandler) ServeAgentDownload(w http.ResponseWriter, r *http.
 	if osParam == "" {
 		osParam = "linux"
 	}
-	validOss := map[string]bool{"linux": true, "freebsd": true, "windows": true}
+	validOss := map[string]bool{"linux": true, "freebsd": true, "openbsd": true, "windows": true}
 	if !validOss[osParam] {
-		JSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid os. Must be one of: linux, freebsd, windows"})
+		JSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid os. Must be one of: linux, freebsd, openbsd, windows"})
 		return
 	}
 	validArchLinux := map[string]bool{"amd64": true, "386": true, "arm64": true, "arm": true}
 	validArchFreebsd := map[string]bool{"amd64": true, "386": true, "arm64": true, "arm": true}
+	validArchOpenbsd := map[string]bool{"amd64": true, "386": true, "arm64": true, "arm": true}
 	validArchWindows := map[string]bool{"amd64": true, "arm64": true}
 	var validArch map[string]bool
 	switch osParam {
 	case "freebsd":
 		validArch = validArchFreebsd
+	case "openbsd":
+		validArch = validArchOpenbsd
 	case "windows":
 		validArch = validArchWindows
 	default:

--- a/server-source-code/internal/handler/agent_version.go
+++ b/server-source-code/internal/handler/agent_version.go
@@ -182,9 +182,9 @@ func (h *AgentVersionHandler) ServeAgentDownload(w http.ResponseWriter, r *http.
 	if osParam == "" {
 		osParam = "linux"
 	}
-	validOss := map[string]bool{"linux": true, "freebsd": true, "windows": true}
+	validOss := map[string]bool{"linux": true, "freebsd": true, "openbsd": true, "windows": true}
 	if !validOss[osParam] {
-		JSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid os. Must be one of: linux, freebsd, windows"})
+		JSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid os. Must be one of: linux, freebsd, openbsd, windows"})
 		return
 	}
 	binaryName, supported := util.AgentBinaryName(osParam, architecture)

--- a/server-source-code/internal/handler/install.go
+++ b/server-source-code/internal/handler/install.go
@@ -142,7 +142,7 @@ func (h *InstallHandler) ServeInstall(w http.ResponseWriter, r *http.Request) {
 		architecture = ""
 	}
 	osParam := r.URL.Query().Get("os")
-	if osParam != "linux" && osParam != "freebsd" && osParam != "windows" {
+	if osParam != "linux" && osParam != "freebsd" && osParam != "openbsd" && osParam != "windows" {
 		osParam = "linux"
 	}
 
@@ -537,6 +537,8 @@ func (h *InstallHandler) ServeAgentVersion(w http.ResponseWriter, r *http.Reques
 			osParam = "windows"
 		} else if strings.Contains(ep, "freebsd") || strings.Contains(ep, "pfsense") {
 			osParam = "freebsd"
+		} else if ep == "openbsd" || strings.Contains(ep, "openbsd") {
+			osParam = "openbsd"
 		} else {
 			osParam = "linux"
 		}
@@ -547,6 +549,8 @@ func (h *InstallHandler) ServeAgentVersion(w http.ResponseWriter, r *http.Reques
 			osParam = "windows"
 		} else if strings.Contains(reported, "freebsd") || strings.Contains(reported, "pfsense") {
 			osParam = "freebsd"
+		} else if strings.Contains(reported, "openbsd") {
+			osParam = "openbsd"
 		} else {
 			osParam = "linux"
 		}
@@ -555,20 +559,24 @@ func (h *InstallHandler) ServeAgentVersion(w http.ResponseWriter, r *http.Reques
 		osParam = "linux"
 	}
 
-	validOss := map[string]bool{"linux": true, "freebsd": true, "windows": true}
+	validOss := map[string]bool{"linux": true, "freebsd": true, "openbsd": true, "windows": true}
 	if !validOss[osParam] {
-		JSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid os. Must be one of: linux, freebsd, windows"})
+		JSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid os. Must be one of: linux, freebsd, openbsd, windows"})
 		return
 	}
 
 	validArchLinux := map[string]bool{"amd64": true, "386": true, "arm64": true, "arm": true}
 	validArchFreebsd := map[string]bool{"amd64": true, "386": true, "arm64": true, "arm": true}
+	validArchOpenbsd := map[string]bool{"amd64": true, "386": true, "arm64": true, "arm": true}
 	validArchWindows := map[string]bool{"amd64": true, "arm64": true}
 	var validArch map[string]bool
 	var archList string
 	switch osParam {
 	case "freebsd":
 		validArch = validArchFreebsd
+		archList = "amd64, 386, arm64, arm"
+	case "openbsd":
+		validArch = validArchOpenbsd
 		archList = "amd64, 386, arm64, arm"
 	case "windows":
 		validArch = validArchWindows
@@ -721,6 +729,8 @@ func (h *InstallHandler) ServeAgentDownload(w http.ResponseWriter, r *http.Reque
 			osParam = "windows"
 		} else if strings.Contains(ep, "freebsd") || strings.Contains(ep, "pfsense") {
 			osParam = "freebsd"
+		} else if ep == "openbsd" || strings.Contains(ep, "openbsd") {
+			osParam = "openbsd"
 		} else {
 			osParam = "linux"
 		}
@@ -731,6 +741,8 @@ func (h *InstallHandler) ServeAgentDownload(w http.ResponseWriter, r *http.Reque
 			osParam = "windows"
 		} else if strings.Contains(reported, "freebsd") || strings.Contains(reported, "pfsense") {
 			osParam = "freebsd"
+		} else if strings.Contains(reported, "openbsd") {
+			osParam = "openbsd"
 		} else {
 			osParam = "linux"
 		}
@@ -739,20 +751,24 @@ func (h *InstallHandler) ServeAgentDownload(w http.ResponseWriter, r *http.Reque
 		osParam = "linux"
 	}
 
-	validOss := map[string]bool{"linux": true, "freebsd": true, "windows": true}
+	validOss := map[string]bool{"linux": true, "freebsd": true, "openbsd": true, "windows": true}
 	if !validOss[osParam] {
-		JSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid os. Must be one of: linux, freebsd, windows"})
+		JSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid os. Must be one of: linux, freebsd, openbsd, windows"})
 		return
 	}
 
 	validArchLinux := map[string]bool{"amd64": true, "386": true, "arm64": true, "arm": true}
 	validArchFreebsd := map[string]bool{"amd64": true, "386": true, "arm64": true, "arm": true}
+	validArchOpenbsd := map[string]bool{"amd64": true, "386": true, "arm64": true, "arm": true}
 	validArchWindows := map[string]bool{"amd64": true, "arm64": true}
 	var validArch map[string]bool
 	var archList string
 	switch osParam {
 	case "freebsd":
 		validArch = validArchFreebsd
+		archList = "amd64, 386, arm64, arm"
+	case "openbsd":
+		validArch = validArchOpenbsd
 		archList = "amd64, 386, arm64, arm"
 	case "windows":
 		validArch = validArchWindows

--- a/server-source-code/internal/handler/install.go
+++ b/server-source-code/internal/handler/install.go
@@ -100,6 +100,9 @@ func inferHostOS(expectedPlatform *string, osType string) string {
 		if strings.Contains(ep, "freebsd") || strings.Contains(ep, "pfsense") {
 			return "freebsd"
 		}
+		if strings.Contains(ep, "openbsd") {
+			return "openbsd"
+		}
 		return "linux"
 	}
 	if osType != "" {
@@ -109,6 +112,9 @@ func inferHostOS(expectedPlatform *string, osType string) string {
 		}
 		if strings.Contains(reported, "freebsd") || strings.Contains(reported, "pfsense") {
 			return "freebsd"
+		}
+		if strings.Contains(reported, "openbsd") {
+			return "openbsd"
 		}
 		return "linux"
 	}
@@ -170,7 +176,7 @@ func (h *InstallHandler) ServeInstall(w http.ResponseWriter, r *http.Request) {
 		architecture = ""
 	}
 	osParam := r.URL.Query().Get("os")
-	if osParam != "linux" && osParam != "freebsd" && osParam != "windows" {
+	if osParam != "linux" && osParam != "freebsd" && osParam != "openbsd" && osParam != "windows" {
 		osParam = inferHostOS(host.ExpectedPlatform, host.OSType)
 	}
 
@@ -945,9 +951,9 @@ func (h *InstallHandler) ServeAgentVersion(w http.ResponseWriter, r *http.Reques
 		osParam = inferHostOS(host.ExpectedPlatform, host.OSType)
 	}
 
-	validOss := map[string]bool{"linux": true, "freebsd": true, "windows": true}
+	validOss := map[string]bool{"linux": true, "freebsd": true, "openbsd": true, "windows": true}
 	if !validOss[osParam] {
-		JSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid os. Must be one of: linux, freebsd, windows"})
+		JSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid os. Must be one of: linux, freebsd, openbsd, windows"})
 		return
 	}
 
@@ -1089,9 +1095,9 @@ func (h *InstallHandler) ServeAgentDownload(w http.ResponseWriter, r *http.Reque
 		osParam = inferHostOS(host.ExpectedPlatform, host.OSType)
 	}
 
-	validOss := map[string]bool{"linux": true, "freebsd": true, "windows": true}
+	validOss := map[string]bool{"linux": true, "freebsd": true, "openbsd": true, "windows": true}
 	if !validOss[osParam] {
-		JSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid os. Must be one of: linux, freebsd, windows"})
+		JSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid os. Must be one of: linux, freebsd, openbsd, windows"})
 		return
 	}
 

--- a/server-source-code/internal/store/report.go
+++ b/server-source-code/internal/store/report.go
@@ -340,6 +340,7 @@ func (s *ReportStore) ProcessReport(ctx context.Context, hostID string, payload 
 	reposByName := make(map[string]string)        // repo.Name -> repo ID
 	reposByURLDistComp := make(map[string]string) // "url|dist|comp" -> repo ID
 	reposByComponent := make(map[string]string)   // components -> repo ID
+	reposByURL := make(map[string]string)         // bare repo URL -> repo ID (for prefix matching)
 
 	if len(payload.Repositories) > 0 {
 		if err := q.DeleteHostRepositoriesByHostID(ctx, hostID); err != nil {
@@ -393,6 +394,7 @@ func (s *ReportStore) ProcessReport(ctx context.Context, hostID string, payload 
 
 			// Build lookup maps for package -> repo resolution
 			reposByName[repoData.Name] = repoID
+			reposByURL[repoData.URL] = repoID
 			key := repoData.URL + "|" + repoData.Distribution + "|" + repoData.Components
 			reposByURLDistComp[key] = repoID
 			// Also index by url|distribution with each individual component for APT.
@@ -453,7 +455,7 @@ func (s *ReportStore) ProcessReport(ctx context.Context, hostID string, payload 
 		// errors if any payload.Packages name is missing from nameToID.
 
 		hpPayload, err := buildHostPackagesPayload(hostID, payload.Packages, nameToID,
-			reposByName, reposByURLDistComp, reposByComponent)
+			reposByName, reposByURLDistComp, reposByComponent, reposByURL)
 		if err != nil {
 			return nil, fmt.Errorf("build host_packages payload: %w", err)
 		}
@@ -496,7 +498,7 @@ func (s *ReportStore) ProcessReport(ctx context.Context, hostID string, payload 
 
 // resolveSourceRepoID matches an agent's sourceRepository string to a repository ID
 // using the lookup maps built during repo processing.
-func resolveSourceRepoID(sourceRepo string, reposByName, reposByURLDistComp, reposByComponent map[string]string) *string {
+func resolveSourceRepoID(sourceRepo string, reposByName, reposByURLDistComp, reposByComponent, reposByURL map[string]string) *string {
 	if sourceRepo == "" || sourceRepo == "local" || sourceRepo == "unknown" || sourceRepo == "foreign" || sourceRepo == "@System" {
 		return nil
 	}
@@ -527,6 +529,19 @@ func resolveSourceRepoID(sourceRepo string, reposByName, reposByURLDistComp, rep
 	// Try component match (APK: "main", "community")
 	if id, ok := reposByComponent[sourceRepo]; ok {
 		return &id
+	}
+
+	// Try URL-prefix match: the agent sends the full mirror directory URL
+	// (e.g. "https://mirror.example.com/OpenBSD/7.8/packages/amd64") while the
+	// repository record stores only the base mirror URL
+	// (e.g. "https://mirror.example.com/OpenBSD"). Walk reposByURL and return
+	// the first entry whose URL is a prefix of sourceRepo.
+	if strings.HasPrefix(sourceRepo, "http://") || strings.HasPrefix(sourceRepo, "https://") {
+		for repoURL, id := range reposByURL {
+			if strings.HasPrefix(sourceRepo, repoURL) {
+				return &id
+			}
+		}
 	}
 
 	return nil
@@ -609,7 +624,7 @@ func buildHostPackagesPayload(
 	hostID string,
 	packages []ReportPackage,
 	nameToID map[string]string,
-	reposByName, reposByURLDistComp, reposByComponent map[string]string,
+	reposByName, reposByURLDistComp, reposByComponent, reposByURL map[string]string,
 ) ([]byte, error) {
 	rows := make([]hostPackageRow, 0, len(packages))
 	for i := range packages {
@@ -624,7 +639,7 @@ func buildHostPackagesPayload(
 			availableVersion = *p.AvailableVersion
 		}
 		sourceRepoID := ""
-		if id := resolveSourceRepoID(p.SourceRepository, reposByName, reposByURLDistComp, reposByComponent); id != nil {
+		if id := resolveSourceRepoID(p.SourceRepository, reposByName, reposByURLDistComp, reposByComponent, reposByURL); id != nil {
 			sourceRepoID = *id
 		}
 

--- a/server-source-code/internal/store/report.go
+++ b/server-source-code/internal/store/report.go
@@ -562,6 +562,7 @@ func (s *ReportStore) ProcessReport(ctx context.Context, hostID string, payload 
 	reposByName := make(map[string]string)        // repo.Name -> repo ID
 	reposByURLDistComp := make(map[string]string) // "url|dist|comp" -> repo ID
 	reposByComponent := make(map[string]string)   // components -> repo ID
+	reposByURL := make(map[string]string)         // bare repo URL -> repo ID (for prefix matching)
 
 	// A repos section EXPLICITLY claimed in the payload's `sections` list is
 	// authoritative even when the array is empty. An empty list is legitimate
@@ -631,6 +632,7 @@ func (s *ReportStore) ProcessReport(ctx context.Context, hostID string, payload 
 
 			// Build lookup maps for package -> repo resolution
 			reposByName[repoData.Name] = repoID
+			reposByURL[repoData.URL] = repoID
 			key := repoData.URL + "|" + repoData.Distribution + "|" + repoData.Components
 			reposByURLDistComp[key] = repoID
 			// Also index by url|distribution with each individual component for APT.
@@ -704,7 +706,7 @@ func (s *ReportStore) ProcessReport(ctx context.Context, hostID string, payload 
 		// errors if any payload.Packages name is still missing from nameToID.
 
 		hpPayload, err := buildHostPackagesPayload(hostID, payload.Packages, nameToID,
-			reposByName, reposByURLDistComp, reposByComponent)
+			reposByName, reposByURLDistComp, reposByComponent, reposByURL)
 		if err != nil {
 			return nil, fmt.Errorf("build host_packages payload: %w", err)
 		}
@@ -868,7 +870,7 @@ func missingPackageNames(packages []ReportPackage, nameToID map[string]string) [
 
 // resolveSourceRepoID matches an agent's sourceRepository string to a repository ID
 // using the lookup maps built during repo processing.
-func resolveSourceRepoID(sourceRepo string, reposByName, reposByURLDistComp, reposByComponent map[string]string) *string {
+func resolveSourceRepoID(sourceRepo string, reposByName, reposByURLDistComp, reposByComponent, reposByURL map[string]string) *string {
 	if sourceRepo == "" || sourceRepo == "local" || sourceRepo == "unknown" || sourceRepo == "foreign" || sourceRepo == "@System" {
 		return nil
 	}
@@ -899,6 +901,19 @@ func resolveSourceRepoID(sourceRepo string, reposByName, reposByURLDistComp, rep
 	// Try component match (APK: "main", "community")
 	if id, ok := reposByComponent[sourceRepo]; ok {
 		return &id
+	}
+
+	// Try URL-prefix match: the agent sends the full mirror directory URL
+	// (e.g. "https://mirror.example.com/OpenBSD/7.8/packages/amd64") while the
+	// repository record stores only the base mirror URL
+	// (e.g. "https://mirror.example.com/OpenBSD"). Walk reposByURL and return
+	// the first entry whose URL is a prefix of sourceRepo.
+	if strings.HasPrefix(sourceRepo, "http://") || strings.HasPrefix(sourceRepo, "https://") {
+		for repoURL, id := range reposByURL {
+			if strings.HasPrefix(sourceRepo, repoURL) {
+				return &id
+			}
+		}
 	}
 
 	return nil
@@ -988,7 +1003,7 @@ func buildHostPackagesPayload(
 	hostID string,
 	packages []ReportPackage,
 	nameToID map[string]string,
-	reposByName, reposByURLDistComp, reposByComponent map[string]string,
+	reposByName, reposByURLDistComp, reposByComponent, reposByURL map[string]string,
 ) ([]byte, error) {
 	rows := make([]hostPackageRow, 0, len(packages))
 	// As above: no ON CONFLICT here, so duplicates violate
@@ -1010,7 +1025,7 @@ func buildHostPackagesPayload(
 			availableVersion = *p.AvailableVersion
 		}
 		sourceRepoID := ""
-		if id := resolveSourceRepoID(p.SourceRepository, reposByName, reposByURLDistComp, reposByComponent); id != nil {
+		if id := resolveSourceRepoID(p.SourceRepository, reposByName, reposByURLDistComp, reposByComponent, reposByURL); id != nil {
 			sourceRepoID = *id
 		}
 

--- a/server-source-code/internal/store/report_test.go
+++ b/server-source-code/internal/store/report_test.go
@@ -192,7 +192,7 @@ func TestBuildHostPackagesPayload_LinuxAndWindowsMixed(t *testing.T) {
 		"windows-update": "pkg-uuid-windows",
 	}
 
-	raw, err := buildHostPackagesPayload(hostID, pkgs, nameToID, nil, nil, nil)
+	raw, err := buildHostPackagesPayload(hostID, pkgs, nameToID, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("buildHostPackagesPayload: %v", err)
 	}
@@ -263,7 +263,7 @@ func TestBuildHostPackagesPayload_SourceRepoResolved(t *testing.T) {
 	nameToID := map[string]string{"a-pkg": "p1", "b-pkg": "p2", "c-pkg": "p3"}
 	reposByName := map[string]string{"baseos": "repo-uuid-1"}
 
-	raw, err := buildHostPackagesPayload("h1", pkgs, nameToID, reposByName, nil, nil)
+	raw, err := buildHostPackagesPayload("h1", pkgs, nameToID, reposByName, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("buildHostPackagesPayload: %v", err)
 	}
@@ -289,7 +289,7 @@ func TestBuildHostPackagesPayload_SourceRepoResolved(t *testing.T) {
 // garbage rows.
 func TestBuildHostPackagesPayload_MissingPackageIDFails(t *testing.T) {
 	pkgs := []ReportPackage{{Name: "missing", CurrentVersion: "1"}}
-	_, err := buildHostPackagesPayload("h1", pkgs, map[string]string{}, nil, nil, nil)
+	_, err := buildHostPackagesPayload("h1", pkgs, map[string]string{}, nil, nil, nil, nil)
 	if err == nil {
 		t.Fatalf("expected error when nameToID is missing the package, got nil")
 	}

--- a/server-source-code/internal/util/agent_binary.go
+++ b/server-source-code/internal/util/agent_binary.go
@@ -46,6 +46,10 @@ var agentBinaryNames = map[string]string{
 	"freebsd/386":   "patchmon-agent-freebsd-386",
 	"freebsd/arm64": "patchmon-agent-freebsd-arm64",
 	"freebsd/arm":   "patchmon-agent-freebsd-arm",
+	"openbsd/amd64": "patchmon-agent-openbsd-amd64",
+	"openbsd/386":   "patchmon-agent-openbsd-386",
+	"openbsd/arm64": "patchmon-agent-openbsd-arm64",
+	"openbsd/arm":   "patchmon-agent-openbsd-arm",
 	"windows/amd64": "patchmon-agent-windows-amd64.exe",
 	"windows/arm64": "patchmon-agent-windows-arm64.exe",
 }


### PR DESCRIPTION
### Summary

Adds first-class OpenBSD support to the PatchMon agent installation script and service infrastructure, enabling monitoring of OpenBSD hosts via the existing `curl | sh` installation flow.

---

### Changes

#### `agents/patchmon_install.sh`

**Architecture validation**
- Restricts OpenBSD to supported architectures: `amd64` and `arm64`

**Package management**
- Installs `curl` via `pkg_add -I` if not already present
- Skips `jq` and `bc` — not required by the OpenBSD agent binary

**Machine ID detection**
- Reads `hw.uuid` via `sysctl -n` as the primary machine identifier
- Falls back to `patchmon-openbsd-<hostname>-<epoch>` if unavailable

**Binary download**
- Downloads the correct binary: `patchmon-agent-openbsd-<arch>` (e.g. `patchmon-agent-openbsd-amd64`)

**Service setup (`rc.d` + `rcctl`)**
- Writes `/etc/rc.d/patchmon_agent` as a ksh rc.d script using OpenBSD's `rc.subr` framework
- Enables and starts the service via `rcctl enable` / `rcctl start`
- Verifies service health with `rcctl check patchmon_agent`

**Installation summary & management commands**
- Prints OpenBSD-specific post-install commands:
  - `rcctl check patchmon_agent`
  - `rcctl restart patchmon_agent`
  - `tail -f /etc/patchmon/logs/patchmon-agent.log`

#### `agents/` (pre-built binaries)
- `patchmon-agent-openbsd-amd64`
- `patchmon-agent-openbsd-arm64`

---

<img width="487" height="368" alt="image" src="https://github.com/user-attachments/assets/dd5aaaa7-e616-4c57-b027-59ed84135589" />

<img width="474" height="234" alt="image" src="https://github.com/user-attachments/assets/a6f4efa9-069f-499e-80e8-73e46e0ed734" />

<img width="1828" height="359" alt="image" src="https://github.com/user-attachments/assets/c5a339ac-f270-4f41-a5d8-e10bfba42cbc" />
