### PR TITLE
feat(security): Ed25519 signing verification for agent updates

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -59,7 +59,12 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
           GOARM: ${{ (matrix.goos == 'linux' || matrix.goos == 'freebsd') && matrix.goarch == 'arm' && '6' || '' }}
           CGO_ENABLED: 0
+          PATCHMON_SIGNING_PUBLIC_KEY: ${{ vars.PATCHMON_SIGNING_PUBLIC_KEY }}
         run: |
+          if [ -z "${PATCHMON_SIGNING_PUBLIC_KEY}" ]; then
+            echo "❌ Error: PATCHMON_SIGNING_PUBLIC_KEY is not set. Set it as a repository variable before releasing."
+            exit 1
+          fi
           OUTPUT_BASE="patchmon-agent-${{ matrix.goos }}-${{ matrix.goarch }}"
           OUTPUT_NAME="${OUTPUT_BASE}${{ matrix.goos == 'windows' && '.exe' || '' }}"
           # Strip leading "v" so "v2.0.0" becomes "2.0.0" — diagnostics.go prints
@@ -67,7 +72,7 @@ jobs:
           VERSION="${{ github.event.release.tag_name }}"
           VERSION="${VERSION#v}"
           go build -buildvcs=false \
-            -ldflags="-s -w -X patchmon-agent/internal/pkgversion.Version=${VERSION}" \
+            -ldflags="-s -w -X patchmon-agent/internal/pkgversion.Version=${VERSION} -X patchmon-agent/internal/pkgversion.SigningPublicKey=${PATCHMON_SIGNING_PUBLIC_KEY}" \
             -o "${OUTPUT_NAME}" ./cmd/patchmon-agent
 
       - name: Verify binary exists and is executable
@@ -159,11 +164,33 @@ jobs:
             fi
           fi
 
+      - name: Install minisign
+        run: |
+          curl -fsSL https://github.com/jedisct1/minisign/releases/download/0.11/minisign-0.11-linux.tar.gz \
+            | tar xz --strip-components=2 -C /usr/local/bin minisign-linux/x86_64/minisign
+          minisign -v
+
+      - name: Sign agent binary
+        working-directory: agent-source-code
+        env:
+          MINISIGN_PRIVATE_KEY: ${{ secrets.AGENT_SIGNING_PRIVATE_KEY }}
+        run: |
+          OUTPUT_BASE="patchmon-agent-${{ matrix.goos }}-${{ matrix.goarch }}"
+          OUTPUT_NAME="${OUTPUT_BASE}${{ matrix.goos == 'windows' && '.exe' || '' }}"
+          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${VERSION#v}"
+          printf '%s' "${MINISIGN_PRIVATE_KEY}" > /tmp/minisign.key
+          minisign -S -s /tmp/minisign.key -m "${OUTPUT_NAME}" -t "PatchMon Agent ${VERSION}" -x "${OUTPUT_NAME}.minisig"
+          rm -f /tmp/minisign.key
+          echo "✅ Signed ${OUTPUT_NAME}"
+
       - name: Upload agent binary to release
         uses: softprops/action-gh-release@b25b93d384199fc0fc8c2e126b2d937a0cbeb2ae
         with:
           tag_name: ${{ github.event.release.tag_name }}
-          files: agent-source-code/patchmon-agent-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.goos == 'windows' && '.exe' || '' }}
+          files: |
+            agent-source-code/patchmon-agent-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.goos == 'windows' && '.exe' || '' }}
+            agent-source-code/patchmon-agent-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.goos == 'windows' && '.exe' || '' }}.minisig
 
       - name: Build summary
         run: |

--- a/agent-source-code/Makefile
+++ b/agent-source-code/Makefile
@@ -68,11 +68,14 @@ sign-all: check-signing-key
 	@[ -n "$(PATCHMON_SIGNING_PRIVATE_KEY)" ] || (echo "❌ Error: PATCHMON_SIGNING_PRIVATE_KEY (path to private key file) is not set."; exit 1)
 	@command -v minisign >/dev/null 2>&1 || (echo "❌ Error: minisign is not installed. See https://jedisct1.github.io/minisign/"; exit 1)
 	@echo "Signing agent binaries..."
-	@[ -n "$(MINISIGN_PASSWORD)" ] || (echo "❌ Error: MINISIGN_PASSWORD is not set. Export it before running sign-all."; exit 1)
 	@for f in $(GOBIN)/$(BINARY_NAME)-linux-* $(GOBIN)/$(BINARY_NAME)-freebsd-* $(GOBIN)/$(BINARY_NAME)-windows-*.exe; do \
 		case "$$f" in *.minisig) continue ;; esac; \
 		[ -f "$$f" ] || continue; \
