### PR TITLE
fix: suppress SSG version warning when correct content file exists

### DIFF
--- a/agent-source-code/internal/integrations/compliance/openscap.go
+++ b/agent-source-code/internal/integrations/compliance/openscap.go
@@ -260,14 +260,30 @@ func (s *OpenSCAPScanner) GetScannerDetails() *models.ComplianceScannerDetails {
 	ssgUpgradeMessage := ""
 	if minVersion != "" && contentVersion != "" {
 		if compareVersions(contentVersion, minVersion) < 0 {
-			ssgNeedsUpgrade = true
-			ssgUpgradeMessage = fmt.Sprintf("ssg-base %s is installed, but %s %s requires v%s+ for proper CIS/STIG content.",
-				contentVersion, s.osInfo.Name, s.osInfo.Version, minVersion)
+			// Check if the correct content file exists despite old package version
+			// (e.g., installed via Ubuntu Security Guide or manual install)
+			osVersion := strings.ReplaceAll(s.osInfo.Version, ".", "")
+			if contentFile != "" && strings.Contains(filepath.Base(contentFile), osVersion) {
+				// Correct content file found — package version is outdated but content is valid
+				ssgUpgradeMessage = fmt.Sprintf("ssg-base %s is installed (outdated), but correct content file %s is available.",
+					contentVersion, filepath.Base(contentFile))
+			} else {
+				ssgNeedsUpgrade = true
+				ssgUpgradeMessage = fmt.Sprintf("ssg-base %s is installed, but %s %s requires v%s+ for proper CIS/STIG content.",
+					contentVersion, s.osInfo.Name, s.osInfo.Version, minVersion)
+			}
 		}
 	} else if minVersion != "" && contentVersion == "" {
-		ssgNeedsUpgrade = true
-		ssgUpgradeMessage = fmt.Sprintf("ssg-base is not installed. %s %s requires ssg-base v%s+ for CIS/STIG scanning.",
-			s.osInfo.Name, s.osInfo.Version, minVersion)
+		// Check if content file exists despite missing package (e.g., USG provides it)
+		osVersion := strings.ReplaceAll(s.osInfo.Version, ".", "")
+		if contentFile != "" && strings.Contains(filepath.Base(contentFile), osVersion) {
+			ssgUpgradeMessage = fmt.Sprintf("ssg-base is not installed, but correct content file %s is available.",
+				filepath.Base(contentFile))
+		} else {
+			ssgNeedsUpgrade = true
+			ssgUpgradeMessage = fmt.Sprintf("ssg-base is not installed. %s %s requires ssg-base v%s+ for CIS/STIG scanning.",
+				s.osInfo.Name, s.osInfo.Version, minVersion)
+		}
 	}
 
 	// Check for content mismatch
@@ -278,11 +294,7 @@ func (s *OpenSCAPScanner) GetScannerDetails() *models.ComplianceScannerDetails {
 		baseName := filepath.Base(contentFile)
 		if !strings.Contains(baseName, osVersion) {
 			contentMismatch = true
-			if ssgNeedsUpgrade {
-				mismatchWarning = ssgUpgradeMessage
-			} else {
-				mismatchWarning = fmt.Sprintf("Content file %s may not match OS version %s.", baseName, s.osInfo.Version)
-			}
+			mismatchWarning = fmt.Sprintf("Content file %s may not match OS version %s.", baseName, s.osInfo.Version)
 		}
 	} else if contentFile == "" && baseOSName == "ubuntu" && s.osInfo.Version >= "24.04" {
 		contentMismatch = true

--- a/agent-source-code/internal/integrations/compliance/openscap.go
+++ b/agent-source-code/internal/integrations/compliance/openscap.go
@@ -263,7 +263,7 @@ func (s *OpenSCAPScanner) GetScannerDetails() *models.ComplianceScannerDetails {
 			// Check if the correct content file exists despite old package version
 			// (e.g., installed via Ubuntu Security Guide or manual install)
 			osVersion := strings.ReplaceAll(s.osInfo.Version, ".", "")
-			if contentFile != "" && strings.Contains(filepath.Base(contentFile), osVersion) {
+			if contentFile != "" && osVersion != "" && strings.Contains(filepath.Base(contentFile), osVersion) {
 				// Correct content file found — package version is outdated but content is valid
 				ssgUpgradeMessage = fmt.Sprintf("ssg-base %s is installed (outdated), but correct content file %s is available.",
 					contentVersion, filepath.Base(contentFile))
@@ -276,7 +276,7 @@ func (s *OpenSCAPScanner) GetScannerDetails() *models.ComplianceScannerDetails {
 	} else if minVersion != "" && contentVersion == "" {
 		// Check if content file exists despite missing package (e.g., USG provides it)
 		osVersion := strings.ReplaceAll(s.osInfo.Version, ".", "")
-		if contentFile != "" && strings.Contains(filepath.Base(contentFile), osVersion) {
+		if contentFile != "" && osVersion != "" && strings.Contains(filepath.Base(contentFile), osVersion) {
 			ssgUpgradeMessage = fmt.Sprintf("ssg-base is not installed, but correct content file %s is available.",
 				filepath.Base(contentFile))
 		} else {


### PR DESCRIPTION
## Summary

Closes #620

When `ssg-base` package version is outdated but the correct SCAP content file exists (e.g., installed via Ubuntu Security Guide), the agent incorrectly shows a version upgrade warning and sets `ssgNeedsUpgrade=true`.

## Problem

On Ubuntu 24.04, `ssg-base` from the Ubuntu repos is v0.1.71 (requires v0.1.76+). Ubuntu Security Guide (USG) via `pro enable usg` installs the correct `ssg-ubuntu2404-ds.xml` content file, but the version check only looks at the apt package version and ignores the actual content files.

Additionally, when content mismatch occurred together with `ssgNeedsUpgrade`, the `mismatchWarning` reused the identical `ssgUpgradeMessage`, causing the **same warning to appear twice** in the dashboard.

## Changes

In `agent-source-code/internal/integrations/compliance/openscap.go`, function `GetScannerDetails()`:

1. **Before setting `ssgNeedsUpgrade=true`**, check if the correct content file for the OS version exists. If it does, downgrade to informational message and keep `ssgNeedsUpgrade=false`.

2. **Content mismatch warnings** now always use a distinct message (`"Content file X may not match OS version Y"`) instead of recycling `ssgUpgradeMessage`, preventing duplicate identical warnings.

## Test plan

**Scenario 1: Old ssg-base + correct content file (USG)**
```bash
# Ubuntu 24.04 with ssg-base 0.1.71 + USG ssg-ubuntu2404-ds.xml
dpkg-query -W ssg-base  # -> 0.1.71-1
ls /usr/share/xml/scap/ssg/content/ssg-ubuntu2404-ds.xml  # -> exists
```
- Before fix: Warning "ssg-base 0.1.71 requires v0.1.76+" shown, `ssgNeedsUpgrade=true`
- After fix: Informational "ssg-base 0.1.71 is installed (outdated), but correct content file ssg-ubuntu2404-ds.xml is available", `ssgNeedsUpgrade=false`

**Scenario 2: Old ssg-base + wrong content file (fallback to ubuntu1604)**
```bash
# Ubuntu 24.04 with ssg-base 0.1.71, no ssg-ubuntu2404-ds.xml
ls /usr/share/xml/scap/ssg/content/ssg-ubuntu2404-ds.xml  # -> not found
```
- Before fix: Same warning shown **twice** (once as ssgUpgradeMessage, once as mismatchWarning)
- After fix: Two **distinct** messages — version warning + content mismatch warning

**Scenario 3: Correct ssg-base version**
- No change in behavior (no warnings shown)