### PR TITLE
fix(queue): honour REDIS_TLS in asynq client options

### DIFF
--- a/server-source-code/internal/queue/client.go
+++ b/server-source-code/internal/queue/client.go
@@ -1,14 +1,13 @@
 package queue
 
 import (
-	"crypto/tls"
-	"crypto/x509"
 	"fmt"
 	"os"
 	"strconv"
-	"strings"
 
 	"github.com/hibiken/asynq"
+
+	patchmonredis "github.com/PatchMon/PatchMon/server-source-code/internal/redis"
 )
 
 const (
@@ -27,37 +26,12 @@ func RedisOpts() asynq.RedisClientOpt {
 	db := getEnvInt("REDIS_DB", defaultRedisDB)
 	password := os.Getenv("REDIS_PASSWORD")
 
-	opts := asynq.RedisClientOpt{
-		Addr:     fmt.Sprintf("%s:%d", host, port),
-		Password: password,
-		DB:       db,
+	return asynq.RedisClientOpt{
+		Addr:      fmt.Sprintf("%s:%d", host, port),
+		Password:  password,
+		DB:        db,
+		TLSConfig: patchmonredis.TLSConfigFromEnv(),
 	}
-
-	if os.Getenv("REDIS_TLS") == "true" {
-		tlsCfg := &tls.Config{
-			MinVersion:         tls.VersionTLS12,
-			InsecureSkipVerify: os.Getenv("REDIS_TLS_VERIFY") == "false",
-		}
-		if ca := strings.TrimSpace(os.Getenv("REDIS_TLS_CA")); ca != "" {
-			pool := x509.NewCertPool()
-			var pem []byte
-			if strings.HasPrefix(ca, "-----") {
-				pem = []byte(ca)
-			} else {
-				var err error
-				pem, err = os.ReadFile(ca)
-				if err != nil {
-					pem = []byte(ca)
-				}
-			}
-			if len(pem) > 0 && pool.AppendCertsFromPEM(pem) {
-				tlsCfg.RootCAs = pool
-			}
-		}
-		opts.TLSConfig = tlsCfg
-	}
-
-	return opts
 }
 
 func getEnvInt(key string, defaultVal int) int {

--- a/server-source-code/internal/queue/client.go
+++ b/server-source-code/internal/queue/client.go
@@ -1,9 +1,12 @@
 package queue
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/hibiken/asynq"
 )
@@ -24,11 +27,38 @@ func RedisOpts() asynq.RedisClientOpt {
 	db := getEnvInt("REDIS_DB", defaultRedisDB)
 	password := os.Getenv("REDIS_PASSWORD")
 
-	return asynq.RedisClientOpt{
+	opts := asynq.RedisClientOpt{
 		Addr:     fmt.Sprintf("%s:%d", host, port),
 		Password: password,
 		DB:       db,
 	}
+
+	if os.Getenv("REDIS_TLS") == "true" {
+		tlsCfg := &tls.Config{
+			MinVersion:         tls.VersionTLS12,
+			InsecureSkipVerify: os.Getenv("REDIS_TLS_VERIFY") == "false",
+		}
+		if ca := os.Getenv("REDIS_TLS_CA"); ca != "" {
+			pool := x509.NewCertPool()
+			var pem []byte
+			trimmed := strings.TrimSpace(ca)
+			if len(trimmed) >= 5 && trimmed[:5] == "-----" {
+				pem = []byte(ca)
+			} else {
+				var err error
+				pem, err = os.ReadFile(ca)
+				if err != nil {
+					pem = []byte(ca)
+				}
+			}
+			if len(pem) > 0 && pool.AppendCertsFromPEM(pem) {
+				tlsCfg.RootCAs = pool
+			}
+		}
+		opts.TLSConfig = tlsCfg
+	}
+
+	return opts
 }
 
 func getEnvInt(key string, defaultVal int) int {

--- a/server-source-code/internal/queue/client.go
+++ b/server-source-code/internal/queue/client.go
@@ -38,11 +38,10 @@ func RedisOpts() asynq.RedisClientOpt {
 			MinVersion:         tls.VersionTLS12,
 			InsecureSkipVerify: os.Getenv("REDIS_TLS_VERIFY") == "false",
 		}
-		if ca := os.Getenv("REDIS_TLS_CA"); ca != "" {
+		if ca := strings.TrimSpace(os.Getenv("REDIS_TLS_CA")); ca != "" {
 			pool := x509.NewCertPool()
 			var pem []byte
-			trimmed := strings.TrimSpace(ca)
-			if len(trimmed) >= 5 && trimmed[:5] == "-----" {
+			if strings.HasPrefix(ca, "-----") {
 				pem = []byte(ca)
 			} else {
 				var err error

--- a/server-source-code/internal/redis/client.go
+++ b/server-source-code/internal/redis/client.go
@@ -2,12 +2,9 @@ package redis
 
 import (
 	"context"
-	"crypto/tls"
-	"crypto/x509"
 	"fmt"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -44,32 +41,7 @@ func NewClient() *redis.Client {
 		DialTimeout:  connTO,
 		ReadTimeout:  cmdTO,
 		WriteTimeout: cmdTO,
-	}
-
-	if os.Getenv("REDIS_TLS") == "true" {
-		tlsCfg := &tls.Config{
-			MinVersion:         tls.VersionTLS12,
-			InsecureSkipVerify: os.Getenv("REDIS_TLS_VERIFY") == "false",
-		}
-		if ca := os.Getenv("REDIS_TLS_CA"); ca != "" {
-			pool := x509.NewCertPool()
-			var pem []byte
-			trimmed := strings.TrimSpace(ca)
-			if len(trimmed) >= 5 && trimmed[:5] == "-----" {
-				pem = []byte(ca)
-			} else {
-				// Assume file path
-				var err error
-				pem, err = os.ReadFile(ca)
-				if err != nil {
-					pem = []byte(ca)
-				}
-			}
-			if len(pem) > 0 && pool.AppendCertsFromPEM(pem) {
-				tlsCfg.RootCAs = pool
-			}
-		}
-		opts.TLSConfig = tlsCfg
+		TLSConfig:    TLSConfigFromEnv(),
 	}
 
 	return redis.NewClient(opts)

--- a/server-source-code/internal/redis/tls.go
+++ b/server-source-code/internal/redis/tls.go
@@ -1,0 +1,43 @@
+package redis
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"os"
+	"strings"
+)
+
+// TLSConfigFromEnv returns a *tls.Config built from REDIS_TLS / REDIS_TLS_VERIFY
+// / REDIS_TLS_CA, or nil when REDIS_TLS != "true".
+//
+// Used by both the cache client (NewClient) and the asynq queue client
+// (queue.RedisOpts) so TLS handling stays consistent across Redis call sites.
+func TLSConfigFromEnv() *tls.Config {
+	if os.Getenv("REDIS_TLS") != "true" {
+		return nil
+	}
+
+	tlsCfg := &tls.Config{
+		MinVersion:         tls.VersionTLS12,
+		InsecureSkipVerify: os.Getenv("REDIS_TLS_VERIFY") == "false",
+	}
+
+	if ca := strings.TrimSpace(os.Getenv("REDIS_TLS_CA")); ca != "" {
+		pool := x509.NewCertPool()
+		var pem []byte
+		if strings.HasPrefix(ca, "-----") {
+			pem = []byte(ca)
+		} else {
+			var err error
+			pem, err = os.ReadFile(ca)
+			if err != nil {
+				pem = []byte(ca)
+			}
+		}
+		if len(pem) > 0 && pool.AppendCertsFromPEM(pem) {
+			tlsCfg.RootCAs = pool
+		}
+	}
+
+	return tlsCfg
+}


### PR DESCRIPTION
Closes #736.

`internal/queue/client.go::RedisOpts()` did not consume any of the
`REDIS_TLS` / `REDIS_TLS_VERIFY` / `REDIS_TLS_CA` env vars that
`internal/redis/client.go` already supports. As a result, on a TLS-only
Redis deployment the HTTP server starts fine (the cache client honours
TLS) while every asynq queue loops on `redis eval error: EOF` /
`SADD failed: EOF` and Redis logs flood with
`SSL routines::wrong version number` — the queue is talking plaintext
to a TLS-only port.

## What this PR does

1. **`fix(queue)`** — `queue.RedisOpts()` now picks up TLS config from
   the same env vars as the cache client, so the asynq queue talks
   TLS when `REDIS_TLS=true`.
2. **`fix(queue)` (per Copilot review)** — when `REDIS_TLS_CA` is a
   file path with surrounding whitespace, the path is now used
   trimmed for both the `-----` prefix check and the `os.ReadFile`
   call (previously it was trimmed for the prefix check but the
   raw value was passed to `ReadFile`, so the read failed and the
   code fell back to using the raw string as PEM, leaving
   `RootCAs` empty).
3. **`refactor(redis)` (per Copilot review)** — extract a shared
   `redis.TLSConfigFromEnv()` helper used by both
   `internal/redis/client.go` and `internal/queue/client.go`, so
   future changes to the env-var contract apply to both call sites
   automatically.

`gofmt`, `go vet ./internal/redis/... ./internal/queue/...`, and
`go build ./internal/redis/... ./internal/queue/...` all clean.

Reproduction and full diagnosis are in #736.

## AI Disclosure

- **Used AI:** yes
- **Model(s):** Claude Opus 4.7 (1M context)
- **Harness / tool:** Claude Code CLI
- **Scope:** code, commit messages, PR description (after the
  diagnosis was independently verified against the live deployment
  that exhibited the bug).
- **Human review completed:** yes — Nicolas Dargent reviewed the
  diff, validated the diagnosis matches the observed Redis log
  storm (`SSL routines::wrong version number` from the asynq
  client) and the asynq EOF spam in patchmon_server logs, ran the
  resulting binary against the same TLS-only Redis it was failing
  on, and confirmed all background queues recover.