-		printf '%s\n' "$(MINISIGN_PASSWORD)" | minisign -S -s $(PATCHMON_SIGNING_PRIVATE_KEY) -m "$$f" -x "$$f.minisig" -W && echo "  ✅ Signed $$f" || { echo "  ❌ Failed to sign $$f (wrong password?)"; exit 1; }; \
+		if [ -n "$(MINISIGN_PASSWORD)" ]; then \
+			printf '%s\n' "$(MINISIGN_PASSWORD)" | minisign -S -s $(PATCHMON_SIGNING_PRIVATE_KEY) -m "$$f" -x "$$f.minisig" -W && echo "  ✅ Signed $$f" || { echo "  ❌ Failed to sign $$f (wrong password?)"; exit 1; }; \
+		else \
+			minisign -S -s $(PATCHMON_SIGNING_PRIVATE_KEY) -m "$$f" -x "$$f.minisig" && echo "  ✅ Signed $$f" || { echo "  ❌ Failed to sign $$f"; exit 1; }; \
+		fi; \
 	done
 
 # Build all (Linux + FreeBSD + Windows), sign, and copy to backend serve dirs

--- a/agent-source-code/Makefile
+++ b/agent-source-code/Makefile
@@ -68,8 +68,11 @@ sign-all: check-signing-key
 	@[ -n "$(PATCHMON_SIGNING_PRIVATE_KEY)" ] || (echo "❌ Error: PATCHMON_SIGNING_PRIVATE_KEY (path to private key file) is not set."; exit 1)
 	@command -v minisign >/dev/null 2>&1 || (echo "❌ Error: minisign is not installed. See https://jedisct1.github.io/minisign/"; exit 1)
 	@echo "Signing agent binaries..."
+	@[ -n "$(MINISIGN_PASSWORD)" ] || (echo "❌ Error: MINISIGN_PASSWORD is not set. Export it before running sign-all."; exit 1)
 	@for f in $(GOBIN)/$(BINARY_NAME)-linux-* $(GOBIN)/$(BINARY_NAME)-freebsd-* $(GOBIN)/$(BINARY_NAME)-windows-*.exe; do \
-		[ -f "$$f" ] && minisign -S -s $(PATCHMON_SIGNING_PRIVATE_KEY) -m "$$f" -x "$$f.minisig" && echo "  ✅ Signed $$f"; \
+		case "$$f" in *.minisig) continue ;; esac; \
+		[ -f "$$f" ] || continue; \
+		printf '%s\n' "$(MINISIGN_PASSWORD)" | minisign -S -s $(PATCHMON_SIGNING_PRIVATE_KEY) -m "$$f" -x "$$f.minisig" -W && echo "  ✅ Signed $$f" || { echo "  ❌ Failed to sign $$f (wrong password?)"; exit 1; }; \
 	done
 
 # Build all (Linux + FreeBSD + Windows), sign, and copy to backend serve dirs

--- a/agent-source-code/Makefile
+++ b/agent-source-code/Makefile
@@ -6,8 +6,9 @@ BUILD_DIR=build
 # Where backend serves agents from (both must stay in sync)
 AGENTS_REPO=../agents
 AGENTS_DOCKER=../docker/compose_dev_data/agents
-# Strip debug info (version comes from internal/version/version.go)
-LDFLAGS=-ldflags "-s -w"
+# Strip debug info and embed signing public key (required — must be set via PATCHMON_SIGNING_PUBLIC_KEY env var)
+SIGNING_KEY_LDFLAG=$(if $(PATCHMON_SIGNING_PUBLIC_KEY),-X patchmon-agent/internal/pkgversion.SigningPublicKey=$(PATCHMON_SIGNING_PUBLIC_KEY),)
+LDFLAGS=-ldflags "-s -w $(SIGNING_KEY_LDFLAG)"
 # Disable VCS stamping
 BUILD_FLAGS=-buildvcs=false
 
