### PR TITLE
feat: Implement Redis-backed distributed registry for agent presence

### DIFF
--- a/server-source-code/cmd/server/main.go
+++ b/server-source-code/cmd/server/main.go
@@ -108,6 +108,22 @@ func main() {
 	}
 
 	registry := agentregistry.New()
+	// Enable distributed registry if Redis is available. Use POD_ID env var or hostname.
+	podID := os.Getenv("POD_ID")
+	if podID == "" {
+		if hn, err := os.Hostname(); err == nil && hn != "" {
+			podID = hn
+		} else {
+			podID = "unknown-pod"
+		}
+	}
+	if rdb != nil {
+		if err := registry.EnableDistributed(ctx, rdb, podID); err != nil {
+			slog.Error("enable distributed registry", "error", err)
+		} else {
+			slog.Info("distributed registry enabled", "pod_id", podID)
+		}
+	}
 	queueOpts := queue.RedisOpts()
 	queueClient := queue.NewClient(queueOpts)
 	defer func() { _ = queueClient.Close() }()

--- a/server-source-code/internal/agentregistry/registry.go
+++ b/server-source-code/internal/agentregistry/registry.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
+	"log/slog"
 	"strings"
 	"sync"
 	"time"
@@ -269,7 +269,7 @@ func (r *Registry) snapshotPresence() error {
 			apiID := strings.TrimPrefix(k, "agent:meta:")
 			vals, err := r.rdb.HGetAll(r.distCtx, k).Result()
 			if err != nil {
-				log.Printf("agentregistry: snapshot HGetAll error key=%s err=%v", k, err)
+				slog.Error("agentregistry: snapshot HGetAll error", "key", k, "error", err)
 				continue
 			}
 			pod := vals["pod"]
@@ -289,7 +289,7 @@ func (r *Registry) snapshotPresence() error {
 			break
 		}
 	}
-	log.Printf("agentregistry: snapshotPresence loaded %d keys", total)
+	slog.Info("agentregistry: snapshotPresence loaded", "keys", total)
 	return nil
 }
 
@@ -303,7 +303,7 @@ func (r *Registry) handlePubSubMessage(channel string, payload []byte) {
 			TS     string `json:"ts"`
 		}
 		if err := json.Unmarshal(payload, &ev); err != nil {
-			log.Printf("agentregistry: invalid event payload: %v", err)
+			slog.Error("agentregistry: invalid event payload", "error", err)
 			return
 		}
 		r.mu.Lock()
@@ -330,17 +330,17 @@ func (r *Registry) handlePubSubMessage(channel string, payload []byte) {
 		DataB64     string `json:"data"`
 	}
 	if err := json.Unmarshal(payload, &fwd); err != nil {
-		log.Printf("agentregistry: invalid forward payload: %v", err)
+		slog.Error("agentregistry: invalid forward payload", "error", err)
 		return
 	}
 	data, err := base64.StdEncoding.DecodeString(fwd.DataB64)
 	if err != nil {
-		log.Printf("agentregistry: invalid forward data b64: %v", err)
+		slog.Error("agentregistry: invalid forward data b64", "error", err)
 		return
 	}
 	// attempt local send
 	if err := r.SendMessage(fwd.APIID, fwd.MessageType, data); err != nil {
-		log.Printf("agentregistry: forward to local send failed: %v", err)
+		slog.Error("agentregistry: forward to local send failed", "error", err)
 	}
 }
 

--- a/server-source-code/internal/agentregistry/registry.go
+++ b/server-source-code/internal/agentregistry/registry.go
@@ -1,11 +1,18 @@
 package agentregistry
 
 import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"log"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/gorilla/websocket"
+	redisclient "github.com/redis/go-redis/v9"
 )
 
 // ErrNotConnected is returned when a send targets an agent with no live WS.
