### PR TITLE
Change compliance upgradeCmd

### DIFF
--- a/agent-source-code/internal/integrations/compliance/openscap.go
+++ b/agent-source-code/internal/integrations/compliance/openscap.go
@@ -368,9 +368,9 @@ func (s *OpenSCAPScanner) EnsureInstalled() error {
 			if s.osInfo.Name == "debian" {
 				upgradePkgs = append(upgradePkgs, "ssg-debian")
 			}
-			upgradeCmd := exec.CommandContext(ctx, "apt-get", append([]string{"upgrade", "-y", "-qq",
-				"-o", "Dpkg::Options::=--force-confdef",
-				"-o", "Dpkg::Options::=--force-confold"}, upgradePkgs...)...)
+			upgradeCmd := exec.CommandContext(ctx, "apt-get", append([]string{"install", "--only-upgrade", "-y", "-qq",
+			    "-o", "Dpkg::Options::=--force-confdef",
+    			"-o", "Dpkg::Options::=--force-confold"}, upgradePkgs...)...)
 			upgradeCmd.Env = nonInteractiveEnv
 			upgradeOutput, upgradeErr := upgradeCmd.CombinedOutput()
 			if upgradeErr != nil {


### PR DESCRIPTION
Change the apt-get command used by the compliance scanner installer, to prevent all packages from being upgraded.
By changing `upgrade` to `install --only-upgrade`, apt-get will solely update the given packages if newer versions exist, and leaving other packages untouched.