@@ -23,7 +24,12 @@ GOLANGCI_LINT_CMD ?= $(shell command -v golangci-lint 2>/dev/null || echo /root/
 .PHONY: all
 all: build
 
-# Build the application
+# Fail fast if PATCHMON_SIGNING_PUBLIC_KEY is not set (required for all release builds)
+.PHONY: check-signing-key
+check-signing-key:
+	@[ -n "$(PATCHMON_SIGNING_PUBLIC_KEY)" ] || (echo "❌ Error: PATCHMON_SIGNING_PUBLIC_KEY is not set. Export it before building."; exit 1)
+
+# Build the application (no signing key required for local dev builds)
 .PHONY: build
 build:
 	@echo "Building $(BINARY_NAME)..."
@@ -32,7 +38,7 @@ build:
 
 # Build Linux binaries only (amd64, 386, arm64, arm)
 .PHONY: build-linux
-build-linux:
+build-linux: check-signing-key
 	@mkdir -p $(BUILD_DIR)
 	@GOOS=linux GOARCH=amd64 CGO_ENABLED=0 $(GO_CMD) build $(BUILD_FLAGS) $(LDFLAGS) -o $(GOBIN)/$(BINARY_NAME)-linux-amd64 ./cmd/patchmon-agent
 	@GOOS=linux GOARCH=386 CGO_ENABLED=0 $(GO_CMD) build $(BUILD_FLAGS) $(LDFLAGS) -o $(GOBIN)/$(BINARY_NAME)-linux-386 ./cmd/patchmon-agent
@@ -41,7 +47,7 @@ build-linux:
 
 # Build FreeBSD binaries only (amd64, 386, arm64, arm)
 .PHONY: build-freebsd
-build-freebsd:
+build-freebsd: check-signing-key
 	@mkdir -p $(BUILD_DIR)
 	@GOOS=freebsd GOARCH=amd64 CGO_ENABLED=0 $(GO_CMD) build $(BUILD_FLAGS) $(LDFLAGS) -o $(GOBIN)/$(BINARY_NAME)-freebsd-amd64 ./cmd/patchmon-agent
 	@GOOS=freebsd GOARCH=386 CGO_ENABLED=0 $(GO_CMD) build $(BUILD_FLAGS) $(LDFLAGS) -o $(GOBIN)/$(BINARY_NAME)-freebsd-386 ./cmd/patchmon-agent
@@ -50,19 +56,30 @@ build-freebsd:
 
 # Build Windows binaries only (amd64, arm64 — 32-bit Windows is not supported; Win10 x86 hit EOL 2025-10-14)
 .PHONY: build-windows
-build-windows:
+build-windows: check-signing-key
 	@mkdir -p $(BUILD_DIR)
 	@GOOS=windows GOARCH=amd64 CGO_ENABLED=0 $(GO_CMD) build $(BUILD_FLAGS) $(LDFLAGS) -o $(GOBIN)/$(BINARY_NAME)-windows-amd64.exe ./cmd/patchmon-agent
 	@GOOS=windows GOARCH=arm64 CGO_ENABLED=0 $(GO_CMD) build $(BUILD_FLAGS) $(LDFLAGS) -o $(GOBIN)/$(BINARY_NAME)-windows-arm64.exe ./cmd/patchmon-agent
 
-# Build all (Linux + FreeBSD + Windows) and copy to backend serve dirs
+# Sign all built binaries in BUILD_DIR using minisign.
+# Requires PATCHMON_SIGNING_PRIVATE_KEY (path to private key file) to be set.
+.PHONY: sign-all
+sign-all: check-signing-key
+	@[ -n "$(PATCHMON_SIGNING_PRIVATE_KEY)" ] || (echo "❌ Error: PATCHMON_SIGNING_PRIVATE_KEY (path to private key file) is not set."; exit 1)
+	@command -v minisign >/dev/null 2>&1 || (echo "❌ Error: minisign is not installed. See https://jedisct1.github.io/minisign/"; exit 1)
+	@echo "Signing agent binaries..."
+	@for f in $(GOBIN)/$(BINARY_NAME)-linux-* $(GOBIN)/$(BINARY_NAME)-freebsd-* $(GOBIN)/$(BINARY_NAME)-windows-*.exe; do \
+		[ -f "$$f" ] && minisign -S -s $(PATCHMON_SIGNING_PRIVATE_KEY) -m "$$f" -x "$$f.minisig" && echo "  ✅ Signed $$f"; \
+	done
+
+# Build all (Linux + FreeBSD + Windows), sign, and copy to backend serve dirs
 .PHONY: build-all
-build-all: build-linux build-freebsd build-windows
+build-all: build-linux build-freebsd build-windows sign-all
 	@mkdir -p $(AGENTS_REPO) $(AGENTS_DOCKER)
 	@for f in $(GOBIN)/$(BINARY_NAME)-linux-* $(GOBIN)/$(BINARY_NAME)-freebsd-* $(GOBIN)/$(BINARY_NAME)-windows-*.exe; do \
-		[ -f "$$f" ] && cp "$$f" $(AGENTS_REPO)/ && cp "$$f" $(AGENTS_DOCKER)/; \
+		[ -f "$$f" ] && cp "$$f" "$$f.minisig" $(AGENTS_REPO)/ && cp "$$f" "$$f.minisig" $(AGENTS_DOCKER)/; \
 	done
-	@echo "Done. agents/ and docker/compose_dev_data/agents/ updated."
+	@echo "Done. agents/ and docker/compose_dev_data/agents/ updated (binaries + signatures)."
 
 # Build all agent binaries into agents-prebuilt/ (for local Docker backend build)
 .PHONY: build-all-for-docker
@@ -70,7 +87,8 @@ build-all-for-docker:
 	@mkdir -p ../agents-prebuilt
 	@$(MAKE) build-all
 	@cp $(BUILD_DIR)/$(BINARY_NAME)-linux-* $(BUILD_DIR)/$(BINARY_NAME)-freebsd-* $(BUILD_DIR)/$(BINARY_NAME)-windows-*.exe ../agents-prebuilt/ 2>/dev/null || true
-	@echo "Agent binaries copied to agents-prebuilt/"
+	@cp $(BUILD_DIR)/$(BINARY_NAME)-linux-*.minisig $(BUILD_DIR)/$(BINARY_NAME)-freebsd-*.minisig $(BUILD_DIR)/$(BINARY_NAME)-windows-*.minisig ../agents-prebuilt/ 2>/dev/null || true
+	@echo "Agent binaries and signatures copied to agents-prebuilt/"
 
 # Install dependencies
 .PHONY: deps

--- a/agent-source-code/cmd/patchmon-agent/commands/version_update.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/version_update.go
@@ -1,10 +1,13 @@
 package commands
 
 import (
+	"bytes"
 	"context"
+	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/tls"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -23,6 +26,7 @@ import (
 	"patchmon-agent/internal/pkgversion"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/crypto/blake2b"
 )
 
 const (
@@ -188,6 +192,31 @@ func updateAgent() error {
 		return fmt.Errorf("binary hash mismatch: expected %s, got %s", versionInfo.Hash, actualHash)
 	}
 	logger.WithField("hash", actualHash).Info("Binary integrity verified successfully")
+
+	// SECURITY: Verify cryptographic signature (Ed25519 via minisign)
+	// This ensures the binary was signed by the holder of the private key, even if the server is compromised.
+	if pkgversion.SigningPublicKey == "" {
+		logger.Error("No signing public key compiled into this binary — refusing to update")
+		return fmt.Errorf("update aborted: binary was built without a signing public key (set PATCHMON_SIGNING_PUBLIC_KEY at build time)")
+	}
+	sigData, err := fetchAgentSignature()
+	if err != nil {
+		return fmt.Errorf("failed to fetch agent signature: %w", err)
+	}
+	signedVersion, err := verifyMinisignSignature(pkgversion.SigningPublicKey, newAgentData, sigData)
+	if err != nil {
+		logger.WithError(err).Error("Cryptographic signature verification failed — refusing to install binary")
+		return fmt.Errorf("signature verification failed: %w", err)
+	}
+	logger.WithField("signedVersion", signedVersion).Info("Cryptographic signature verified successfully")
+
+	// Downgrade protection: the version in the signature must be greater than the current version.
+	// This prevents a compromised server from serving an old but validly-signed binary.
+	if signedVersion != "" {
+		if compareVersions(signedVersion, currentVersion) <= 0 {
+			return fmt.Errorf("downgrade rejected: signed binary version %s is not newer than current version %s", signedVersion, currentVersion)
+		}
+	}
 
 	// Get the new version from server version info (more reliable than parsing binary output)
 	newVersion := currentVersion // Default to current if we can't determine
@@ -470,6 +499,176 @@ func getPlatform() string {
 	default:
 		return "linux"
 	}
+}
+
+// verifyMinisignSignature verifies a minisign Ed25519 signature over data using the given base64-encoded public key.
+// Returns the version string extracted from the trusted comment (format: "PatchMon Agent <version>").
+// The minisign public key format is: base64(algorithm[2] + keyID[8] + ed25519PublicKey[32])
+// The minisign signature format (per line): untrusted comment, base64(algorithm[2] + keyID[8] + signature[64]), trusted comment, global signature.
+func verifyMinisignSignature(publicKeyB64 string, data, sigFile []byte) (string, error) {
+	// Decode public key
+	pubKeyRaw, err := base64.StdEncoding.DecodeString(publicKeyB64)
+	if err != nil {
+		return "", fmt.Errorf("invalid public key encoding: %w", err)
+	}
+	// algorithm(2) + keyID(8) + ed25519 key(32) = 42 bytes
+	if len(pubKeyRaw) != 42 {
+		return "", fmt.Errorf("invalid public key length: expected 42 bytes, got %d", len(pubKeyRaw))
+	}
+	if pubKeyRaw[0] != 'E' || pubKeyRaw[1] != 'd' {
+		return "", fmt.Errorf("unsupported signing algorithm: expected Ed (Ed25519)")
+	}
+	pubKey := ed25519.PublicKey(pubKeyRaw[10:]) // skip algorithm(2) + keyID(8)
+
+	// Parse signature file: line 0 = untrusted comment, line 1 = base64 sig, line 2 = trusted comment, line 3 = global sig
+	lines := strings.Split(strings.ReplaceAll(string(sigFile), "\r\n", "\n"), "\n")
+	// Filter empty trailing lines
+	for len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
+		lines = lines[:len(lines)-1]
+	}
+	if len(lines) < 4 {
+		return "", fmt.Errorf("invalid signature file: expected 4 lines, got %d", len(lines))
+	}
+
+	sigRaw, err := base64.StdEncoding.DecodeString(strings.TrimSpace(lines[1]))
+	if err != nil {
+		return "", fmt.Errorf("invalid signature encoding: %w", err)
+	}
+	// algorithm(2) + keyID(8) + signature(64) = 74 bytes
+	if len(sigRaw) != 74 {
+		return "", fmt.Errorf("invalid signature length: expected 74 bytes, got %d", len(sigRaw))
+	}
+	if sigRaw[0] != 'E' || sigRaw[1] != 'd' {
+		return "", fmt.Errorf("unsupported signature algorithm: expected Ed")
+	}
+	// Verify key ID matches
+	if !bytes.Equal(pubKeyRaw[2:10], sigRaw[2:10]) {
+		return "", fmt.Errorf("signature key ID does not match public key")
+	}
+	sig := sigRaw[10:] // skip algorithm(2) + keyID(8)
+
+	// minisign signs a prehash: Blake2b-512 of the data
+	h := blake2b.Sum512(data)
+	if !ed25519.Verify(pubKey, h[:], sig) {
+		return "", fmt.Errorf("Ed25519 signature is invalid")
+	}
+
+	// Extract version from trusted comment (format: "trusted comment: PatchMon Agent <version>")
+	trustedComment := strings.TrimPrefix(strings.TrimSpace(lines[2]), "trusted comment: ")
+	signedVersion := strings.TrimPrefix(strings.TrimSpace(trustedComment), "PatchMon Agent ")
+	signedVersion = strings.TrimPrefix(signedVersion, "v")
+
+	return signedVersion, nil
+}
+
+// compareVersions compares two semantic version strings.
+// Returns 1 if v1 > v2, -1 if v1 < v2, 0 if equal.
+func compareVersions(v1, v2 string) int {
+	parse := func(v string) []int {
+		v = strings.TrimPrefix(v, "v")
+		parts := strings.Split(v, ".")
+		nums := make([]int, 0, len(parts))
+		for _, p := range parts {
+			n := 0
+			for _, c := range p {
+				if c >= '0' && c <= '9' {
+					n = n*10 + int(c-'0')
+				} else {
+					break
+				}
+			}
+			nums = append(nums, n)
+		}
+		return nums
+	}
+	p1, p2 := parse(v1), parse(v2)
+	max := len(p1)
+	if len(p2) > max {
+		max = len(p2)
+	}
+	for i := 0; i < max; i++ {
+		a, b := 0, 0
+		if i < len(p1) {
+			a = p1[i]
+		}
+		if i < len(p2) {
+			b = p2[i]
+		}
+		if a > b {
+			return 1
+		}
+		if a < b {
+			return -1
+		}
+	}
+	return 0
+}
+
+// fetchAgentSignature downloads the minisign signature file for the agent binary from the server.
+func fetchAgentSignature() ([]byte, error) {
+	cfg := cfgManager.GetConfig()
+
+	if err := cfgManager.LoadCredentials(); err != nil {
+		return nil, fmt.Errorf("failed to load credentials: %w", err)
+	}
+	credentials := cfgManager.GetCredentials()
+
+	architecture := getArchitecture()
+	platform := getPlatform()
+	url := fmt.Sprintf("%s/api/v1/hosts/agent/signature?arch=%s&os=%s", cfg.PatchmonServer, architecture, platform)
+
+	ctx, cancel := context.WithTimeout(context.Background(), versionCheckTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("User-Agent", fmt.Sprintf("patchmon-agent/%s", pkgversion.Version))
+	req.Header.Set("X-API-ID", credentials.APIID)
+	req.Header.Set("X-API-KEY", credentials.APIKey)
+
+	httpClient := &http.Client{
+		Timeout: versionCheckTimeout,
+		Transport: &http.Transport{
+			ResponseHeaderTimeout: 5 * time.Second,
+		},
+	}
+
+	if cfg.SkipSSLVerify || client.IsSkipSSLVerifyEnvSet() {
+		httpClient.Transport = &http.Transport{
+			ResponseHeaderTimeout: 5 * time.Second,
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		}
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			logger.WithError(closeErr).Debug("Failed to close signature response body")
+		}
+	}()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("signature file not found on server (status 404) — ensure the release was signed")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("server returned status %d for signature request", resp.StatusCode)
+	}
+
+	const maxSigSize = 512 * 1024 // 512 KB — minisig files are tiny (~150 bytes)
+	sigData, err := io.ReadAll(io.LimitReader(resp.Body, maxSigSize))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read signature data: %w", err)
+	}
+
+	return sigData, nil
 }
 
 // copyFile copies a file from src to dst

