### PR TITLE
fix: add real_ip_module to nginx for correct client IP behind reverse proxy

### DIFF
--- a/docker/nginx.conf.template
+++ b/docker/nginx.conf.template
@@ -28,6 +28,16 @@ server {
     # Prevent search engine indexing
     add_header X-Robots-Tag "noindex, nofollow, noarchive, nosnippet" always;
 
+    # Resolve real client IP when behind a reverse proxy (e.g., Traefik, Nginx, Caddy).
+    # Without this, $remote_addr contains the proxy's internal IP, causing
+    # X-Real-IP and X-Forwarded-For to be set incorrectly for the backend.
+    set_real_ip_from 10.0.0.0/8;
+    set_real_ip_from 172.16.0.0/12;
+    set_real_ip_from 192.168.0.0/16;
+    set_real_ip_from 100.64.0.0/10;
+    real_ip_header X-Forwarded-For;
+    real_ip_recursive on;
+
     # Bull Board proxy - must come before the root location to avoid conflicts
     location /bullboard {
         proxy_pass http://${BACKEND_HOST}:${BACKEND_PORT};


### PR DESCRIPTION
## Summary

Closes #622

When PatchMon runs behind a reverse proxy, the frontend nginx container sets `X-Real-IP` and `X-Forwarded-For` to the internal Docker/proxy network IP (e.g., `10.242.8.130`) instead of the real client IP. This causes all sessions to show internal IPs, breaking security logging and suspicious activity detection.

## Changes

Added `real_ip_module` directives to `docker/nginx.conf.template`:

```nginx
set_real_ip_from 10.0.0.0/8;
set_real_ip_from 172.16.0.0/12;
set_real_ip_from 192.168.0.0/16;
set_real_ip_from 100.64.0.0/10;
real_ip_header X-Forwarded-For;
real_ip_recursive on;
```

This resolves `$remote_addr` to the real client IP before nginx sets the `X-Real-IP` and `X-Forwarded-For` proxy headers for the backend.

## Why these ranges?

- `10.0.0.0/8` — Docker networks, internal proxies
- `172.16.0.0/12` — Docker bridge networks, private infrastructure
- `192.168.0.0/16` — Local networks
- `100.64.0.0/10` — CGNAT range (used by Tailscale, WireGuard tunnels like Pangolin/Gerbil)

## Test plan

1. Deploy PatchMon behind a reverse proxy (e.g., Traefik, Nginx, Caddy)
2. Set `TRUST_PROXY` to appropriate value (e.g., `10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,100.64.0.0/10`)
3. Log in to PatchMon
4. Navigate to profile → Sessions
5. Verify that the session shows the real client IP, not an internal Docker IP

**Before fix:** Sessions show `10.242.x.x` (internal Docker/tunnel IP)
**After fix:** Sessions show real client IP (e.g., public IPv4/IPv6)

## Notes

- The `real_ip_module` is included by default in the official nginx Docker image
- `real_ip_recursive on` ensures the correct client IP is extracted even with multiple proxy hops
- This change is safe for non-proxied deployments (no effect when requests come from non-private IPs)