### PR TITLE
fix: include superadmin role in admin users check

### DIFF
--- a/backend/src/routes/authRoutes.js
+++ b/backend/src/routes/authRoutes.js
@@ -325,7 +325,7 @@ function get_location_from_ip(ip) {
 router.get("/check-admin-users", async (_req, res) => {
 	try {
 		const adminCount = await prisma.users.count({
-			where: { role: "admin" },
+			where: { role: { in: ["admin", "superadmin"] } },
 		});
 
 		// Check OIDC configuration

--- a/backend/src/routes/authRoutes.js
+++ b/backend/src/routes/authRoutes.js
@@ -383,9 +383,9 @@ router.post(
 			// could both pass the admin check and create duplicate admins
 			const user = await prisma
 				.$transaction(async (tx) => {
-					// Check if any admin users already exist
+					// Check if any admin users already exist (including superadmin)
 					const adminCount = await tx.users.count({
-						where: { role: "admin" },
+						where: { role: { in: ["admin", "superadmin"] } },
 					});
 
 					if (adminCount > 0) {


### PR DESCRIPTION
## Summary

Closes #618

**Problem:** The setup wizard (`/auth/check-admin-users` endpoint) only checks for users with `role = 'admin'`. When all existing users have the `superadmin` role, the endpoint returns `hasAdminUsers: false`, causing the frontend to incorrectly display the first-time setup wizard.

**Fix:** Changed the Prisma query from:
```js
where: { role: "admin" }
```
to:
```js
where: { role: { in: ["admin", "superadmin"] } }
```

This ensures that both `admin` and `superadmin` users are recognized as admin users, preventing the setup wizard from appearing when a `superadmin` already exists.

## Test plan

- [ ] Create a fresh PatchMon instance with only a `superadmin` user (no `admin` users)
- [ ] Navigate to the login page and verify the setup wizard is **not** shown
- [ ] Verify that with no users at all, the setup wizard **is** still shown
- [ ] Verify that with an `admin` user, the setup wizard is **not** shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)