@@ -34,29 +41,45 @@ type Registry struct {
 	mu    sync.RWMutex
 	meta  map[string]ConnectionInfo // api_id -> { connected, secure }
 	conns map[string]*agentConn     // api_id -> connection + write mutex
+	// distributed presence fields (optional)
+	distCtx    context.Context
+	distCancel context.CancelFunc
+	rdb        *redisclient.Client
+	podMap     map[string]string // api_id -> podID (for remote routing)
+	podID      string
 }
 
 // New creates a new agent connection registry.
 func New() *Registry {
 	return &Registry{
-		meta:  make(map[string]ConnectionInfo),
-		conns: make(map[string]*agentConn),
+		meta:   make(map[string]ConnectionInfo),
+		conns:  make(map[string]*agentConn),
+		podMap: make(map[string]string),
 	}
 }
 
 // Register adds or updates an agent as connected.
 func (r *Registry) Register(apiID string, secure bool) {
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	r.meta[apiID] = ConnectionInfo{Connected: true, Secure: secure}
+	r.podMap[apiID] = r.podID
+	r.mu.Unlock()
+	// Publish presence asynchronously (best-effort)
+	if r.rdb != nil {
+		go func() { _ = r.setPresence(apiID, secure) }()
+	}
 }
 
 // SetConnection stores the agent WebSocket alongside a fresh per-agent write
 // mutex. Must be called once per upgraded connection.
 func (r *Registry) SetConnection(apiID string, conn *websocket.Conn) {
 	r.mu.Lock()
-	defer r.mu.Unlock()
 	r.conns[apiID] = &agentConn{ws: conn}
+	r.podMap[apiID] = r.podID
+	r.mu.Unlock()
+	if r.rdb != nil {
+		go func() { _ = r.setPresence(apiID, true) }()
+	}
 }
 
 // getEntry returns the agent conn entry, or nil if no WS is live.
