### PR TITLE
feat: add GeoIP location lookup for session IPs using MaxMind MMDB

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -35,6 +35,7 @@
 		"helmet": "^8.0.0",
 		"ioredis": "^5.9.3",
 		"jsonwebtoken": "^9.0.2",
+		"maxmind": "^5.0.5",
 		"openid-client": "^5.6.0",
 		"prisma": "^6.1.0",
 		"qrcode": "^1.5.4",

--- a/backend/src/routes/authRoutes.js
+++ b/backend/src/routes/authRoutes.js
@@ -1,4 +1,5 @@
 const express = require("express");
+const path = require("node:path");
 const logger = require("../utils/logger");
 const bcrypt = require("bcryptjs");
 const jwt = require("jsonwebtoken");
@@ -299,24 +300,110 @@ function parse_user_agent(user_agent) {
 }
 
 /**
- * Get basic location info from IP (simplified - in production you'd use a service)
+ * GeoIP location lookup using MaxMind MMDB database.
+ *
+ * Provide MMDB files via volume mount and set GEOIP_DB_PATH env var.
+ * The database is loaded lazily on first lookup and automatically reloaded
+ * when the file changes (e.g., updated by geoipupdate container).
+ *
+ * Supported databases (checked in order):
+ *   - GeoLite2-City.mmdb  (free, city + country)
+ *   - GeoIP2-City.mmdb    (commercial, city + country)
+ *   - GeoLite2-Country.mmdb (free, country only)
+ *
+ * If no database is found, falls back to { country: "Unknown", city: "Unknown" }.
  */