--- a/agent-source-code/cmd/patchmon-agent/commands/version_update.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/version_update.go
@@ -538,7 +538,7 @@ func verifyMinisignSignature(publicKeyB64 string, data, sigFile []byte) (string,
 	if len(sigRaw) != 74 {
 		return "", fmt.Errorf("invalid signature length: expected 74 bytes, got %d", len(sigRaw))
 	}
-	if sigRaw[0] != 'E' || sigRaw[1] != 'd' {
+	if sigRaw[0] != 'E' || sigRaw[1] != 'D' {
 		return "", fmt.Errorf("unsupported signature algorithm: expected Ed")
 	}
 	// Verify key ID matches

--- a/agent-source-code/cmd/patchmon-agent/commands/version_update_test.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/version_update_test.go
@@ -36,7 +36,7 @@ func signData(t *testing.T, priv ed25519.PrivateKey, keyID, data []byte, trusted
 	sig := ed25519.Sign(priv, h[:])
 
 	// minisign signature: algorithm(2) + keyID(8) + signature(64)
-	sigRaw := append([]byte("Ed"), keyID...)
+	sigRaw := append([]byte("ED"), keyID...)
 	sigRaw = append(sigRaw, sig...)
 	sigB64 := base64.StdEncoding.EncodeToString(sigRaw)
 

--- a/agent-source-code/cmd/patchmon-agent/commands/version_update_test.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/version_update_test.go
@@ -1,0 +1,183 @@
+package commands
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"testing"
+
+	"golang.org/x/crypto/blake2b"
+)
+
+// generateTestKeypair creates a minisign-compatible Ed25519 keypair for testing.
+// Returns (publicKeyB64, privateKey, keyID).
+func generateTestKeypair(t *testing.T) (string, ed25519.PrivateKey, []byte) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate keypair: %v", err)
+	}
+	keyID := make([]byte, 8)
+	if _, err := rand.Read(keyID); err != nil {
+		t.Fatalf("failed to generate key ID: %v", err)
+	}
+	// minisign public key: algorithm(2) + keyID(8) + ed25519PublicKey(32)
+	raw := append([]byte("Ed"), keyID...)
+	raw = append(raw, pub...)
+	return base64.StdEncoding.EncodeToString(raw), priv, keyID
+}
+
+// signData creates a minisign signature file for data using the given private key.
+func signData(t *testing.T, priv ed25519.PrivateKey, keyID, data []byte, trustedComment string) []byte {
+	t.Helper()
+	h := blake2b.Sum512(data)
+	sig := ed25519.Sign(priv, h[:])
+
+	// minisign signature: algorithm(2) + keyID(8) + signature(64)
+	sigRaw := append([]byte("Ed"), keyID...)
+	sigRaw = append(sigRaw, sig...)
+	sigB64 := base64.StdEncoding.EncodeToString(sigRaw)
+
+	// Global signature covers "trusted comment: <comment>\n"
+	tc := fmt.Sprintf("trusted comment: %s", trustedComment)
+	globalSig := ed25519.Sign(priv, []byte(tc+"\n"))
+	globalB64 := base64.StdEncoding.EncodeToString(globalSig)
+
+	sigFile := fmt.Sprintf("untrusted comment: minisign signature\n%s\n%s\n%s\n", sigB64, tc, globalB64)
+	return []byte(sigFile)
+}
+
+func TestVerifyMinisignSignature(t *testing.T) {
+	pubKeyB64, priv, keyID := generateTestKeypair(t)
+	data := []byte("fake agent binary content")
+
+	t.Run("valid signature is accepted", func(t *testing.T) {
+		sigFile := signData(t, priv, keyID, data, "PatchMon Agent 2.0.0")
+		version, err := verifyMinisignSignature(pubKeyB64, data, sigFile)
+		if err != nil {
+			t.Fatalf("expected valid signature to pass, got error: %v", err)
+		}
+		if version != "2.0.0" {
+			t.Errorf("expected version 2.0.0, got %q", version)
+		}
+	})
+
+	t.Run("tampered binary is rejected", func(t *testing.T) {
+		sigFile := signData(t, priv, keyID, data, "PatchMon Agent 2.0.0")
+		tampered := append([]byte(nil), data...)
+		tampered[0] ^= 0xFF
+		_, err := verifyMinisignSignature(pubKeyB64, tampered, sigFile)
+		if err == nil {
+			t.Fatal("expected tampered binary to fail verification")
+		}
+	})
+
+	t.Run("signature from different key is rejected", func(t *testing.T) {
+		_, otherPriv, otherKeyID := generateTestKeypair(t)
+		sigFile := signData(t, otherPriv, otherKeyID, data, "PatchMon Agent 2.0.0")
+		_, err := verifyMinisignSignature(pubKeyB64, data, sigFile)
+		if err == nil {
+			t.Fatal("expected signature from different key to fail verification")
+		}
+	})
+
+	t.Run("invalid public key encoding is rejected", func(t *testing.T) {
+		_, err := verifyMinisignSignature("not-valid-base64!!!", data, []byte("sig"))
+		if err == nil {
+			t.Fatal("expected invalid public key to fail")
+		}
+	})
+
+	t.Run("malformed signature file is rejected", func(t *testing.T) {
+		_, err := verifyMinisignSignature(pubKeyB64, data, []byte("only one line\n"))
+		if err == nil {
+			t.Fatal("expected malformed signature file to fail")
+		}
+	})
+
+	t.Run("version is extracted from trusted comment", func(t *testing.T) {
+		sigFile := signData(t, priv, keyID, data, "PatchMon Agent 1.9.3")
+		version, err := verifyMinisignSignature(pubKeyB64, data, sigFile)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if version != "1.9.3" {
+			t.Errorf("expected version 1.9.3, got %q", version)
+		}
+	})
+}
+
+func TestCompareVersions(t *testing.T) {
+	cases := []struct {
+		v1, v2 string
+		want   int
+	}{
+		{"2.0.0", "1.9.9", 1},
+		{"1.0.0", "1.0.0", 0},
+		{"1.0.0", "2.0.0", -1},
+		{"1.10.0", "1.9.0", 1},
+		{"v2.0.0", "v1.9.9", 1},
+		{"2.0.1", "2.0.0", 1},
+		{"2.0.0", "2.0.1", -1},
+	}
+	for _, c := range cases {
+		got := compareVersions(c.v1, c.v2)
+		if got != c.want {
+			t.Errorf("compareVersions(%q, %q) = %d, want %d", c.v1, c.v2, got, c.want)
+		}
+	}
+}
+
+func TestDowngradeProtection(t *testing.T) {
+	pubKeyB64, priv, keyID := generateTestKeypair(t)
+	data := []byte("fake agent binary content")
+
+	cases := []struct {
+		name           string
+		signedVersion  string
+		currentVersion string
+		wantRejected   bool
+	}{
+		{"newer version is accepted", "2.1.0", "2.0.0", false},
+		{"same version is rejected", "2.0.0", "2.0.0", true},
+		{"older version is rejected", "1.9.0", "2.0.0", true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			sigFile := signData(t, priv, keyID, data, "PatchMon Agent "+c.signedVersion)
+			signedVersion, err := verifyMinisignSignature(pubKeyB64, data, sigFile)
+			if err != nil {
+				t.Fatalf("signature verification failed unexpectedly: %v", err)
+			}
+			rejected := compareVersions(signedVersion, c.currentVersion) <= 0
+			if rejected != c.wantRejected {
+				t.Errorf("downgrade check for signed=%s current=%s: rejected=%v, want %v",
+					c.signedVersion, c.currentVersion, rejected, c.wantRejected)
+			}
+		})
+	}
+}
+
+// Ensure keyID mismatch is caught even when signature is otherwise valid.
+func TestKeyIDMismatch(t *testing.T) {
+	pubKeyB64, priv, _ := generateTestKeypair(t)
+	data := []byte("fake agent binary content")
+
+	// Sign with a different keyID than what's in the public key
+	wrongKeyID := make([]byte, 8)
+	if _, err := rand.Read(wrongKeyID); err != nil {
+		t.Fatalf("failed to generate wrong key ID: %v", err)
+	}
+	sigFile := signData(t, priv, wrongKeyID, data, "PatchMon Agent 2.0.0")
+
+	_, err := verifyMinisignSignature(pubKeyB64, data, sigFile)
+	if err == nil {
+		t.Fatal("expected key ID mismatch to fail verification")
+	}
+	if !bytes.Contains([]byte(err.Error()), []byte("key ID")) {
+		t.Errorf("expected key ID error, got: %v", err)
+	}
+}