@@ -69,7 +92,15 @@ func (r *Registry) getEntry(apiID string) *agentConn {
 // IsConnected reports whether the registry currently tracks a live WS for apiID.
 // Prefer this over checking the raw conn pointer.
 func (r *Registry) IsConnected(apiID string) bool {
-	return r.getEntry(apiID) != nil
+	if r.getEntry(apiID) != nil {
+		return true
+	}
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if info, ok := r.meta[apiID]; ok && info.Connected {
+		return true
+	}
+	return false
 }
 
 // SendJSON writes v as JSON to the named agent under the per-agent write mutex.
@@ -78,6 +109,17 @@ func (r *Registry) IsConnected(apiID string) bool {
 func (r *Registry) SendJSON(apiID string, v any) error {
 	e := r.getEntry(apiID)
 	if e == nil {
+		// If agent present on another pod, forward via Redis
+		if r.rdb != nil {
+			// marshal v to JSON and forward
+			b, err := json.Marshal(v)
+			if err != nil {
+				return ErrNotConnected
+			}
+			if err := r.publishForward(apiID, 1, b); err == nil {
+				return nil
+			}
+		}
 		return ErrNotConnected
 	}
 	e.writeMu.Lock()
@@ -91,6 +133,11 @@ func (r *Registry) SendJSON(apiID string, v any) error {
 func (r *Registry) SendMessage(apiID string, messageType int, data []byte) error {
 	e := r.getEntry(apiID)
 	if e == nil {
+		if r.rdb != nil {
+			if err := r.publishForward(apiID, messageType, data); err == nil {
+				return nil
+			}
+		}
 		return ErrNotConnected
 	}
 	e.writeMu.Lock()
@@ -105,6 +152,11 @@ func (r *Registry) SendMessage(apiID string, messageType int, data []byte) error
 func (r *Registry) SendMessageWithTimeout(apiID string, messageType int, data []byte, timeout time.Duration) error {
 	e := r.getEntry(apiID)
 	if e == nil {
+		if r.rdb != nil {
+			if err := r.publishForward(apiID, messageType, data); err == nil {
+				return nil
+			}
+		}
 		return ErrNotConnected
 	}
 	e.writeMu.Lock()
@@ -139,6 +191,11 @@ func (r *Registry) Unregister(apiID string) {
 	defer r.mu.Unlock()
 	delete(r.meta, apiID)
 	delete(r.conns, apiID)
+	delete(r.podMap, apiID)
+	if r.rdb != nil {
+		// best-effort notify other pods
+		_ = r.removePresence(apiID)
+	}
 }
 
 // Get returns connection info for an api_id.
@@ -149,6 +206,198 @@ func (r *Registry) Get(apiID string) ConnectionInfo {
 		return info
 	}
 	return ConnectionInfo{Connected: false, Secure: false}
+}
+
+// EnableDistributed activates Redis-backed presence syncing and per-pod
+// message routing. podID should be a stable identifier for this process/pod.
+func (r *Registry) EnableDistributed(ctx context.Context, rdb *redisclient.Client, podID string) error {
+	if rdb == nil {
+		return fmt.Errorf("redis client nil")
+	}
+	r.mu.Lock()
+	if r.rdb != nil {
+		r.mu.Unlock()
+		return fmt.Errorf("distributed already enabled")
+	}
+	r.rdb = rdb
+	r.podID = podID
+	r.distCtx, r.distCancel = context.WithCancel(ctx)
+	r.mu.Unlock()
+
+	// perform initial snapshot of existing presence keys so a newly-started
+	// pod has the current state even if it missed earlier connect events
+	_ = r.snapshotPresence()
+
+	// subscribe to global events and per-pod channel
+	ch := []string{"agent:events", fmt.Sprintf("agent:pod:%s", podID)}
+	pubsub := rdb.Subscribe(r.distCtx, ch...)
+	// Start goroutine to listen for events
+
+	go func() {
+		c := pubsub.Channel()
+		for {
+			select {
+			case <-r.distCtx.Done():
+				_ = pubsub.Close()
+				return
+			case msg, ok := <-c:
+				if !ok {
+					return
+				}
+				r.handlePubSubMessage(msg.Channel, []byte(msg.Payload))
+			}
+		}
+	}()
+	return nil
+}
+
+// snapshotPresence reads existing agent:meta:* keys and populates local maps.
+func (r *Registry) snapshotPresence() error {
+	if r.rdb == nil {
+		return fmt.Errorf("redis not configured")
+	}
+	var cursor uint64
+	var total int
+	for {
+		keys, cur, err := r.rdb.Scan(r.distCtx, cursor, "agent:meta:*", 100).Result()
+		if err != nil {
+			return err
+		}
+		cursor = cur
+		for _, k := range keys {
+			// k is agent:meta:{api_id}
+			apiID := strings.TrimPrefix(k, "agent:meta:")
+			vals, err := r.rdb.HGetAll(r.distCtx, k).Result()
+			if err != nil {
+				log.Printf("agentregistry: snapshot HGetAll error key=%s err=%v", k, err)
+				continue
+			}
+			pod := vals["pod"]
+			secure := false
+			if s, ok := vals["secure"]; ok && (s == "1" || strings.EqualFold(s, "true")) {
+				secure = true
+			}
+			r.mu.Lock()
+			r.meta[apiID] = ConnectionInfo{Connected: true, Secure: secure}
+			if pod != "" {
+				r.podMap[apiID] = pod
+			}
+			r.mu.Unlock()
+			total++
+		}
+		if cursor == 0 {
+			break
+		}
+	}
+	log.Printf("agentregistry: snapshotPresence loaded %d keys", total)
+	return nil
+}
+
+func (r *Registry) handlePubSubMessage(channel string, payload []byte) {
+	if channel == "agent:events" {
+		var ev struct {
+			APIID  string `json:"api_id"`
+			Type   string `json:"type"`
+			Pod    string `json:"pod"`
+			Secure bool   `json:"secure"`
+			TS     string `json:"ts"`
+		}
+		if err := json.Unmarshal(payload, &ev); err != nil {
+			log.Printf("agentregistry: invalid event payload: %v", err)
+			return
+		}
+		r.mu.Lock()
+		switch ev.Type {
+		case "connect":
+			r.meta[ev.APIID] = ConnectionInfo{Connected: true, Secure: ev.Secure}
+			r.podMap[ev.APIID] = ev.Pod
+		case "disconnect":
+			// mark disconnected unless we have a local connection
+			if _, ok := r.conns[ev.APIID]; !ok {
+				delete(r.meta, ev.APIID)
+				delete(r.podMap, ev.APIID)
+			}
+		default:
+			// ignore unknown event types
+		}
+		r.mu.Unlock()
+		return
+	}
+	// per-pod channel: forward message to local WS
+	var fwd struct {
+		APIID       string `json:"api_id"`
+		MessageType int    `json:"message_type"`
+		DataB64     string `json:"data"`
+	}
+	if err := json.Unmarshal(payload, &fwd); err != nil {
+		log.Printf("agentregistry: invalid forward payload: %v", err)
+		return
+	}
+	data, err := base64.StdEncoding.DecodeString(fwd.DataB64)
+	if err != nil {
+		log.Printf("agentregistry: invalid forward data b64: %v", err)
+		return
+	}
+	// attempt local send
+	if err := r.SendMessage(fwd.APIID, fwd.MessageType, data); err != nil {
+		log.Printf("agentregistry: forward to local send failed: %v", err)
+	}
+}
+
+func (r *Registry) publishEvent(apiID, typ string, secure bool) error {
+	if r.rdb == nil {
+		return fmt.Errorf("redis not configured")
+	}
+	ev := map[string]any{
+		"api_id": apiID,
+		"type":   typ,
+		"pod":    r.podID,
+		"secure": secure,
+		"ts":     time.Now().UTC().Format(time.RFC3339),
+	}
+	b, _ := json.Marshal(ev)
+	return r.rdb.Publish(r.distCtx, "agent:events", b).Err()
+}
+
+func (r *Registry) setPresence(apiID string, secure bool) error {
+	if r.rdb == nil {
+		return fmt.Errorf("redis not configured")
+	}
+	key := fmt.Sprintf("agent:meta:%s", apiID)
+	vals := map[string]interface{}{`pod`: r.podID, `secure`: secure, `last_seen`: time.Now().UTC().Format(time.RFC3339)}
+	if err := r.rdb.HSet(r.distCtx, key, vals).Err(); err != nil {
+		return err
+	}
+	// keep a TTL so crashed pods eventually expire
+	_ = r.rdb.Expire(r.distCtx, key, 5*time.Minute).Err()
+	_ = r.publishEvent(apiID, "connect", secure)
+	return nil
+}
+
+func (r *Registry) removePresence(apiID string) error {
+	if r.rdb == nil {
+		return fmt.Errorf("redis not configured")
+	}
+	key := fmt.Sprintf("agent:meta:%s", apiID)
+	if err := r.rdb.Del(r.distCtx, key).Err(); err != nil {
+		return err
+	}
+	_ = r.publishEvent(apiID, "disconnect", false)
+	return nil
+}
+
+func (r *Registry) publishForward(apiID string, messageType int, data []byte) error {
+	r.mu.RLock()
+	pod := r.podMap[apiID]
+	r.mu.RUnlock()
+	if pod == "" {
+		return fmt.Errorf("no remote pod for apiID")
+	}
+	b64 := base64.StdEncoding.EncodeToString(data)
+	fwd := map[string]any{"api_id": apiID, "message_type": messageType, "data": b64}
+	b, _ := json.Marshal(fwd)
+	ch := fmt.Sprintf("agent:pod:%s", pod)
+	return r.rdb.Publish(r.distCtx, ch, b).Err()
 }
 
 // GetConnectedApiIDs returns all api_ids that are currently connected.


### PR DESCRIPTION
## AI Disclosure

- **Used AI:** yes
- **Model(s):** GPT-5 mini (I ran out of claude tokens :( )
- **Harness / tool:** GitHub Copilot (VS Code extension; interactive coding assistant)
- **Scope:** Code changes and small handler fixes in the server: implemented distributed agent presence (Redis hash + Pub/Sub). 
- Files modified include:
  - server-source-code/internal/agentregistry/registry.go
  - server-source-code/cmd/server/main.go
- **Human review completed:** yes — changes were reviewed and tested by the contributor: functional behavior validated (connect/disconnect, presence sync) and smoke-tested in a multi-pod dev environment.

### Notes

- This disclosure follows the project's requirements in `CONTRIBUTING.md` and aligns with the AI Declaration (`AI-DECLARATION.md`).
- The AI output was used to generate and iterate on code changes; all produced code was inspected, adjusted, and tested by the human contributor before committing.
- Responsibility: the human contributor remains fully responsible for the changes and verified behavior. Security-sensitive areas were checked manually.

I've tested it on k8s with 1,2,5 replicas. Up- & downscaling works, agent stays connected. Please build the server container yourself and test it on docker before merging