### PR TITLE
feat(helm): add initial PatchMon Helm chart and examples

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,302 @@
+# PatchMon Helm Chart
+
+Portable Helm chart for PatchMon across EKS, AKS, kubeadm, kind, and other conformant Kubernetes clusters.
+
+Chart path: `helm/patchmon`
+
+Example profiles:
+
+- `helm/examples/values-eks.yaml`
+- `helm/examples/values-external-db-redis.yaml`
+- `helm/examples/values-local.yaml`
+- `helm/examples/values-kind.yaml`
+- `helm/examples/values-persistent-nfs.yaml`
+
+## Security model (passwords/secrets)
+
+This chart is **secret-first**. Runtime credentials should come from a Kubernetes Secret, not from plain values files.
+
+Default mode in `values.yaml`:
+
+- `secret.create: false`
+- `secret.existingSecretName: patchmon-app-secrets`
+
+Required keys in the referenced secret:
+
+- `JWT_SECRET`
+- `SESSION_SECRET`
+- `AI_ENCRYPTION_KEY`
+- `POSTGRES_PASSWORD` (required when in-chart Postgres is enabled)
+- `REDIS_PASSWORD` (required when in-chart Redis is enabled)
+- `DATABASE_URL` (required only when using external Postgres with `database.enabled=false`)
+
+---
+
+## Manual install (EKS, internal DB + internal Redis)
+
+### Prerequisites
+
+- A working EKS cluster and `kubectl` context set to it
+- `helm` and `openssl` installed
+- A default storage class that can provision PVCs (for example `gp3`)
+
+### 1) Verify Kubernetes context
+
+```bash
+kubectl config current-context
+kubectl get nodes
+```
+
+### 2) Create namespace
+
+```bash
+kubectl create namespace patchmon --dry-run=client -o yaml | kubectl apply -f -
+```
+
+### 3) Set runtime ingress values (always pass these)
+
+```bash
+INGRESS_CLASS="alb"
+INGRESS_HOST="patchmon.example.com"
+```
+
+`CORS_ORIGIN` is auto-derived when `config.corsOrigin` is empty:
+
+- `http://<INGRESS_HOST>` when no ingress TLS is configured
+- `https://<INGRESS_HOST>` when ingress TLS is configured
+
+### 4) Create secret values
+
+This profile uses internal Postgres and Redis services (`database`, `redis`) and builds `DATABASE_URL` directly in the server deployment.
+
+```bash
+JWT_SECRET="$(openssl rand -hex 64)"
+SESSION_SECRET="$(openssl rand -hex 64)"
+AI_ENCRYPTION_KEY="$(openssl rand -hex 64)"
+POSTGRES_PASSWORD="$(openssl rand -hex 32)"
+REDIS_PASSWORD="$(openssl rand -hex 32)"
+```
+
+### 5) Create Kubernetes secret
+
+```bash
+kubectl -n patchmon create secret generic patchmon-app-secrets \
+  --from-literal=JWT_SECRET="$JWT_SECRET" \
+  --from-literal=SESSION_SECRET="$SESSION_SECRET" \
+  --from-literal=AI_ENCRYPTION_KEY="$AI_ENCRYPTION_KEY" \
+  --from-literal=POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
+  --from-literal=REDIS_PASSWORD="$REDIS_PASSWORD" \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+### 6) (Optional) Validate chart before install
+
+```bash
+helm lint ./helm/patchmon
+helm template patchmon ./helm/patchmon -f ./helm/examples/values-eks.yaml > /tmp/patchmon-rendered.yaml
+```
+
+### 7) Install chart
+
+```bash
+helm upgrade --install patchmon ./helm/patchmon \
+  --namespace patchmon \
+  --create-namespace \
+  --wait --timeout 20m \
+  -f ./helm/examples/values-eks.yaml \
+  --set-string ingress.className="${INGRESS_CLASS}" \
+  --set-string ingress.hosts[0].host="${INGRESS_HOST}"
+```
+
+### 8) Verify
+
+```bash
+kubectl -n patchmon get pods
+kubectl -n patchmon get svc
+kubectl -n patchmon get pvc
+kubectl -n patchmon get ingress
+kubectl -n patchmon get ingress patchmon-ingress -o jsonpath='{.spec.ingressClassName}{"\n"}'
+kubectl -n patchmon get ingress patchmon-ingress -o jsonpath='{.spec.rules[0].host}{"\n"}'
+kubectl -n patchmon get configmap patchmon-config -o jsonpath='{.data.CORS_ORIGIN}{"\n"}'
+helm status patchmon -n patchmon
+```
+
+### 9) Get ingress hostname (ALB)
+
+```bash
+kubectl -n patchmon get ingress patchmon-ingress -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'; echo
+```
+
+---
+
+## Troubleshooting (EKS)
+
+If install is stuck on `--wait`, run:
+
+```bash
+kubectl -n patchmon get pods
+kubectl -n patchmon logs deploy/patchmon-database --tail=200
+kubectl -n patchmon logs deploy/patchmon-guacd --tail=200
+kubectl -n patchmon get events --sort-by=.lastTimestamp | tail -n 40
+```
+
+Known notes:
+
+- Postgres `lost+found` error is handled by setting `PGDATA=/var/lib/postgresql/data/pgdata` in this chart.
+- EKS example uses HTTP ALB by default. If you enable HTTPS, add an ACM certificate annotation in ingress values.
+- If guacd fails with `exec format error` on ARM/Graviton nodes, use `guacd.image.tag: "1.6.0"` (already set in `helm/examples/values-eks.yaml`).
+
+---
+
+## Universal install pattern (any cluster)
+
+Always pass your ingress class + hostname at install/upgrade time:
+
+```bash
+INGRESS_CLASS="nginx"                # e.g. nginx, alb, traefik
+INGRESS_HOST="patchmon.example.com"  # your DNS host
+
+helm upgrade --install patchmon ./helm/patchmon \
+  -n patchmon --create-namespace \
+  --wait --timeout 20m \
+  --set ingress.enabled=true \
+  --set-string ingress.className="${INGRESS_CLASS}" \
+  --set-string ingress.hosts[0].host="${INGRESS_HOST}" \
+  --set-string ingress.hosts[0].paths[0].path="/" \
+  --set-string ingress.hosts[0].paths[0].pathType="Prefix"
+```
+
+Optional explicit override:
+
+```bash
+--set-string config.corsOrigin="https://${INGRESS_HOST}"
+```
+
+---
+
+## Deployment option: external DB + external Redis (any cluster)
+
+1) Prepare secret with external `DATABASE_URL` and other keys.
+2) Deploy:
+
+```bash
+kubectl -n patchmon create secret generic patchmon-app-secrets \
+  --from-literal=JWT_SECRET="$JWT_SECRET" \
+  --from-literal=SESSION_SECRET="$SESSION_SECRET" \
+  --from-literal=AI_ENCRYPTION_KEY="$AI_ENCRYPTION_KEY" \
+  --from-literal=DATABASE_URL='postgresql://patchmon_user:REPLACE_DB_PASSWORD@my-postgres.example.internal:5432/patchmon_db' \
+  --from-literal=REDIS_PASSWORD="$REDIS_PASSWORD" \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+```bash
+helm upgrade --install patchmon ./helm/patchmon \
+  -n patchmon --create-namespace \
+  --wait --timeout 20m \
+  -f ./helm/examples/values-external-db-redis.yaml
+```
+
+---
+
+## Deployment option: kubeadm/local ingress with internal DB/Redis (ephemeral)
+
+1) Create secret:
+
+```bash
+JWT_SECRET="$(openssl rand -hex 64)"
+SESSION_SECRET="$(openssl rand -hex 64)"
+AI_ENCRYPTION_KEY="$(openssl rand -hex 64)"
+POSTGRES_PASSWORD="$(openssl rand -hex 32)"
+REDIS_PASSWORD="$(openssl rand -hex 32)"
+
+kubectl -n patchmon create secret generic patchmon-app-secrets \
+  --from-literal=JWT_SECRET="$JWT_SECRET" \
+  --from-literal=SESSION_SECRET="$SESSION_SECRET" \
+  --from-literal=AI_ENCRYPTION_KEY="$AI_ENCRYPTION_KEY" \
+  --from-literal=POSTGRES_PASSWORD="$POSTGRES_PASSWORD" \
+  --from-literal=REDIS_PASSWORD="$REDIS_PASSWORD" \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+2) Deploy:
+
+```bash
+helm upgrade --install patchmon ./helm/patchmon \
+  -n patchmon --create-namespace \
+  --wait --timeout 20m \
+  -f ./helm/examples/values-local.yaml
+```
+
+---
+
+## Deployment option: kind
+
+```bash
+helm upgrade --install patchmon ./helm/patchmon \
+  -n patchmon --create-namespace \
+  --wait --timeout 20m \
+  -f ./helm/examples/values-kind.yaml
+```
+
+---
+
+## Deployment option: persistent NFS (internal DB/Redis)
+
+```bash
+helm upgrade --install patchmon ./helm/patchmon \
+  -n patchmon --create-namespace \
+  --wait --timeout 20m \
+  -f ./helm/examples/values-persistent-nfs.yaml
+```
+
+---
+
+## Validation and quality checks
+
+```bash
+helm lint ./helm/patchmon
+helm template patchmon ./helm/patchmon -f ./helm/examples/values-eks.yaml
+helm template patchmon ./helm/patchmon -f ./helm/examples/values-local.yaml
+```
+
+---
+
+## Day-2 operations
+
+```bash
+helm status patchmon -n patchmon
+helm history patchmon -n patchmon
+kubectl -n patchmon get pods,svc,ingress,pvc
+kubectl -n patchmon logs deploy/patchmon-server --tail=200 -f
+```
+
+Rollback:
+
+```bash
+helm rollback patchmon <REVISION> -n patchmon
+```
+
+Uninstall:
+
+```bash
+helm uninstall patchmon -n patchmon
+```
+
+If persistence is enabled and you want a full reset:
+
+```bash
+kubectl -n patchmon delete pvc --all
+```
+
+---
+
+## Update management (safe release flow)
+
+1. Pin image tags in `helm/patchmon/values.yaml` (avoid mutable tags).
+2. Bump `helm/patchmon/Chart.yaml`:
+   - `version` for chart changes
+   - `appVersion` for PatchMon app version
+3. Run `helm lint` and `helm template` on all target profiles.
+4. Upgrade with `--wait --timeout`.
+5. Verify health, then promote to next environment.
+6. Keep rollback revision handy (`helm history`).

--- a/helm/examples/values-eks.yaml
+++ b/helm/examples/values-eks.yaml
@@ -1,0 +1,94 @@
+fullnameOverride: patchmon
+
+secret:
+  create: false
+  existingSecretName: patchmon-app-secrets
+
+config:
+  # Auto-derived from ingress host because this is left empty.
+  corsOrigin: ""
+  extraEnv:
+    - name: TRUST_PROXY
+      value: "true"
+    - name: ENABLE_HSTS
+      value: "true"
+    - name: APP_ENV
+      value: "production"
+
+server:
+  replicaCount: 2
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 1Gi
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    runAsGroup: 1000
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+database:
+  enabled: true
+  persistence:
+    enabled: true
+    storageClass: gp3
+    size: 20Gi
+  resources:
+    requests:
+      cpu: 200m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 2Gi
+
+redis:
+  enabled: true
+  persistence:
+    enabled: true
+    storageClass: gp3
+    size: 8Gi
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      cpu: 500m
+      memory: 1Gi
+
+guacd:
+  enabled: true
+  image:
+    repository: guacamole/guacd
+    # 1.6.0 includes arm64 support; avoids exec format errors on Graviton nodes.
+    tag: "1.6.0"
+  # Keep defaults for this image on EKS to avoid container startup conflicts.
+  securityContext: {}
+  resources:
+    requests:
+      cpu: 50m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+
+ingress:
+  enabled: true
+  className: alb
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80}]'
+    alb.ingress.kubernetes.io/healthcheck-path: /health
+    alb.ingress.kubernetes.io/success-codes: "200"
+  hosts:
+    - host: patchmon.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []

--- a/helm/examples/values-external-db-redis.yaml
+++ b/helm/examples/values-external-db-redis.yaml
@@ -1,0 +1,33 @@
+fullnameOverride: patchmon
+
+config:
+  corsOrigin: "https://patchmon.example.com"
+  postgresHost: "my-postgres.example.internal"
+  redisHost: "my-redis.example.internal"
+  redisPort: "6379"
+  guacdAddress: "guacd:4822"
+
+secret:
+  # Use an existing secret to avoid storing databaseUrl credentials in values files.
+  create: false
+  existingSecretName: patchmon-app-secrets
+
+database:
+  enabled: false
+
+redis:
+  enabled: false
+
+server:
+  waitFor:
+    database: false
+    redis: false
+
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: patchmon.example.com
+      paths:
+        - path: /
+          pathType: Prefix

--- a/helm/examples/values-kind.yaml
+++ b/helm/examples/values-kind.yaml
@@ -1,0 +1,21 @@
+fullnameOverride: patchmon
+
+config:
+  corsOrigin: "http://localhost:3000,http://127.0.0.1:3000"
+
+secret:
+  create: false
+  existingSecretName: patchmon-app-secrets
+
+database:
+  enabled: true
+  persistence:
+    enabled: false
+
+redis:
+  enabled: true
+  persistence:
+    enabled: false
+
+ingress:
+  enabled: false

--- a/helm/examples/values-local.yaml
+++ b/helm/examples/values-local.yaml
@@ -1,0 +1,32 @@
+fullnameOverride: patchmon
+
+config:
+  corsOrigin: "http://patchmon.example.com,https://patchmon.example.com"
+
+secret:
+  create: false
+  existingSecretName: patchmon-app-secrets
+
+server:
+  image:
+    repository: ghcr.io/patchmon/patchmon-server
+    tag: "2.0.1"
+
+database:
+  enabled: true
+  persistence:
+    enabled: false
+
+redis:
+  enabled: true
+  persistence:
+    enabled: false
+
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: patchmon.example.com
+      paths:
+        - path: /
+          pathType: Prefix

--- a/helm/examples/values-persistent-nfs.yaml
+++ b/helm/examples/values-persistent-nfs.yaml
@@ -1,0 +1,34 @@
+fullnameOverride: patchmon
+
+config:
+  corsOrigin: "https://patchmon.example.com,http://patchmon.example.com"
+
+secret:
+  create: false
+  existingSecretName: patchmon-app-secrets
+
+database:
+  enabled: true
+  persistence:
+    enabled: true
+    storageClass: nfs-csi
+    size: 10Gi
+  # Enable this only if your NFS export permissions allow it.
+  # podSecurityContext:
+  #   fsGroup: 999
+
+redis:
+  enabled: true
+  persistence:
+    enabled: true
+    storageClass: nfs-csi
+    size: 5Gi
+
+ingress:
+  enabled: true
+  className: nginx
+  hosts:
+    - host: patchmon.example.com
+      paths:
+        - path: /
+          pathType: Prefix

--- a/helm/patchmon/.helmignore
+++ b/helm/patchmon/.helmignore
@@ -1,0 +1,7 @@
+.DS_Store
+.git/
+.idea/
+.vscode/
+*.swp
+*.tmp
+*.bak

--- a/helm/patchmon/Chart.yaml
+++ b/helm/patchmon/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: patchmon
+description: Custom PatchMon Helm chart derived from the working Docker Compose stack.
+type: application
+version: 0.2.0
+appVersion: "2.0.1"
+icon: https://raw.githubusercontent.com/PatchMon/PatchMon/main/dashboard.png

--- a/helm/patchmon/templates/NOTES.txt
+++ b/helm/patchmon/templates/NOTES.txt
@@ -1,0 +1,19 @@
+PatchMon has been deployed.
+
+Release: {{ .Release.Name }}
+Namespace: {{ .Release.Namespace }}
+
+Useful commands:
+  kubectl get pods -n {{ .Release.Namespace }}
+  kubectl logs -n {{ .Release.Namespace }} deploy/{{ include "patchmon.fullname" . }}-server --tail=100 -f
+  helm get values {{ .Release.Name }} -n {{ .Release.Namespace }}
+
+{{- if .Values.ingress.enabled }}
+Access URLs:
+{{- range .Values.ingress.hosts }}
+  http://{{ .host }}
+{{- end }}
+{{- else }}
+Ingress is disabled. Port-forward to access:
+  kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "patchmon.fullname" . }}-server 3000:{{ .Values.server.service.port }}
+{{- end }}

--- a/helm/patchmon/templates/_helpers.tpl
+++ b/helm/patchmon/templates/_helpers.tpl
@@ -1,0 +1,66 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "patchmon.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "patchmon.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "patchmon.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/name: {{ include "patchmon.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "patchmon.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "patchmon.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "patchmon.secretName" -}}
+{{- if .Values.secret.create -}}
+{{- printf "%s-secrets" (include "patchmon.fullname" .) -}}
+{{- else -}}
+{{- required "secret.existingSecretName is required when secret.create=false" .Values.secret.existingSecretName -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "patchmon.databaseServiceName" -}}
+{{- default "database" .Values.database.service.name -}}
+{{- end -}}
+
+{{- define "patchmon.redisServiceName" -}}
+{{- default "redis" .Values.redis.service.name -}}
+{{- end -}}
+
+{{- define "patchmon.guacdServiceName" -}}
+{{- default "guacd" .Values.guacd.service.name -}}
+{{- end -}}
+
+{{- define "patchmon.databasePvcName" -}}
+{{- printf "%s-postgres-data" (include "patchmon.fullname" .) -}}
+{{- end -}}
+
+{{- define "patchmon.redisPvcName" -}}
+{{- printf "%s-redis-data" (include "patchmon.fullname" .) -}}
+{{- end -}}

--- a/helm/patchmon/templates/configmap.yaml
+++ b/helm/patchmon/templates/configmap.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "patchmon.fullname" . }}-config
+  labels:
+    {{- include "patchmon.labels" . | nindent 4 }}
+data:
+  {{- $corsOrigin := .Values.config.corsOrigin }}
+  {{- if and (eq $corsOrigin "") .Values.ingress.enabled (gt (len .Values.ingress.hosts) 0) (ne (index .Values.ingress.hosts 0).host "") }}
+  {{- $scheme := ternary "https" "http" (gt (len .Values.ingress.tls) 0) }}
+  {{- $corsOrigin = printf "%s://%s" $scheme (index .Values.ingress.hosts 0).host }}
+  {{- end }}
+  {{- if eq $corsOrigin "" }}
+  {{- $corsOrigin = "http://localhost:3000" }}
+  {{- end }}
+  {{- $postgresHost := .Values.config.postgresHost }}
+  {{- if and (eq $postgresHost "") .Values.database.enabled }}
+  {{- $postgresHost = include "patchmon.databaseServiceName" . }}
+  {{- end }}
+  {{- $redisHost := .Values.config.redisHost }}
+  {{- if and (eq $redisHost "") .Values.redis.enabled }}
+  {{- $redisHost = include "patchmon.redisServiceName" . }}
+  {{- end }}
+  {{- $guacdAddress := .Values.config.guacdAddress }}
+  {{- if and (eq $guacdAddress "") .Values.guacd.enabled }}
+  {{- $guacdAddress = printf "%s:%v" (include "patchmon.guacdServiceName" .) .Values.guacd.service.port }}
+  {{- end }}
+  CORS_ORIGIN: {{ $corsOrigin | quote }}
+  POSTGRES_HOST: {{ $postgresHost | quote }}
+  POSTGRES_PORT: {{ .Values.config.postgresPort | quote }}
+  POSTGRES_USER: {{ .Values.config.postgresUser | quote }}
+  POSTGRES_DB: {{ .Values.config.postgresDb | quote }}
+  REDIS_HOST: {{ $redisHost | quote }}
+  REDIS_PORT: {{ .Values.config.redisPort | quote }}
+  REDIS_DB: {{ .Values.config.redisDb | quote }}
+  GUACD_ADDRESS: {{ $guacdAddress | quote }}
+  {{- range .Values.config.extraEnv }}
+  {{ .name }}: {{ .value | quote }}
+  {{- end }}

--- a/helm/patchmon/templates/database-deployment.yaml
+++ b/helm/patchmon/templates/database-deployment.yaml
@@ -1,0 +1,113 @@
+{{- if .Values.database.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "patchmon.fullname" . }}-database
+  labels:
+    {{- include "patchmon.labels" . | nindent 4 }}
+    app.kubernetes.io/component: database
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "patchmon.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: database
+  template:
+    metadata:
+      {{- with .Values.database.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "patchmon.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: database
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.database.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: database
+          image: "{{ .Values.database.image.repository }}:{{ .Values.database.image.tag }}"
+          imagePullPolicy: {{ .Values.database.image.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "patchmon.fullname" . }}-config
+            - secretRef:
+                name: {{ include "patchmon.secretName" . }}
+          env:
+            # Avoid initdb failure on some CSI volumes that contain lost+found at mount root.
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          ports:
+            - name: postgres
+              containerPort: {{ .Values.database.service.port }}
+              protocol: TCP
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 30
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 7
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 7
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+          {{- with .Values.database.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.database.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: postgres-data
+          {{- if .Values.database.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ default (include "patchmon.databasePvcName" .) .Values.database.persistence.existingClaim }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+      {{- with .Values.database.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.database.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.database.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/helm/patchmon/templates/database-pvc.yaml
+++ b/helm/patchmon/templates/database-pvc.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.database.enabled .Values.database.persistence.enabled (eq .Values.database.persistence.existingClaim "") }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "patchmon.databasePvcName" . }}
+  labels:
+    {{- include "patchmon.labels" . | nindent 4 }}
+    app.kubernetes.io/component: database
+spec:
+  accessModes:
+    {{- toYaml .Values.database.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.database.persistence.size }}
+  {{- if ne .Values.database.persistence.storageClass "" }}
+  storageClassName: {{ .Values.database.persistence.storageClass | quote }}
+  {{- end }}
+{{- end }}

--- a/helm/patchmon/templates/database-service.yaml
+++ b/helm/patchmon/templates/database-service.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.database.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "patchmon.databaseServiceName" . }}
+  labels:
+    {{- include "patchmon.labels" . | nindent 4 }}
+    app.kubernetes.io/component: database
+  {{- with .Values.database.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.database.service.type }}
+  ports:
+    - name: postgres
+      port: {{ .Values.database.service.port }}
+      targetPort: {{ .Values.database.service.port }}
+      protocol: TCP
+  selector:
+    {{- include "patchmon.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: database
+{{- end }}

--- a/helm/patchmon/templates/guacd-deployment.yaml
+++ b/helm/patchmon/templates/guacd-deployment.yaml
@@ -1,0 +1,82 @@
+{{- if .Values.guacd.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "patchmon.fullname" . }}-guacd
+  labels:
+    {{- include "patchmon.labels" . | nindent 4 }}
+    app.kubernetes.io/component: guacd
+spec:
+  replicas: {{ .Values.guacd.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "patchmon.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: guacd
+  template:
+    metadata:
+      {{- with .Values.guacd.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "patchmon.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: guacd
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.guacd.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: guacd
+          image: "{{ .Values.guacd.image.repository }}:{{ .Values.guacd.image.tag }}"
+          imagePullPolicy: {{ .Values.guacd.image.pullPolicy }}
+          ports:
+            - name: guacd
+              containerPort: {{ .Values.guacd.service.port }}
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.guacd.service.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.guacd.service.port }}
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 3
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+          {{- with .Values.guacd.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.guacd.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: tmp
+          emptyDir:
+            medium: Memory
+      {{- with .Values.guacd.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.guacd.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.guacd.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/helm/patchmon/templates/guacd-service.yaml
+++ b/helm/patchmon/templates/guacd-service.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.guacd.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "patchmon.guacdServiceName" . }}
+  labels:
+    {{- include "patchmon.labels" . | nindent 4 }}
+    app.kubernetes.io/component: guacd
+  {{- with .Values.guacd.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.guacd.service.type }}
+  ports:
+    - name: guacd
+      port: {{ .Values.guacd.service.port }}
+      targetPort: {{ .Values.guacd.service.port }}
+      protocol: TCP
+  selector:
+    {{- include "patchmon.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: guacd
+{{- end }}

--- a/helm/patchmon/templates/ingress.yaml
+++ b/helm/patchmon/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "patchmon.fullname" . }}-ingress
+  labels:
+    {{- include "patchmon.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "patchmon.fullname" $ }}-server
+                port:
+                  number: {{ $.Values.server.service.port }}
+          {{- end }}
+    {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName | quote }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/helm/patchmon/templates/ingress.yaml
+++ b/helm/patchmon/templates/ingress.yaml
@@ -5,10 +5,15 @@ metadata:
   name: {{ include "patchmon.fullname" . }}-ingress
   labels:
     {{- include "patchmon.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
   annotations:
+    alb.ingress.kubernetes.io/load-balancer-attributes: idle_timeout.timeout_seconds=3600
+    alb.ingress.kubernetes.io/healthcheck-path: /health
+    alb.ingress.kubernetes.io/success-codes: "200"
+    alb.ingress.kubernetes.io/target-group-attributes: stickiness.enabled=true,stickiness.lb_cookie.duration_seconds=86400
+    alb.ingress.kubernetes.io/healthcheck-host: {{ .Values.ingress.healthcheckHost | quote }}
+    {{- with .Values.ingress.annotations }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
 spec:
   {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}

--- a/helm/patchmon/templates/redis-deployment.yaml
+++ b/helm/patchmon/templates/redis-deployment.yaml
@@ -1,0 +1,104 @@
+{{- if .Values.redis.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "patchmon.fullname" . }}-redis
+  labels:
+    {{- include "patchmon.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "patchmon.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: redis
+  template:
+    metadata:
+      {{- with .Values.redis.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "patchmon.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: redis
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.redis.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: redis
+          image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+          imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - redis-server --requirepass "$REDIS_PASSWORD"
+          envFrom:
+            - configMapRef:
+                name: {{ include "patchmon.fullname" . }}-config
+            - secretRef:
+                name: {{ include "patchmon.secretName" . }}
+          ports:
+            - name: redis
+              containerPort: {{ .Values.redis.service.port }}
+              protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - redis-cli --no-auth-warning -a "$REDIS_PASSWORD" ping
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 7
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - redis-cli --no-auth-warning -a "$REDIS_PASSWORD" ping
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            timeoutSeconds: 5
+            failureThreshold: 7
+          volumeMounts:
+            - name: redis-data
+              mountPath: /data
+          {{- with .Values.redis.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.redis.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: redis-data
+          {{- if .Values.redis.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ default (include "patchmon.redisPvcName" .) .Values.redis.persistence.existingClaim }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+      {{- with .Values.redis.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.redis.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.redis.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/helm/patchmon/templates/redis-pvc.yaml
+++ b/helm/patchmon/templates/redis-pvc.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.redis.enabled .Values.redis.persistence.enabled (eq .Values.redis.persistence.existingClaim "") }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "patchmon.redisPvcName" . }}
+  labels:
+    {{- include "patchmon.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  accessModes:
+    {{- toYaml .Values.redis.persistence.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.redis.persistence.size }}
+  {{- if ne .Values.redis.persistence.storageClass "" }}
+  storageClassName: {{ .Values.redis.persistence.storageClass | quote }}
+  {{- end }}
+{{- end }}

--- a/helm/patchmon/templates/redis-service.yaml
+++ b/helm/patchmon/templates/redis-service.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.redis.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "patchmon.redisServiceName" . }}
+  labels:
+    {{- include "patchmon.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+  {{- with .Values.redis.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.redis.service.type }}
+  ports:
+    - name: redis
+      port: {{ .Values.redis.service.port }}
+      targetPort: {{ .Values.redis.service.port }}
+      protocol: TCP
+  selector:
+    {{- include "patchmon.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+{{- end }}

--- a/helm/patchmon/templates/secret.yaml
+++ b/helm/patchmon/templates/secret.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.secret.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "patchmon.secretName" . }}
+  labels:
+    {{- include "patchmon.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  JWT_SECRET: {{ required "secret.values.jwtSecret is required" .Values.secret.values.jwtSecret | quote }}
+  SESSION_SECRET: {{ required "secret.values.sessionSecret is required" .Values.secret.values.sessionSecret | quote }}
+  AI_ENCRYPTION_KEY: {{ required "secret.values.aiEncryptionKey is required" .Values.secret.values.aiEncryptionKey | quote }}
+  {{- if .Values.database.enabled }}
+  POSTGRES_PASSWORD: {{ required "secret.values.postgresPassword is required when database.enabled=true" .Values.secret.values.postgresPassword | quote }}
+  {{- end }}
+  {{- if .Values.redis.enabled }}
+  REDIS_PASSWORD: {{ required "secret.values.redisPassword is required when redis.enabled=true" .Values.secret.values.redisPassword | quote }}
+  {{- end }}
+  {{- if not .Values.database.enabled }}
+  DATABASE_URL: {{ required "secret.values.databaseUrl is required when database.enabled=false" .Values.secret.values.databaseUrl | quote }}
+  {{- end }}
+{{- end }}

--- a/helm/patchmon/templates/server-deployment.yaml
+++ b/helm/patchmon/templates/server-deployment.yaml
@@ -1,0 +1,153 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "patchmon.fullname" . }}-server
+  labels:
+    {{- include "patchmon.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+spec:
+  replicas: {{ .Values.server.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "patchmon.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: server
+  template:
+    metadata:
+      {{- with .Values.server.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "patchmon.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: server
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      initContainers:
+        {{- if and .Values.server.waitFor.database (or .Values.database.enabled (ne .Values.config.postgresHost "")) }}
+        - name: wait-for-database
+          image: {{ .Values.server.initContainers.waitImage | quote }}
+          imagePullPolicy: {{ .Values.server.initContainers.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "patchmon.fullname" . }}-config
+          command:
+            - /bin/sh
+            - -c
+            - >-
+              until nc -z "$POSTGRES_HOST" "$POSTGRES_PORT";
+              do echo "waiting for database"; sleep 2; done
+        {{- end }}
+        {{- if and .Values.server.waitFor.redis (or .Values.redis.enabled (ne .Values.config.redisHost "")) }}
+        - name: wait-for-redis
+          image: {{ .Values.server.initContainers.waitImage | quote }}
+          imagePullPolicy: {{ .Values.server.initContainers.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "patchmon.fullname" . }}-config
+          command:
+            - /bin/sh
+            - -c
+            - >-
+              until nc -z "$REDIS_HOST" "$REDIS_PORT";
+              do echo "waiting for redis"; sleep 2; done
+        {{- end }}
+        {{- if and .Values.server.waitFor.guacd (or .Values.guacd.enabled (ne .Values.config.guacdAddress "")) }}
+        - name: wait-for-guacd
+          image: {{ .Values.server.initContainers.waitImage | quote }}
+          imagePullPolicy: {{ .Values.server.initContainers.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "patchmon.fullname" . }}-config
+          command:
+            - /bin/sh
+            - -c
+            - >-
+              host="$(echo "$GUACD_ADDRESS" | cut -d: -f1)";
+              port="$(echo "$GUACD_ADDRESS" | cut -d: -f2)";
+              until nc -z "$host" "$port";
+              do echo "waiting for guacd"; sleep 2; done
+        {{- end }}
+      containers:
+        - name: server
+          image: "{{ .Values.server.image.repository }}:{{ .Values.server.image.tag }}"
+          imagePullPolicy: {{ .Values.server.image.pullPolicy }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "patchmon.fullname" . }}-config
+            - secretRef:
+                name: {{ include "patchmon.secretName" . }}
+          {{- if .Values.database.enabled }}
+          env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "patchmon.secretName" . }}
+                  key: POSTGRES_PASSWORD
+            - name: DATABASE_URL
+              value: "postgresql://patchmon_user:$(POSTGRES_PASSWORD)@database:5432/patchmon_db"
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.server.service.targetPort }}
+              protocol: TCP
+          {{- if .Values.server.probes.startup.enabled }}
+          startupProbe:
+            httpGet:
+              path: {{ .Values.server.probes.startup.path }}
+              port: {{ .Values.server.service.targetPort }}
+              httpHeaders:
+                - name: Host
+                  value: localhost
+            periodSeconds: {{ .Values.server.probes.startup.periodSeconds }}
+            timeoutSeconds: {{ .Values.server.probes.startup.timeoutSeconds }}
+            failureThreshold: {{ .Values.server.probes.startup.failureThreshold }}
+          {{- end }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.server.probes.liveness.path }}
+              port: {{ .Values.server.service.targetPort }}
+              httpHeaders:
+                - name: Host
+                  value: localhost
+            initialDelaySeconds: {{ .Values.server.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.server.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.server.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.server.probes.liveness.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.server.probes.readiness.path }}
+              port: {{ .Values.server.service.targetPort }}
+              httpHeaders:
+                - name: Host
+                  value: localhost
+            initialDelaySeconds: {{ .Values.server.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.server.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.server.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.server.probes.readiness.failureThreshold }}
+          {{- with .Values.server.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.server.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.server.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.server.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/patchmon/templates/server-service.yaml
+++ b/helm/patchmon/templates/server-service.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "patchmon.fullname" . }}-server
+  labels:
+    {{- include "patchmon.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+  {{- with .Values.server.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.server.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.server.service.port }}
+      targetPort: {{ .Values.server.service.targetPort }}
+      protocol: TCP
+  selector:
+    {{- include "patchmon.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: server

--- a/helm/patchmon/values.schema.json
+++ b/helm/patchmon/values.schema.json
@@ -1,0 +1,135 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "PatchMon Helm values",
+  "type": "object",
+  "properties": {
+    "secret": {
+      "type": "object",
+      "properties": {
+        "create": { "type": "boolean" },
+        "existingSecretName": { "type": "string" },
+        "values": {
+          "type": "object",
+          "properties": {
+            "jwtSecret": { "type": "string" },
+            "sessionSecret": { "type": "string" },
+            "aiEncryptionKey": { "type": "string" },
+            "postgresPassword": { "type": "string" },
+            "redisPassword": { "type": "string" },
+            "databaseUrl": { "type": "string" }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "config": {
+      "type": "object",
+      "properties": {
+        "corsOrigin": { "type": "string" },
+        "postgresHost": { "type": "string" },
+        "postgresPort": { "type": "string" },
+        "postgresUser": { "type": "string" },
+        "postgresDb": { "type": "string" },
+        "redisHost": { "type": "string" },
+        "redisPort": { "type": "string" },
+        "redisDb": { "type": "string" },
+        "guacdAddress": { "type": "string" },
+        "extraEnv": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "value": { "type": "string" }
+            },
+            "required": ["name", "value"],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "database": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "persistence": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "existingClaim": { "type": "string" },
+            "storageClass": { "type": "string" },
+            "size": { "type": "string" }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    },
+    "redis": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "persistence": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "existingClaim": { "type": "string" },
+            "storageClass": { "type": "string" },
+            "size": { "type": "string" }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    },
+    "ingress": {
+      "type": "object",
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "className": { "type": "string" },
+        "hosts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "host": { "type": "string" },
+              "paths": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "path": { "type": "string" },
+                    "pathType": { "type": "string" }
+                  },
+                  "required": ["path", "pathType"],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": ["host", "paths"],
+            "additionalProperties": false
+          }
+        },
+        "tls": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "hosts": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "secretName": { "type": "string" }
+            },
+            "required": ["hosts", "secretName"],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/helm/patchmon/values.yaml
+++ b/helm/patchmon/values.yaml
@@ -1,0 +1,174 @@
+nameOverride: ""
+fullnameOverride: "patchmon"
+
+imagePullSecrets: []
+
+secret:
+  create: false
+  # When create=false, this secret must include required PatchMon keys.
+  existingSecretName: "patchmon-app-secrets"
+  values:
+    jwtSecret: ""
+    sessionSecret: ""
+    aiEncryptionKey: ""
+    postgresPassword: ""
+    redisPassword: ""
+    # Optional for create=true when using external DB URL directly.
+    databaseUrl: ""
+
+config:
+  # Leave empty to auto-derive from ingress host:
+  # - https://<host> when ingress.tls is configured
+  # - http://<host> otherwise
+  # Falls back to http://localhost:3000 when ingress is disabled.
+  corsOrigin: ""
+  # Internal service name for in-chart Postgres.
+  postgresHost: "database"
+  postgresPort: "5432"
+  postgresUser: "patchmon_user"
+  postgresDb: "patchmon_db"
+  # Internal service name for in-chart Redis.
+  redisHost: "redis"
+  redisPort: "6379"
+  redisDb: "0"
+  # Internal service endpoint for in-chart guacd.
+  guacdAddress: "guacd:4822"
+  extraEnv: []
+  # extraEnv example:
+  # - name: TRUST_PROXY
+  #   value: "true"
+
+server:
+  replicaCount: 1
+  image:
+    repository: ghcr.io/patchmon/patchmon-server
+    tag: "2.0.1"
+    pullPolicy: IfNotPresent
+  service:
+    type: ClusterIP
+    port: 3000
+    targetPort: 3000
+    annotations: {}
+  initContainers:
+    waitImage: "busybox:latest"
+    pullPolicy: IfNotPresent
+  waitFor:
+    database: true
+    redis: true
+    guacd: true
+  probes:
+    startup:
+      enabled: true
+      path: /health
+      periodSeconds: 5
+      timeoutSeconds: 3
+      failureThreshold: 24
+    liveness:
+      path: /health
+      initialDelaySeconds: 30
+      periodSeconds: 10
+      timeoutSeconds: 5
+      failureThreshold: 6
+    readiness:
+      path: /health
+      initialDelaySeconds: 10
+      periodSeconds: 5
+      timeoutSeconds: 3
+      failureThreshold: 12
+  resources: {}
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+database:
+  enabled: true
+  image:
+    repository: postgres
+    tag: "17-alpine"
+    pullPolicy: IfNotPresent
+  service:
+    name: "database"
+    type: ClusterIP
+    port: 5432
+    annotations: {}
+  persistence:
+    enabled: false
+    existingClaim: ""
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 5Gi
+  resources: {}
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+redis:
+  enabled: true
+  image:
+    repository: redis
+    tag: "7-alpine"
+    pullPolicy: IfNotPresent
+  service:
+    name: "redis"
+    type: ClusterIP
+    port: 6379
+    annotations: {}
+  persistence:
+    enabled: false
+    existingClaim: ""
+    storageClass: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 5Gi
+  resources: {}
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+guacd:
+  enabled: true
+  replicaCount: 1
+  image:
+    repository: guacamole/guacd
+    tag: "1.5.5"
+    pullPolicy: IfNotPresent
+  service:
+    name: "guacd"
+    type: ClusterIP
+    port: 4822
+    annotations: {}
+  resources:
+    limits:
+      memory: 512Mi
+  podAnnotations: {}
+  podSecurityContext: {}
+  securityContext:
+    readOnlyRootFilesystem: true
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
+ingress:
+  enabled: false
+  className: "nginx"
+  annotations: {}
+  hosts:
+    - host: "patchmon.local"
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []

--- a/helm/patchmon/values.yaml
+++ b/helm/patchmon/values.yaml
@@ -165,6 +165,7 @@ guacd:
 ingress:
   enabled: false
   className: "nginx"
+  healthcheckHost: "patchmon.example.com"
   annotations: {}
   hosts:
     - host: "patchmon.local"


### PR DESCRIPTION
## Summary
- add an initial `helm/patchmon` chart to deploy PatchMon components on Kubernetes
- include configurable templates for server, postgres, redis, guacd, services, ingress, config, and secrets
- add usage docs and environment-specific example values files under `helm/examples/`

## Test plan
- [x] `helm lint helm/patchmon`
- [x] `helm template patchmon helm/patchmon`

## AI Disclosure

- **Used AI:** yes
- **Model(s):** GPT-5.3 Codex High Fast
- **Harness / tool:** Cursor
- **Scope:** PR description drafting and contribution guidance
- **Human review completed:** yes - contributor reviewed chart templates, values files, and rendered output before submission