--- a/agent-source-code/internal/pkgversion/signing_keys.go
+++ b/agent-source-code/internal/pkgversion/signing_keys.go
@@ -1,0 +1,11 @@
+package pkgversion
+
+// SigningPublicKey is the Ed25519 public key used to verify agent update binaries.
+// It must be set at build time via the PATCHMON_SIGNING_PUBLIC_KEY environment variable:
+//
+//	go build \
+//	  -ldflags="-X patchmon-agent/internal/pkgversion.SigningPublicKey=${PATCHMON_SIGNING_PUBLIC_KEY}" \
+//	  ./cmd/patchmon-agent
+//
+// A build without this variable will refuse to perform updates.
+var SigningPublicKey = ""

--- a/docker/server.Dockerfile
+++ b/docker/server.Dockerfile
@@ -1,7 +1,7 @@
 # Development stage - run with go run, source can be volume-mounted for live reload
 FROM golang:1.26-alpine AS development
 
-RUN apk add --no-cache git ca-certificates tzdata curl node npm
+RUN apk add --no-cache git ca-certificates tzdata curl nodejs npm
 
 WORKDIR /app
 
@@ -12,9 +12,9 @@ COPY --chmod=755 agents-prebuilt/patchmon-agent-* ./agents/
 # Build frontend for embed
 WORKDIR /app/frontend
 COPY frontend/package*.json ./