-function get_location_from_ip(ip) {
+const maxmind = require("maxmind");
+const fs = require("node:fs");
+
+let geoipReader = null;
+let geoipMtime = 0;
+let geoipType = null; // "city" or "country"
+const GEOIP_DB_PATH = process.env.GEOIP_DB_PATH || "";
+const GEOIP_DB_NAMES = [
+	{ file: "GeoLite2-City.mmdb", type: "city" },
+	{ file: "GeoIP2-City.mmdb", type: "city" },
+	{ file: "GeoLite2-Country.mmdb", type: "country" },
+];
+
+function findGeoIPDB() {
+	if (!GEOIP_DB_PATH) return null;
+	for (const db of GEOIP_DB_NAMES) {
+		const dbPath = path.join(GEOIP_DB_PATH, db.file);
+		if (fs.existsSync(dbPath)) {
+			return { path: dbPath, type: db.type };
+		}
+	}
+	return null;
+}
+
+async function loadGeoIPReader() {
+	const db = findGeoIPDB();
+	if (!db) return null;
+
+	try {
+		const stat = fs.statSync(db.path);
+		const mtime = stat.mtimeMs;
+
+		if (!geoipReader || mtime !== geoipMtime) {
+			geoipReader = await maxmind.open(db.path);
+			geoipMtime = mtime;
+			geoipType = db.type;
+			logger.info(
+				`GeoIP database loaded: ${path.basename(db.path)} (${new Date(mtime).toISOString()})`,
+			);
+		}
+		return geoipReader;
+	} catch (err) {
+		logger.warn(`GeoIP database error: ${err.message}`);
+		return null;
+	}
+}
+
+function isPrivateIP(ip) {
+	if (!ip) return false;
+	// IPv6 loopback
+	if (ip === "::1") return true;
+	// Strip IPv6 prefix for mapped IPv4
+	const cleanIP = ip.replace(/^::ffff:/, "");
+	return (
+		cleanIP === "127.0.0.1" ||
+		cleanIP.startsWith("10.") ||
+		cleanIP.startsWith("192.168.") ||
+		/^172\.(1[6-9]|2\d|3[01])\./.test(cleanIP) ||
+		/^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./.test(cleanIP) ||
+		cleanIP.startsWith("fd") // IPv6 ULA
+	);
+}
+
+async function get_location_from_ip(ip) {
 	if (!ip) return { country: "Unknown", city: "Unknown" };
 
-	// For localhost/private IPs
-	if (
-		ip === "127.0.0.1" ||
-		ip === "::1" ||
-		ip.startsWith("192.168.") ||
-		ip.startsWith("10.")
-	) {
+	// Private/local IPs
+	if (isPrivateIP(ip)) {
 		return { country: "Local", city: "Local Network" };
 	}
 
-	// In a real implementation, you'd use a service like MaxMind GeoIP2
-	// For now, return unknown for external IPs
-	return { country: "Unknown", city: "Unknown" };
+	// GeoIP lookup
+	const reader = await loadGeoIPReader();
+	if (!reader) return { country: "Unknown", city: "Unknown" };
+
+	try {
+		const result = reader.get(ip);
+		if (!result) return { country: "Unknown", city: "Unknown" };
+
+		const country =
+			result.country?.names?.en ||
+			result.registered_country?.names?.en ||
+			"Unknown";
+
+		const city =
+			geoipType === "city" ? result.city?.names?.en || "Unknown" : "Unknown";
+
+		return { country, city };
+	} catch {
+		return { country: "Unknown", city: "Unknown" };
+	}
 }
 
 // Check if any admin users exist (for first-time setup)
@@ -2208,18 +2295,20 @@ router.get("/sessions", authenticateToken, async (req, res) => {
 			orderBy: { last_activity: "desc" },
 		});
 
-		// Enhance sessions with device info
-		const enhanced_sessions = sessions.map((session) => {
-			const is_current_session = session.id === req.session_id;
-			const device_info = parse_user_agent(session.user_agent);
+		// Enhance sessions with device info and location
+		const enhanced_sessions = await Promise.all(
+			sessions.map(async (session) => {
+				const is_current_session = session.id === req.session_id;
+				const device_info = parse_user_agent(session.user_agent);
 
-			return {
-				...session,
-				is_current_session,
-				device_info,
-				location_info: get_location_from_ip(session.ip_address),
-			};
-		});
+				return {
+					...session,
+					is_current_session,
+					device_info,
+					location_info: await get_location_from_ip(session.ip_address),
+				};
+			}),
+		);
 
 		res.json({
 			sessions: enhanced_sessions,

--- a/backend/src/routes/authRoutes.js
+++ b/backend/src/routes/authRoutes.js
@@ -319,6 +319,9 @@ const fs = require("node:fs");
 let geoipReader = null;
 let geoipMtime = 0;
 let geoipType = null; // "city" or "country"
+let geoipLoadPromise = null; // Prevents parallel maxmind.open() calls
+let geoipLastCheck = 0; // Throttle mtime checks to once per 60s
+const GEOIP_CHECK_INTERVAL = 60000; // 60 seconds between mtime checks
 const GEOIP_DB_PATH = process.env.GEOIP_DB_PATH || "";
 const GEOIP_DB_NAMES = [
 	{ file: "GeoLite2-City.mmdb", type: "city" },
@@ -330,49 +333,69 @@ function findGeoIPDB() {
 	if (!GEOIP_DB_PATH) return null;
 	for (const db of GEOIP_DB_NAMES) {
 		const dbPath = path.join(GEOIP_DB_PATH, db.file);
-		if (fs.existsSync(dbPath)) {
+		try {
+			fs.accessSync(dbPath, fs.constants.R_OK);
 			return { path: dbPath, type: db.type };
+		} catch {
+			continue;
 		}
 	}
 	return null;
 }
 
 async function loadGeoIPReader() {
-	const db = findGeoIPDB();
-	if (!db) return null;
-
-	try {
-		const stat = fs.statSync(db.path);
-		const mtime = stat.mtimeMs;
-
-		if (!geoipReader || mtime !== geoipMtime) {
-			geoipReader = await maxmind.open(db.path);
-			geoipMtime = mtime;
-			geoipType = db.type;
-			logger.info(
-				`GeoIP database loaded: ${path.basename(db.path)} (${new Date(mtime).toISOString()})`,
-			);
-		}
+	// Return cached reader if mtime check interval not reached
+	const now = Date.now();
+	if (geoipReader && (now - geoipLastCheck) < GEOIP_CHECK_INTERVAL) {
 		return geoipReader;
-	} catch (err) {
-		logger.warn(`GeoIP database error: ${err.message}`);
-		return null;
 	}
+
+	// Prevent parallel loads (race condition)
+	if (geoipLoadPromise) return geoipLoadPromise;
+
+	geoipLoadPromise = (async () => {
+		const db = findGeoIPDB();
+		if (!db) return geoipReader; // Keep existing reader if DB disappeared
+
+		try {
+			const stat = await fs.promises.stat(db.path);
+			const mtime = stat.mtimeMs;
+			geoipLastCheck = now;
+
+			if (!geoipReader || mtime !== geoipMtime) {
+				geoipReader = await maxmind.open(db.path);
+				geoipMtime = mtime;
+				geoipType = db.type;
+				logger.info(
+					`GeoIP database loaded: ${path.basename(db.path)} (${new Date(mtime).toISOString()})`,
+				);
+			}
+			return geoipReader;
+		} catch (err) {
+			logger.warn(`GeoIP database error: ${err.message}`);
+			geoipLastCheck = now; // Don't retry immediately on error
+			return geoipReader; // Return existing reader if available
+		} finally {
+			geoipLoadPromise = null;
+		}
+	})();
+
+	return geoipLoadPromise;
 }
 
 function isPrivateIP(ip) {
 	if (!ip) return false;
 	// IPv6 loopback
 	if (ip === "::1") return true;
-	// Strip IPv6 prefix for mapped IPv4
-	const cleanIP = ip.replace(/^::ffff:/, "");
+	// Strip IPv6 prefix for mapped IPv4, normalize case for IPv6
+	const cleanIP = ip.replace(/^::ffff:/, "").toLowerCase();
 	return (
 		cleanIP === "127.0.0.1" ||
 		cleanIP.startsWith("10.") ||
 		cleanIP.startsWith("192.168.") ||
 		/^172\.(1[6-9]|2\d|3[01])\./.test(cleanIP) ||
 		/^100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./.test(cleanIP) ||
-		cleanIP.startsWith("fd") // IPv6 ULA
+		cleanIP.startsWith("fd") // IPv6 ULA (fc00::/7)
 	);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
 				"helmet": "^8.0.0",
 				"ioredis": "^5.9.3",
 				"jsonwebtoken": "^9.0.2",
+				"maxmind": "^5.0.5",
 				"openid-client": "^5.6.0",
 				"prisma": "^6.1.0",
 				"qrcode": "^1.5.4",
@@ -9130,6 +9131,20 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/maxmind": {
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/maxmind/-/maxmind-5.0.5.tgz",
+			"integrity": "sha512-1lcH2kMjbBpCFhuHaMU32vz8CuOsKttRcWMQyXvtlklopCzN7NNHSVR/h9RYa8JPuFTGmkn2vYARm+7cIGuqDw==",
+			"license": "MIT",
+			"dependencies": {
+				"mmdb-lib": "3.0.2",
+				"tiny-lru": "11.4.7"
+			},
+			"engines": {
+				"node": ">=12",
+				"npm": ">=6"
+			}
+		},
 		"node_modules/mdast-util-from-markdown": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
@@ -9865,6 +9880,16 @@
 			"license": "BlueOak-1.0.0",
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
+			}
+		},
+		"node_modules/mmdb-lib": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mmdb-lib/-/mmdb-lib-3.0.2.tgz",
+			"integrity": "sha512-7e87vk0DdWT647wjcfEtWeMtjm+zVGqNohN/aeIymbUfjHQ2T4Sx5kM+1irVDBSloNC3CkGKxswdMoo8yhqTDg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10",
+				"npm": ">=6"
 			}
 		},
 		"node_modules/mrmime": {
@@ -12504,6 +12529,15 @@
 			"resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
 			"integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
 			"license": "MIT"
+		},
+		"node_modules/tiny-lru": {
+			"version": "11.4.7",
+			"resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-11.4.7.tgz",
+			"integrity": "sha512-w/Te7uMUVeH0CR8vZIjr+XiN41V+30lkDdK+NRIDCUYKKuL9VcmaUEmaPISuwGhLlrTGh5yu18lENtR9axSxYw==",
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">=12"
+			}
 		},
 		"node_modules/tinybench": {
 			"version": "2.9.0",


### PR DESCRIPTION
## Summary

Closes #623

Replaces the stub `get_location_from_ip()` with a real GeoIP lookup using MaxMind MMDB databases. Users provide MMDB files via volume mount — no built-in download logic, no external API calls.

## Changes

**`backend/src/routes/authRoutes.js`:**
- Replaced stub function with MaxMind-based async GeoIP lookup
- Lazy DB loading with automatic hot-reload on file change (mtime check)
- Extended private IP detection: Docker networks, Tailscale CGNAT (`100.64.0.0/10`), IPv6 ULA (`fd::/8`)
- Session listing now uses `Promise.all()` for async location lookups

**`backend/package.json`:**
- Added `maxmind` dependency (pure JS MMDB reader, no native code)

## Configuration

```env
# Optional: path to directory containing MaxMind MMDB files
GEOIP_DB_PATH=/app/geoip
```

Searches for (in order): `GeoLite2-City.mmdb`, `GeoIP2-City.mmdb`, `GeoLite2-Country.mmdb`.
If not configured or no files found → graceful fallback to `"Unknown"`.

## Docker deployment

```yaml
services:
  backend:
    environment:
      GEOIP_DB_PATH: /app/geoip
    volumes:
      - geoip_data:/app/geoip:ro

  # Optional: auto-update sidecar
  geoipupdate:
    image: ghcr.io/maxmind/geoipupdate:latest
    environment:
      GEOIPUPDATE_ACCOUNT_ID: "123456"
      GEOIPUPDATE_LICENSE_KEY: "xxxxxx"
      GEOIPUPDATE_EDITION_IDS: "GeoLite2-City GeoLite2-Country"
      GEOIPUPDATE_FREQUENCY: "168"
    volumes:
      - geoip_data:/usr/share/GeoIP

volumes:
  geoip_data:
```

## Hot-reload behavior

| Scenario | Behavior |
|---|---|
| No `GEOIP_DB_PATH` set | "Unknown, Unknown" — no error |
| Empty directory | "Unknown, Unknown" |
| DB file present | Country + city resolved |
| DB updated by geoipupdate | Next lookup automatically loads new DB |
| DB deleted | Fallback to "Unknown" |
| Corrupt DB | Error caught, "Unknown" returned |

## Test plan

1. **Without config:** No `GEOIP_DB_PATH` → sessions show "Unknown, Unknown" (no crash)
2. **With GeoLite2-City.mmdb:** Login → session shows correct country + city
3. **Private IPs:** `10.x`, `192.168.x`, `100.64.x` → "Local, Local Network"
4. **IPv6:** Public IPv6 → resolved; `::1`, `fd::` → "Local, Local Network"
5. **Hot-reload:** Update MMDB file while running → next lookup uses new data
6. **Country-only DB:** Only `GeoLite2-Country.mmdb` → country resolved, city = "Unknown"