-RUN npm install --ignore-scripts --legacy-peer-deps 2>/dev/null || true
+RUN npm install --ignore-scripts --legacy-peer-deps
 COPY frontend/ ./
-RUN npm run build 2>/dev/null || mkdir -p dist && echo '<!DOCTYPE html><html><body>Build frontend first</body></html>' > dist/index.html
+RUN npm run build
 
 WORKDIR /app/server
 COPY server-source-code/ ./

--- a/server-source-code/internal/handler/install.go
+++ b/server-source-code/internal/handler/install.go
@@ -811,3 +811,84 @@ func (h *InstallHandler) ServeAgentDownload(w http.ResponseWriter, r *http.Reque
 	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, binaryName))
 	http.ServeContent(w, r, binaryName, info.ModTime(), f)
 }
+
+// ServeAgentSignature handles GET /api/v1/hosts/agent/signature.
+// Requires X-API-ID and X-API-KEY headers. Serves the minisign signature file for the agent binary.
+func (h *InstallHandler) ServeAgentSignature(w http.ResponseWriter, r *http.Request) {
+	defer func() {
+		if err := recover(); err != nil {
+			slog.Error("agent signature handler panic", "error", err, "stack", string(debug.Stack()))
+			JSON(w, http.StatusInternalServerError, map[string]string{"error": "Internal Server Error"})
+		}
+	}()
+
+	apiID := r.Header.Get("X-API-ID")
+	apiKey := r.Header.Get("X-API-KEY")
+	if apiID == "" || apiKey == "" {
+		JSON(w, http.StatusUnauthorized, map[string]string{"error": "API credentials required"})
+		return
+	}
+
+	host, err := h.hosts.GetByApiID(r.Context(), apiID)
+	if err != nil || host == nil {
+		JSON(w, http.StatusUnauthorized, map[string]string{"error": "Invalid API credentials"})
+		return
+	}
+
+	ok, err := util.VerifyAPIKey(apiKey, host.ApiKey)
+	if err != nil || !ok {
+		JSON(w, http.StatusUnauthorized, map[string]string{"error": "Invalid API credentials"})
+		return
+	}
+
+	architecture := r.URL.Query().Get("arch")
+	if architecture == "" {
+		architecture = "amd64"
+	}
+
+	osParam := r.URL.Query().Get("os")
+	if osParam == "" {
+		osParam = "linux"
+	}
+
+	validOss := map[string]bool{"linux": true, "freebsd": true, "windows": true}
+	if !validOss[osParam] {
+		JSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid os. Must be one of: linux, freebsd, windows"})
+		return
+	}
+
+	binaryName := fmt.Sprintf("patchmon-agent-%s-%s", osParam, architecture)
+	if osParam == "windows" {
+		binaryName = binaryName + ".exe"
+	}
+	sigName := binaryName + ".minisig"
+
+	binDir := util.GetAgentsDir()
+	sigPath, err := util.SafePathUnderBase(binDir, sigName)
+	if err != nil {
+		JSON(w, http.StatusNotFound, map[string]string{
+			"error": fmt.Sprintf("Signature file not found for %s/%s. Ensure %s exists in the agent binaries directory.", osParam, architecture, sigName),
+		})
+		return
+	}
+
+	info, err := os.Stat(sigPath)
+	if err != nil || info.IsDir() {
+		JSON(w, http.StatusNotFound, map[string]string{
+			"error": fmt.Sprintf("Signature file not found for %s/%s. Run the signing step for this release.", osParam, architecture),
+		})
+		return
+	}
+
+	f, err := os.Open(sigPath)
+	if err != nil {
+		slog.Error("failed to open agent signature file", "path", sigPath, "error", err)
+		JSON(w, http.StatusInternalServerError, map[string]string{"error": "Failed to serve signature file"})
+		return
+	}
+	defer func() { _ = f.Close() }()
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, sigName))
+	http.ServeContent(w, r, sigName, info.ModTime(), f)
+}

--- a/server-source-code/internal/server/router.go
+++ b/server-source-code/internal/server/router.go
@@ -291,6 +291,7 @@ func NewRouter(ctx context.Context, cfg *config.Config, db *database.DB, rdb *re
 		r.Get("/hosts/remove", installHandler.ServeRemove)
 		r.Get("/hosts/agent/version", installHandler.ServeAgentVersion)
 		r.Get("/hosts/agent/download", installHandler.ServeAgentDownload)
+		r.Get("/hosts/agent/signature", installHandler.ServeAgentSignature)
 		r.With(middleware.RateLimit(redisResolver, resolved, middleware.RateLimitAgent)).Post("/hosts/ping", installHandler.ServePing)
 		r.With(middleware.RateLimit(redisResolver, resolved, middleware.RateLimitAgent), middleware.BodyLimit(resolved.AgentUpdateBodyLimitBytes)).Post("/hosts/update", installHandler.ServeUpdate)
 		r.Post("/hosts/bootstrap/exchange", installHandler.BootstrapExchange)


### PR DESCRIPTION
Closes #754.

The agent auto-update mechanism previously verified downloaded binaries via SHA256, but both the binary and the hash were served by the same server. A compromised server could deliver a malicious binary alongside a matching hash — the check would pass.

This PR adds asymmetric Ed25519 signing via minisign as a second, independent verification layer:

- **Developer signs** agent binaries with a private key at build/release time
- **Agent verifies** the signature using a public key embedded at build time via `-ldflags`
- A compromised server cannot forge a valid signature without the private key

## Changes

- **`internal/pkgversion/signing_keys.go`** — new file; `SigningPublicKey` variable embedded at build time via `-ldflags="-X ...SigningPublicKey=RW..."`. Build without key set aborts.
- **`cmd/patchmon-agent/commands/version_update.go`** — after SHA256 check: fetch `.minisig` from server, verify Ed25519 signature, enforce downgrade protection (version in trusted comment must be strictly greater than current)
- **`cmd/patchmon-agent/commands/version_update_test.go`** — unit tests for signature verification, key ID mismatch, downgrade protection, and version comparison using real Ed25519 keypairs (no external dependencies)
- **`server-source-code/internal/handler/install.go`** — new `ServeAgentSignature` handler serving `patchmon-agent-{os}-{arch}.minisig`
- **`server-source-code/internal/server/router.go`** — route `GET /api/v1/hosts/agent/signature`
- **`Makefile`** — `check-signing-key` guard, `sign-all` target, `PATCHMON_SIGNING_PUBLIC_KEY` / `PATCHMON_SIGNING_PRIVATE_KEY` env vars; local dev build (`make build`) does not require a key
- **`.github/workflows/agent-release.yml`** — minisign install, sign step, `.minisig` upload to release artifacts
- **`docker/server.Dockerfile`** — fix `node` → `nodejs` (correct Alpine package name), remove silent frontend build fallback

## Security model

| Scenario | Key source |
|----------|-----------|
| Official build | Developer public key embedded via CI (`vars.PATCHMON_SIGNING_PUBLIC_KEY`) |
| Self-hosted | Operator builds agent from source with own key via `-ldflags` |

First installation (bootstrap) is not covered by signature verification — known, accepted limitation (chicken-and-egg). All subsequent updates are verified.

## Test plan

- [x] Unit tests pass (`go test ./...`)
- [x] Valid signature accepted, tampered binary rejected, wrong key rejected, key ID mismatch rejected, downgrade rejected
- [x] End-to-end update tested locally: agent 2.0.4 → 2.0.5 via `update-agent` command with real minisign keypair