### PR TITLE
macOS Agent and Patch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ A lightweight agent communicates outbound-only to the PatchMon server on your sc
 - **Outbound-only agents** - no inbound firewall changes, no SSH or WinRM exposure, no VPN required.
 - **Single binary, bundled UI** - one Go binary with the React frontend embedded. One container, no Node runtime at deploy time.
 - **Open source, with a managed cloud** - AGPL v3 licensed, free to self-host. Production hosting available at [patchmon.net/cloud](https://patchmon.net/cloud).
-- **Multi-OS by design** - Linux (apt, dnf, yum, apk, pacman), FreeBSD (pkg) and Windows, handled by the same agent and control plane.
+- **Multi-OS by design** - Linux (apt, dnf, yum, apk, pacman), FreeBSD (pkg), macOS (Homebrew + softwareupdate) and Windows, handled by the same agent and control plane.
 
 ---
 
@@ -155,7 +155,9 @@ Once the server is running:
 2. PatchMon generates a one-line install command with a per-host API key.
 3. Paste the command on the target server (requires root/sudo) and the agent enrols itself.
 
-Supported agent platforms: Linux (amd64, 386, arm64, arm), FreeBSD (amd64, 386, arm64, arm), Windows (amd64, 386, arm64).
+Supported agent platforms: Linux (amd64, 386, arm64, arm), FreeBSD (amd64, 386, arm64, arm), macOS (amd64, arm64), Windows (amd64, 386, arm64).
+
+macOS support includes Homebrew package inventory when `brew` is installed, plus built-in system update discovery and patching via `softwareupdate`.
 
 ### Minimum Server Specs
 
@@ -175,7 +177,7 @@ Supported agent platforms: Linux (amd64, 386, arm64, arm), FreeBSD (amd64, 386, 
 | Frontend | React + Vite, embedded in the `patchmon-server` binary |
 | Database | PostgreSQL 17 |
 | Queue | Redis 7 (Asynq) |
-| Agent | Go binary - Linux, FreeBSD, Windows |
+| Agent | Go binary - Linux, FreeBSD, macOS, Windows |
 
 ```mermaid
 flowchart LR
@@ -187,6 +189,8 @@ flowchart LR
 ```
 
 Agents initiate all communication. HTTPS carries reports and config; WSS (WebSocket over TLS) carries real-time events such as live patch streaming and Docker status.
+
+macOS agents use darwin binaries and can be installed as a launchd service for automatic startup and restart handling.
 Ensure that **Websockets** is supported by your proxy when passing the traffic to PatchMon container :3000 or whichever port you decide to use.
 
 ---

--- a/agent-source-code/Makefile
+++ b/agent-source-code/Makefile
@@ -59,12 +59,12 @@ build-windows:
 .PHONY: build-darwin-amd64
 build-darwin-amd64:
 	@mkdir -p $(BUILD_DIR)
-	@CGO_ENABLED=0 $(GO_CMD) build $(BUILD_FLAGS) $(LDFLAGS) -o $(GOBIN)/$(BINARY_NAME)-darwin-amd64 ./cmd/patchmon-agent
+	@GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 $(GO_CMD) build $(BUILD_FLAGS) $(LDFLAGS) -o $(GOBIN)/$(BINARY_NAME)-darwin-amd64 ./cmd/patchmon-agent
 
 .PHONY: build-darwin-arm64
 build-darwin-arm64:
 	@mkdir -p $(BUILD_DIR)
-	@CGO_ENABLED=0 $(GO_CMD) build $(BUILD_FLAGS) $(LDFLAGS) -o $(GOBIN)/$(BINARY_NAME)-darwin-arm64 ./cmd/patchmon-agent
+	@GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 $(GO_CMD) build $(BUILD_FLAGS) $(LDFLAGS) -o $(GOBIN)/$(BINARY_NAME)-darwin-arm64 ./cmd/patchmon-agent
 
 
 # Build all (Linux + FreeBSD + Windows + Darwin) and copy to backend serve dirs

--- a/agent-source-code/Makefile
+++ b/agent-source-code/Makefile
@@ -55,21 +55,35 @@ build-windows:
 	@GOOS=windows GOARCH=amd64 CGO_ENABLED=0 $(GO_CMD) build $(BUILD_FLAGS) $(LDFLAGS) -o $(GOBIN)/$(BINARY_NAME)-windows-amd64.exe ./cmd/patchmon-agent
 	@GOOS=windows GOARCH=arm64 CGO_ENABLED=0 $(GO_CMD) build $(BUILD_FLAGS) $(LDFLAGS) -o $(GOBIN)/$(BINARY_NAME)-windows-arm64.exe ./cmd/patchmon-agent
 
-# Build all (Linux + FreeBSD + Windows) and copy to backend serve dirs
+# Build Darwin binaries only (amd64, arm64)
+.PHONY: build-darwin-amd64
+build-darwin-amd64:
+	@mkdir -p $(BUILD_DIR)
+	@CGO_ENABLED=0 $(GO_CMD) build $(BUILD_FLAGS) $(LDFLAGS) -o $(GOBIN)/$(BINARY_NAME)-darwin-amd64 ./cmd/patchmon-agent
+
+.PHONY: build-darwin-arm64
+build-darwin-arm64:
+	@mkdir -p $(BUILD_DIR)
+	@CGO_ENABLED=0 $(GO_CMD) build $(BUILD_FLAGS) $(LDFLAGS) -o $(GOBIN)/$(BINARY_NAME)-darwin-arm64 ./cmd/patchmon-agent
+
+
+# Build all (Linux + FreeBSD + Windows + Darwin) and copy to backend serve dirs
 .PHONY: build-all
-build-all: build-linux build-freebsd build-windows
+build-all: build-linux build-freebsd build-windows build-darwin-amd64 build-darwin-arm64
 	@mkdir -p $(AGENTS_REPO) $(AGENTS_DOCKER)
-	@for f in $(GOBIN)/$(BINARY_NAME)-linux-* $(GOBIN)/$(BINARY_NAME)-freebsd-* $(GOBIN)/$(BINARY_NAME)-windows-*.exe; do \
+	@for f in $(GOBIN)/$(BINARY_NAME)-linux-* $(GOBIN)/$(BINARY_NAME)-freebsd-* $(GOBIN)/$(BINARY_NAME)-windows-*.exe $(GOBIN)/$(BINARY_NAME)-darwin-*; do \
 		[ -f "$$f" ] && cp "$$f" $(AGENTS_REPO)/ && cp "$$f" $(AGENTS_DOCKER)/; \
 	done
 	@echo "Done. agents/ and docker/compose_dev_data/agents/ updated."
+
+
 
 # Build all agent binaries into agents-prebuilt/ (for local Docker backend build)
 .PHONY: build-all-for-docker
 build-all-for-docker:
 	@mkdir -p ../agents-prebuilt
 	@$(MAKE) build-all
-	@cp $(BUILD_DIR)/$(BINARY_NAME)-linux-* $(BUILD_DIR)/$(BINARY_NAME)-freebsd-* $(BUILD_DIR)/$(BINARY_NAME)-windows-*.exe ../agents-prebuilt/ 2>/dev/null || true
+	@cp $(BUILD_DIR)/$(BINARY_NAME)-linux-* $(BUILD_DIR)/$(BINARY_NAME)-freebsd-* $(BUILD_DIR)/$(BINARY_NAME)-windows-*.exe $(BUILD_DIR)/$(BINARY_NAME)-darwin-* ../agents-prebuilt/ 2>/dev/null || true
 	@echo "Agent binaries copied to agents-prebuilt/"
 
 # Install dependencies

--- a/agent-source-code/README.md
+++ b/agent-source-code/README.md
@@ -10,6 +10,13 @@ PatchMon's monitoring agent collects and reports package, system, hardware, and 
 - Arch Linux / Manjaro (pacman)
 - Alpine Linux (apk)
 
+**macOS** (amd64, arm64):
+- macOS 12+ / Monterey+ (darwin)
+- Homebrew package inventory and upgrades when `brew` is installed
+- System update inventory and patching via `softwareupdate`
+- `patch_all` applies Homebrew upgrades and available OS updates; non-Homebrew macOS still reports system updates
+- Auto-start across reboots via `patchmon-agent install-service` and launchd
+
 **FreeBSD** (amd64, 386, arm64, arm):
 - FreeBSD
 
@@ -21,12 +28,14 @@ PatchMon's monitoring agent collects and reports package, system, hardware, and 
 ### Binary Installation
 
 1. **Download** the appropriate binary for your OS and architecture from the releases page, or via the install script served by your PatchMon server.
-2. **Make executable** and move to system path (Linux/FreeBSD):
+2. **Make executable** and move to system path (Linux/macOS/FreeBSD):
 
 ```bash
 chmod +x patchmon-agent-linux-amd64
 sudo mv patchmon-agent-linux-amd64 /usr/local/bin/patchmon-agent
 ```
+
+On **macOS**, use the darwin binary name, for example `patchmon-agent-darwin-amd64` or `patchmon-agent-darwin-arm64`.
 
 On **Windows**, download the `.exe` binary and place it in a suitable location (e.g. `C:\Program Files\PatchMon\`).
 
@@ -61,6 +70,10 @@ sudo patchmon-agent config set-api patchmon_1a2b3c4d abcd1234567890abcdef1234567
 ```
 
 This saves the server URL to the config file and the API credentials to the credentials file, then automatically runs a connectivity test to verify everything is working.
+
+> On macOS, the agent uses the same default Linux-style config paths: `/etc/patchmon/config.yml` and `/etc/patchmon/credentials.yml`.
+>
+> `softwareupdate` is required for macOS system update inventory and OS patching; Homebrew is optional but supported when installed.
 
 2. **Test Connectivity** (optional — already tested during setup):
 
@@ -193,9 +206,12 @@ The agent supports the following init systems for service restarts during update
 - **systemd** (most Linux distributions)
 - **OpenRC** (Alpine Linux)
 - **FreeBSD rc.d** (FreeBSD)
+- **launchd** (macOS)
 - **Windows Service** (Windows Service Control Manager via `golang.org/x/sys/windows/svc`)
 
-If no init system is detected, it falls back to a helper script for safe restarts.
+On macOS, install the service with `patchmon-agent install-service`. This writes a LaunchDaemon plist to `/Library/LaunchDaemons/net.patchmon.patchmon-agent.plist`, loads it into launchd, and enables automatic startup across reboots.
+
+If no init system is detected, it falls back to a helper script for safe restarts during updates.
 
 ## Integrations
 

--- a/agent-source-code/cmd/patchmon-agent/commands/serve.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/serve.go
@@ -2597,8 +2597,14 @@ func runPatchBrew(ctx context.Context, httpClient *client.Client, patchRunID, pa
 
 	if patchType == "patch_all" {
 		if dryRun {
-			if err, abort := runStep(true, "brew outdated", "brew outdated failed: %w", "brew", "outdated", "--json=v2"); abort {
-				stepErr = err
+			if consoleUser != "" {
+				if err, abort := runStep(true, "brew outdated", "brew outdated failed: %w", "sudo", "-n", "-u", consoleUser, brewPath, "outdated", "--json=v2"); abort {
+					stepErr = err
+				}
+			} else {
+				if err, abort := runStep(true, "brew outdated", "brew outdated failed: %w", brewPath, "outdated", "--json=v2"); abort {
+					stepErr = err
+				}
 			}
 			if stepErr == nil && softwareUpdateAvailable() {
 				if err, abort := runStep(true, "softwareupdate --list", "softwareupdate --list failed: %w", "softwareupdate", "--list"); abort {

--- a/agent-source-code/cmd/patchmon-agent/commands/serve.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/serve.go
@@ -2213,8 +2213,16 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 		return runPatchWindows(ctx, httpClient, patchRunID, patchType, packageNames, dryRun)
 	}
 
+	if pkgManager == "brew" {
+		return runPatchBrew(ctx, httpClient, patchRunID, patchType, packageNames, dryRun)
+	}
+
+	if pkgManager == "darwin" {
+		return runPatchDarwin(ctx, httpClient, patchRunID, patchType, packageNames, dryRun)
+	}
+
 	if pkgManager != "apt" && pkgManager != "dnf" && pkgManager != "yum" && pkgManager != "pkg" && pkgManager != "pacman" {
-		errMsg := fmt.Sprintf("package manager %q not supported for patching (apt, dnf, yum, pkg, pacman required)", pkgManager)
+		errMsg := fmt.Sprintf("package manager %q not supported for patching (apt, dnf, yum, pkg, pacman, brew required)", pkgManager)
 		_ = httpClient.SendPatchOutput(ctx, patchRunID, "failed", "", errMsg)
 		return fmt.Errorf("%s", errMsg)
 	}
@@ -2495,6 +2503,284 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 	if wasStopped {
 		return fmt.Errorf("patch run stopped by user")
 	}
+	return nil
+}
+
+func runPatchBrew(ctx context.Context, httpClient *client.Client, patchRunID, patchType string, packageNames []string, dryRun bool) error {
+	if _, err := exec.LookPath("brew"); err != nil {
+		errMsg := "brew not found: macOS Homebrew package manager is required for brew patching"
+		_ = httpClient.SendPatchOutput(ctx, patchRunID, "failed", "", errMsg)
+		return fmt.Errorf("%s: %w", errMsg, err)
+	}
+
+	if err := httpClient.SendPatchOutput(ctx, patchRunID, "started", "", ""); err != nil {
+		logger.WithError(err).Warn("Failed to send patch started to server")
+	}
+
+	var fullOutput strings.Builder
+	fullOutput.Grow(8192)
+	sink := newStreamSink(httpClient, patchRunID, &fullOutput)
+
+	runStep := func(isDryRunStep bool, errTag, errFmt, name string, args ...string) (error, bool) {
+		sink.WriteString(formatCmd(name, args...))
+		sink.Flush()
+		err := runStreamingPatchStep(ctx, sink, os.Environ(), name, args...)
+		if err == nil {
+			return nil, false
+		}
+		if isDryRunStep && isDryRunExit1Success(err, fullOutput.String()) {
+			return nil, false
+		}
+		logger.WithError(err).Warn(errTag + " failed")
+		sink.WriteString(fmt.Sprintf("\n[%s error] %s\n", errTag, err.Error()))
+		sink.Flush()
+		return fmt.Errorf(errFmt, err), true
+	}
+
+	brewPackageInstalled := func(pkg string) bool {
+		cmd := exec.Command("brew", "list", "--versions", pkg)
+		return cmd.Run() == nil
+	}
+
+	softwareUpdateAvailable := func() bool {
+		_, err := exec.LookPath("softwareupdate")
+		return err == nil
+	}
+
+	var stepErr error
+
+	if patchType == "patch_all" {
+		if dryRun {
+			if err, abort := runStep(true, "brew outdated", "brew outdated failed: %w", "brew", "outdated", "--json=v2"); abort {
+				stepErr = err
+			}
+			if stepErr == nil && softwareUpdateAvailable() {
+				if err, abort := runStep(true, "softwareupdate --list", "softwareupdate --list failed: %w", "softwareupdate", "--list"); abort {
+					stepErr = err
+				}
+			}
+		} else {
+			if err, abort := runStep(false, "brew update", "brew update failed: %w", "brew", "update"); abort {
+				stepErr = err
+			}
+			if stepErr == nil {
+				if err, abort := runStep(false, "brew upgrade", "brew upgrade failed: %w", "brew", "upgrade"); abort {
+					stepErr = err
+				}
+			}
+			if stepErr == nil && softwareUpdateAvailable() {
+				if err, abort := runStep(false, "softwareupdate --install --all", "softwareupdate --install --all failed: %w", "softwareupdate", "--install", "--all"); abort {
+					stepErr = err
+				}
+			}
+		}
+	} else {
+		if len(packageNames) == 0 {
+			sink.Flush()
+			_ = httpClient.SendPatchOutput(ctx, patchRunID, "failed", fullOutput.String(), "package_names required for patch_package")
+			return fmt.Errorf("package_names required for patch_package")
+		}
+
+		for _, pkg := range packageNames {
+			if stepErr != nil {
+				break
+			}
+			if brewPackageInstalled(pkg) {
+				if dryRun {
+					if err, abort := runStep(true, "brew upgrade --dry-run", "brew upgrade --dry-run failed: %w", "brew", "upgrade", "--dry-run", pkg); abort {
+						stepErr = err
+					}
+				} else {
+					if err, abort := runStep(false, "brew upgrade", "brew upgrade failed: %w", "brew", "upgrade", pkg); abort {
+						stepErr = err
+					}
+				}
+			} else {
+				if dryRun {
+					if err, abort := runStep(true, "brew install --dry-run", "brew install --dry-run failed: %w", "brew", "install", "--dry-run", pkg); abort {
+						stepErr = err
+					}
+				} else {
+					if err, abort := runStep(false, "brew install", "brew install failed: %w", "brew", "install", pkg); abort {
+						stepErr = err
+					}
+				}
+			}
+		}
+	}
+
+	sink.Flush()
+
+	_, wasStopped := patchRunStopped.LoadAndDelete(patchRunID)
+
+	trailer := patchRunTrailer(wasStopped, stepErr, dryRun)
+	sink.WriteString(trailer)
+	sink.Flush()
+
+	finalCtx, finalCancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer finalCancel()
+
+	switch {
+	case wasStopped:
+		if err := httpClient.SendPatchOutput(finalCtx, patchRunID, "cancelled", fullOutput.String(), "stopped by user"); err != nil {
+			logger.WithError(err).Warn("Failed to send patch cancelled output to server")
+		}
+		return fmt.Errorf("patch run stopped by user")
+	case stepErr != nil:
+		if err := httpClient.SendPatchOutput(finalCtx, patchRunID, "failed", fullOutput.String(), stepErr.Error()); err != nil {
+			logger.WithError(err).Warn("Failed to send patch failed output to server")
+		}
+		return stepErr
+	default:
+		stage := "completed"
+		if dryRun {
+			stage = "dry_run_completed"
+		}
+		if err := httpClient.SendPatchOutput(finalCtx, patchRunID, stage, fullOutput.String(), ""); err != nil {
+			logger.WithError(err).Warn("Failed to send patch output to server")
+			return err
+		}
+	}
+
+	if !dryRun && (wasStopped || stepErr == nil) {
+		logger.Info("Sending post-patch report to refresh package lists...")
+		reportDone := make(chan error, 1)
+		go func() { reportDone <- sendReport(false) }()
+		select {
+		case err := <-reportDone:
+			if err != nil {
+				logger.WithError(err).Warn("Post-patch report failed")
+			} else {
+				logger.Info("Post-patch report sent successfully")
+			}
+		case <-time.After(2 * time.Minute):
+			logger.Warn("Post-patch report timed out after 2 minutes; will retry on next scheduled report")
+		}
+	}
+
+	return nil
+}
+
+func runPatchDarwin(ctx context.Context, httpClient *client.Client, patchRunID, patchType string, packageNames []string, dryRun bool) error {
+	if _, err := exec.LookPath("softwareupdate"); err != nil {
+		errMsg := "softwareupdate not found: macOS system update tooling is required"
+		_ = httpClient.SendPatchOutput(ctx, patchRunID, "failed", "", errMsg)
+		return fmt.Errorf("%s: %w", errMsg, err)
+	}
+
+	if err := httpClient.SendPatchOutput(ctx, patchRunID, "started", "", ""); err != nil {
+		logger.WithError(err).Warn("Failed to send patch started to server")
+	}
+
+	var fullOutput strings.Builder
+	fullOutput.Grow(8192)
+	sink := newStreamSink(httpClient, patchRunID, &fullOutput)
+
+	runStep := func(isDryRunStep bool, errTag, errFmt, name string, args ...string) (error, bool) {
+		sink.WriteString(formatCmd(name, args...))
+		sink.Flush()
+		err := runStreamingPatchStep(ctx, sink, os.Environ(), name, args...)
+		if err == nil {
+			return nil, false
+		}
+		if isDryRunStep && isDryRunExit1Success(err, fullOutput.String()) {
+			return nil, false
+		}
+		logger.WithError(err).Warn(errTag + " failed")
+		sink.WriteString(fmt.Sprintf("\n[%s error] %s\n", errTag, err.Error()))
+		sink.Flush()
+		return fmt.Errorf(errFmt, err), true
+	}
+
+	var stepErr error
+
+	if patchType == "patch_all" {
+		if dryRun {
+			if err, abort := runStep(true, "softwareupdate --list", "softwareupdate --list failed: %w", "softwareupdate", "--list"); abort {
+				stepErr = err
+			}
+		} else {
+			if err, abort := runStep(false, "softwareupdate --install --all", "softwareupdate --install --all failed: %w", "softwareupdate", "--install", "--all"); abort {
+				stepErr = err
+			}
+		}
+	} else {
+		if len(packageNames) == 0 {
+			sink.Flush()
+			_ = httpClient.SendPatchOutput(ctx, patchRunID, "failed", fullOutput.String(), "package_names required for patch_package")
+			return fmt.Errorf("package_names required for patch_package")
+		}
+
+		if dryRun {
+			if err, abort := runStep(true, "softwareupdate --list", "softwareupdate --list failed: %w", "softwareupdate", "--list"); abort {
+				stepErr = err
+			}
+		} else {
+			for _, pkg := range packageNames {
+				if stepErr != nil {
+					break
+				}
+				if err, abort := runStep(false, "softwareupdate --install", "softwareupdate --install failed: %w", "softwareupdate", "--install", pkg); abort {
+					stepErr = err
+				}
+			}
+		}
+	}
+
+	sink.Flush()
+
+	needsReboot, rebootReason := system.New(logger).CheckRebootRequired()
+	if !dryRun && needsReboot {
+		fullOutput.WriteString(fmt.Sprintf("\n[Reboot Required] %s\n", rebootReason))
+	}
+
+	_, wasStopped := patchRunStopped.LoadAndDelete(patchRunID)
+
+	trailer := patchRunTrailer(wasStopped, stepErr, dryRun)
+	sink.WriteString(trailer)
+	sink.Flush()
+
+	finalCtx, finalCancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer finalCancel()
+
+	switch {
+	case wasStopped:
+		if err := httpClient.SendPatchOutput(finalCtx, patchRunID, "cancelled", fullOutput.String(), "stopped by user"); err != nil {
+			logger.WithError(err).Warn("Failed to send patch cancelled output to server")
+		}
+		return fmt.Errorf("patch run stopped by user")
+	case stepErr != nil:
+		if err := httpClient.SendPatchOutput(finalCtx, patchRunID, "failed", fullOutput.String(), stepErr.Error()); err != nil {
+			logger.WithError(err).Warn("Failed to send patch failed output to server")
+		}
+		return stepErr
+	default:
+		stage := "completed"
+		if dryRun {
+			stage = "dry_run_completed"
+		}
+		if err := httpClient.SendPatchOutput(finalCtx, patchRunID, stage, fullOutput.String(), ""); err != nil {
+			logger.WithError(err).Warn("Failed to send patch output to server")
+			return err
+		}
+	}
+
+	if !dryRun && (wasStopped || stepErr == nil) {
+		logger.Info("Sending post-patch report to refresh package lists...")
+		reportDone := make(chan error, 1)
+		go func() { reportDone <- sendReport(false) }()
+		select {
+		case err := <-reportDone:
+			if err != nil {
+				logger.WithError(err).Warn("Post-patch report failed")
+			} else {
+				logger.Info("Post-patch report sent successfully")
+			}
+		case <-time.After(2 * time.Minute):
+			logger.Warn("Post-patch report timed out after 2 minutes; will retry on next scheduled report")
+		}
+	}
+
 	return nil
 }
 

--- a/agent-source-code/cmd/patchmon-agent/commands/serve.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/serve.go
@@ -2560,6 +2560,12 @@ func runPatchBrew(ctx context.Context, httpClient *client.Client, patchRunID, pa
 		return cmd.Run() == nil
 	}
 
+	brewFormulaExists := func(pkg string) bool {
+		cmd := exec.Command("sudo", "-u", sudoUser, "brew", "info", pkg)
+		cmd.Env = brewEnv
+		return cmd.Run() == nil
+	}
+
 	softwareUpdateAvailable := func() bool {
 		_, err := exec.LookPath("softwareupdate")
 		return err == nil
@@ -2613,13 +2619,25 @@ func runPatchBrew(ctx context.Context, httpClient *client.Client, patchRunID, pa
 						stepErr = err
 					}
 				}
-			} else {
+			} else if brewFormulaExists(pkg) {
 				if dryRun {
 					if err, abort := runStep(true, "brew install --dry-run", "brew install --dry-run failed: %w", "brew", "install", "--dry-run", pkg); abort {
 						stepErr = err
 					}
 				} else {
 					if err, abort := runStep(false, "brew install", "brew install failed: %w", "brew", "install", pkg); abort {
+						stepErr = err
+					}
+				}
+			} else {
+				// Assume softwareupdate package
+				if dryRun {
+					// For dry-run, check if softwareupdate lists it
+					if err, abort := runStep(true, "softwareupdate --list", "softwareupdate --list failed: %w", "softwareupdate", "--list"); abort {
+						stepErr = err
+					}
+				} else {
+					if err, abort := runStep(false, "softwareupdate --install", "softwareupdate --install failed: %w", "softwareupdate", "--install", pkg); abort {
 						stepErr = err
 					}
 				}

--- a/agent-source-code/cmd/patchmon-agent/commands/serve.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/serve.go
@@ -2507,15 +2507,26 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 }
 
 func runPatchBrew(ctx context.Context, httpClient *client.Client, patchRunID, patchType string, packageNames []string, dryRun bool) error {
-	if _, err := exec.LookPath("brew"); err != nil {
+	brewPath := ""
+	for _, p := range []string{"/opt/homebrew/bin/brew", "/usr/local/bin/brew", "/opt/local/bin/brew"} {
+		if _, err := os.Stat(p); err == nil {
+			brewPath = p
+			break
+		}
+	}
+	if brewPath == "" {
+		if p, err := exec.LookPath("brew"); err == nil {
+			brewPath = p
+		}
+	}
+	if brewPath == "" {
 		errMsg := "brew not found: macOS Homebrew package manager is required for brew patching"
 		_ = httpClient.SendPatchOutput(ctx, patchRunID, "failed", "", errMsg)
-		return fmt.Errorf("%s: %w", errMsg, err)
+		return fmt.Errorf(errMsg)
 	}
 
-	sudoUser := getConsoleUser()
-
 	brewEnv := append(os.Environ(),
+		"HOMEBREW_ALLOW_RUN_AS_ROOT=1",
 		"HOMEBREW_NO_AUTO_UPDATE=1",
 	)
 
@@ -2528,14 +2539,13 @@ func runPatchBrew(ctx context.Context, httpClient *client.Client, patchRunID, pa
 	sink := newStreamSink(httpClient, patchRunID, &fullOutput)
 
 	runStep := func(isDryRunStep bool, errTag, errFmt, name string, args ...string) (error, bool) {
-		// For brew commands, run as the original user via sudo
+		execName := name
 		if name == "brew" {
-			args = append([]string{"-u", sudoUser, "brew"}, args...)
-			name = "sudo"
+			execName = brewPath
 		}
 		sink.WriteString(formatCmd(name, args...))
 		sink.Flush()
-		err := runStreamingPatchStep(ctx, sink, brewEnv, name, args...)
+		err := runStreamingPatchStep(ctx, sink, brewEnv, execName, args...)
 		if err == nil {
 			return nil, false
 		}
@@ -2549,13 +2559,13 @@ func runPatchBrew(ctx context.Context, httpClient *client.Client, patchRunID, pa
 	}
 
 	brewPackageInstalled := func(pkg string) bool {
-		cmd := exec.Command("sudo", "-u", sudoUser, "brew", "list", "--versions", pkg)
+		cmd := exec.Command(brewPath, "list", "--versions", pkg)
 		cmd.Env = brewEnv
 		return cmd.Run() == nil
 	}
 
 	brewFormulaExists := func(pkg string) bool {
-		cmd := exec.Command("sudo", "-u", sudoUser, "brew", "info", pkg)
+		cmd := exec.Command(brewPath, "info", pkg)
 		cmd.Env = brewEnv
 		return cmd.Run() == nil
 	}

--- a/agent-source-code/cmd/patchmon-agent/commands/serve.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/serve.go
@@ -1185,7 +1185,7 @@ var (
 	// Rule IDs: same as profile IDs (e.g., xccdf_org.ssgproject.content_rule_audit_rules_...)
 	validRuleIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_.\-]+$`)
 	// APT package names: alphanumeric, dots, plus, minus, underscores (no path/command injection)
-	validAptPackagePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9.+-_@]*$`)
+	validAptPackagePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9.+\-_ @]*$`)
 	// Docker image names: alphanumeric, slashes, colons, dots, hyphens, underscores (e.g., ubuntu:22.04, myregistry.io/app:v1)
 	validDockerImagePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.\-/:@]*$`)
 	// Docker container names: alphanumeric, underscores, hyphens (e.g., my-container, container_1)
@@ -2513,8 +2513,15 @@ func runPatchBrew(ctx context.Context, httpClient *client.Client, patchRunID, pa
 		return fmt.Errorf("%s: %w", errMsg, err)
 	}
 
+	sudoUser := os.Getenv("SUDO_USER")
+	if sudoUser == "" {
+		sudoUser = os.Getenv("USER")
+	}
+	if sudoUser == "" {
+		sudoUser = "root"
+	}
+
 	brewEnv := append(os.Environ(),
-		"HOMEBREW_ALLOW_RUN_AS_ROOT=1",
 		"HOMEBREW_NO_AUTO_UPDATE=1",
 	)
 
@@ -2527,6 +2534,11 @@ func runPatchBrew(ctx context.Context, httpClient *client.Client, patchRunID, pa
 	sink := newStreamSink(httpClient, patchRunID, &fullOutput)
 
 	runStep := func(isDryRunStep bool, errTag, errFmt, name string, args ...string) (error, bool) {
+		// For brew commands, run as the original user via sudo
+		if name == "brew" {
+			args = append([]string{"-u", sudoUser, "brew"}, args...)
+			name = "sudo"
+		}
 		sink.WriteString(formatCmd(name, args...))
 		sink.Flush()
 		err := runStreamingPatchStep(ctx, sink, brewEnv, name, args...)
@@ -2543,7 +2555,7 @@ func runPatchBrew(ctx context.Context, httpClient *client.Client, patchRunID, pa
 	}
 
 	brewPackageInstalled := func(pkg string) bool {
-		cmd := exec.Command("brew", "list", "--versions", pkg)
+		cmd := exec.Command("sudo", "-u", sudoUser, "brew", "list", "--versions", pkg)
 		cmd.Env = brewEnv
 		return cmd.Run() == nil
 	}

--- a/agent-source-code/cmd/patchmon-agent/commands/serve.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/serve.go
@@ -1185,7 +1185,7 @@ var (
 	// Rule IDs: same as profile IDs (e.g., xccdf_org.ssgproject.content_rule_audit_rules_...)
 	validRuleIDPattern = regexp.MustCompile(`^[a-zA-Z0-9_.\-]+$`)
 	// APT package names: alphanumeric, dots, plus, minus, underscores (no path/command injection)
-	validAptPackagePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9.+-_]*$`)
+	validAptPackagePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9.+-_@]*$`)
 	// Docker image names: alphanumeric, slashes, colons, dots, hyphens, underscores (e.g., ubuntu:22.04, myregistry.io/app:v1)
 	validDockerImagePattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.\-/:@]*$`)
 	// Docker container names: alphanumeric, underscores, hyphens (e.g., my-container, container_1)

--- a/agent-source-code/cmd/patchmon-agent/commands/serve.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/serve.go
@@ -2525,8 +2525,9 @@ func runPatchBrew(ctx context.Context, httpClient *client.Client, patchRunID, pa
 		return fmt.Errorf(errMsg)
 	}
 
+	consoleUser := getConsoleUser()
+
 	brewEnv := append(os.Environ(),
-		"HOMEBREW_ALLOW_RUN_AS_ROOT=1",
 		"HOMEBREW_NO_AUTO_UPDATE=1",
 	)
 
@@ -2538,14 +2539,31 @@ func runPatchBrew(ctx context.Context, httpClient *client.Client, patchRunID, pa
 	fullOutput.Grow(8192)
 	sink := newStreamSink(httpClient, patchRunID, &fullOutput)
 
+	brewCmd := func(args ...string) *exec.Cmd {
+		if consoleUser != "" {
+			return exec.Command("sudo", append([]string{"-u", consoleUser, brewPath}, args...)...)
+		}
+		return exec.Command(brewPath, args...)
+	}
+
 	runStep := func(isDryRunStep bool, errTag, errFmt, name string, args ...string) (error, bool) {
-		execName := name
+		var execName string
+		var execArgs []string
 		if name == "brew" {
-			execName = brewPath
+			if consoleUser != "" {
+				execName = "sudo"
+				execArgs = append([]string{"-u", consoleUser, brewPath}, args...)
+			} else {
+				execName = brewPath
+				execArgs = args
+			}
+		} else {
+			execName = name
+			execArgs = args
 		}
 		sink.WriteString(formatCmd(name, args...))
 		sink.Flush()
-		err := runStreamingPatchStep(ctx, sink, brewEnv, execName, args...)
+		err := runStreamingPatchStep(ctx, sink, brewEnv, execName, execArgs...)
 		if err == nil {
 			return nil, false
 		}
@@ -2559,13 +2577,13 @@ func runPatchBrew(ctx context.Context, httpClient *client.Client, patchRunID, pa
 	}
 
 	brewPackageInstalled := func(pkg string) bool {
-		cmd := exec.Command(brewPath, "list", "--versions", pkg)
+		cmd := brewCmd("list", "--versions", pkg)
 		cmd.Env = brewEnv
 		return cmd.Run() == nil
 	}
 
 	brewFormulaExists := func(pkg string) bool {
-		cmd := exec.Command(brewPath, "info", pkg)
+		cmd := brewCmd("info", pkg)
 		cmd.Env = brewEnv
 		return cmd.Run() == nil
 	}

--- a/agent-source-code/cmd/patchmon-agent/commands/serve.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/serve.go
@@ -2513,6 +2513,11 @@ func runPatchBrew(ctx context.Context, httpClient *client.Client, patchRunID, pa
 		return fmt.Errorf("%s: %w", errMsg, err)
 	}
 
+	brewEnv := append(os.Environ(),
+		"HOMEBREW_ALLOW_RUN_AS_ROOT=1",
+		"HOMEBREW_NO_AUTO_UPDATE=1",
+	)
+
 	if err := httpClient.SendPatchOutput(ctx, patchRunID, "started", "", ""); err != nil {
 		logger.WithError(err).Warn("Failed to send patch started to server")
 	}
@@ -2524,7 +2529,7 @@ func runPatchBrew(ctx context.Context, httpClient *client.Client, patchRunID, pa
 	runStep := func(isDryRunStep bool, errTag, errFmt, name string, args ...string) (error, bool) {
 		sink.WriteString(formatCmd(name, args...))
 		sink.Flush()
-		err := runStreamingPatchStep(ctx, sink, os.Environ(), name, args...)
+		err := runStreamingPatchStep(ctx, sink, brewEnv, name, args...)
 		if err == nil {
 			return nil, false
 		}
@@ -2539,6 +2544,7 @@ func runPatchBrew(ctx context.Context, httpClient *client.Client, patchRunID, pa
 
 	brewPackageInstalled := func(pkg string) bool {
 		cmd := exec.Command("brew", "list", "--versions", pkg)
+		cmd.Env = brewEnv
 		return cmd.Run() == nil
 	}
 

--- a/agent-source-code/cmd/patchmon-agent/commands/serve.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/serve.go
@@ -2513,13 +2513,7 @@ func runPatchBrew(ctx context.Context, httpClient *client.Client, patchRunID, pa
 		return fmt.Errorf("%s: %w", errMsg, err)
 	}
 
-	sudoUser := os.Getenv("SUDO_USER")
-	if sudoUser == "" {
-		sudoUser = os.Getenv("USER")
-	}
-	if sudoUser == "" {
-		sudoUser = "root"
-	}
+	sudoUser := getConsoleUser()
 
 	brewEnv := append(os.Environ(),
 		"HOMEBREW_NO_AUTO_UPDATE=1",

--- a/agent-source-code/cmd/patchmon-agent/commands/service_install.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/service_install.go
@@ -1,0 +1,124 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	launchdServiceLabel = "net.patchmon.patchmon-agent"
+	launchdPlistPath    = "/Library/LaunchDaemons/net.patchmon.patchmon-agent.plist"
+	launchdLogDir       = "/etc/patchmon/logs"
+)
+
+var installServiceCmd = &cobra.Command{
+	Use:   "install-service",
+	Short: "Install patchmon-agent as a launchd service on macOS",
+	Long: `Install the patchmon-agent launchd service on macOS.
+This command writes a system LaunchDaemon plist to /Library/LaunchDaemons and loads it so the agent
+starts automatically on boot and restarts if it exits unexpectedly.`,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		if runtime.GOOS != "darwin" {
+			return fmt.Errorf("install-service is only supported on macOS")
+		}
+		if err := checkRoot(); err != nil {
+			return err
+		}
+		return installLaunchdService()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(installServiceCmd)
+}
+
+func installLaunchdService() error {
+	execPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("failed to determine agent executable path: %w", err)
+	}
+	execPath, err = filepath.EvalSymlinks(execPath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve executable symlink: %w", err)
+	}
+	if _, err := os.Stat(execPath); err != nil {
+		return fmt.Errorf("agent executable not found at %s: %w", execPath, err)
+	}
+
+	if _, err := exec.LookPath("launchctl"); err != nil {
+		return fmt.Errorf("launchctl not found: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(launchdPlistPath), 0755); err != nil {
+		return fmt.Errorf("failed to create LaunchDaemons directory: %w", err)
+	}
+	if err := os.MkdirAll(launchdLogDir, 0750); err != nil {
+		return fmt.Errorf("failed to create log directory %s: %w", launchdLogDir, err)
+	}
+
+	plist := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>%s</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>%s</string>
+        <string>serve</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>%s/patchmon-agent.out.log</string>
+    <key>StandardErrorPath</key>
+    <string>%s/patchmon-agent.err.log</string>
+    <key>WorkingDirectory</key>
+    <string>/</string>
+</dict>
+</plist>
+`, launchdServiceLabel, execPath, launchdLogDir, launchdLogDir)
+
+	if err := os.WriteFile(launchdPlistPath, []byte(plist), 0644); err != nil {
+		return fmt.Errorf("failed to write launchd plist: %w", err)
+	}
+
+	if err := os.Chmod(launchdPlistPath, 0644); err != nil {
+		return fmt.Errorf("failed to set permissions on launchd plist: %w", err)
+	}
+
+	if err := bootstrapLaunchdService(); err != nil {
+		return err
+	}
+
+	logger.Infof("Installed launchd service %s", launchdServiceLabel)
+	return nil
+}
+
+func bootstrapLaunchdService() error {
+	if exec.Command("launchctl", "print", "system/"+launchdServiceLabel).Run() == nil {
+		return kickstartLaunchdService()
+	}
+
+	if err := exec.Command("launchctl", "bootstrap", "system", launchdPlistPath).Run(); err != nil {
+		if err2 := exec.Command("launchctl", "load", "-w", launchdPlistPath).Run(); err2 != nil {
+			return fmt.Errorf("failed to bootstrap or load launchd service: %v, %v", err, err2)
+		}
+	}
+
+	return kickstartLaunchdService()
+}
+
+func kickstartLaunchdService() error {
+	if err := exec.Command("launchctl", "kickstart", "-k", "system/"+launchdServiceLabel).Run(); err != nil {
+		return fmt.Errorf("failed to kickstart launchd service: %w", err)
+	}
+	return nil
+}

--- a/agent-source-code/cmd/patchmon-agent/commands/sysproc_darwin.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/sysproc_darwin.go
@@ -2,10 +2,34 @@
 
 package commands
 
-import "syscall"
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+)
 
 // sysProcAttrForDetach returns SysProcAttr to detach a child process (new session).
 // Darwin: Setsid creates a new session so the child survives parent exit.
 func sysProcAttrForDetach() *syscall.SysProcAttr {
 	return &syscall.SysProcAttr{Setsid: true}
+}
+
+// getConsoleUser returns the logged-in console user. Falls back to
+// stat /dev/console so it works when running as a launchd service
+// (where SUDO_USER is not set).
+func getConsoleUser() string {
+	if u := os.Getenv("SUDO_USER"); u != "" {
+		return u
+	}
+	out, err := exec.Command("stat", "-f", "%Su", "/dev/console").Output()
+	if err == nil {
+		if u := strings.TrimSpace(string(out)); u != "" && u != "root" {
+			return u
+		}
+	}
+	if u := os.Getenv("USER"); u != "" {
+		return u
+	}
+	return "root"
 }

--- a/agent-source-code/cmd/patchmon-agent/commands/sysproc_darwin.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/sysproc_darwin.go
@@ -3,9 +3,6 @@
 package commands
 
 import (
-	"os"
-	"os/exec"
-	"strings"
 	"syscall"
 )
 
@@ -13,23 +10,4 @@ import (
 // Darwin: Setsid creates a new session so the child survives parent exit.
 func sysProcAttrForDetach() *syscall.SysProcAttr {
 	return &syscall.SysProcAttr{Setsid: true}
-}
-
-// getConsoleUser returns the logged-in console user. Falls back to
-// stat /dev/console so it works when running as a launchd service
-// (where SUDO_USER is not set).
-func getConsoleUser() string {
-	if u := os.Getenv("SUDO_USER"); u != "" {
-		return u
-	}
-	out, err := exec.Command("stat", "-f", "%Su", "/dev/console").Output()
-	if err == nil {
-		if u := strings.TrimSpace(string(out)); u != "" && u != "root" {
-			return u
-		}
-	}
-	if u := os.Getenv("USER"); u != "" {
-		return u
-	}
-	return "root"
 }

--- a/agent-source-code/cmd/patchmon-agent/commands/sysproc_darwin.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/sysproc_darwin.go
@@ -3,6 +3,9 @@
 package commands
 
 import (
+	"os"
+	"os/exec"
+	"strings"
 	"syscall"
 )
 
@@ -10,4 +13,22 @@ import (
 // Darwin: Setsid creates a new session so the child survives parent exit.
 func sysProcAttrForDetach() *syscall.SysProcAttr {
 	return &syscall.SysProcAttr{Setsid: true}
+}
+
+// getConsoleUser returns the logged-in GUI user. Falls back to stat /dev/console
+// so it works when running as a launchd service (where SUDO_USER is not set).
+func getConsoleUser() string {
+	if u := os.Getenv("SUDO_USER"); u != "" {
+		return u
+	}
+	out, err := exec.Command("stat", "-f", "%Su", "/dev/console").Output()
+	if err == nil {
+		if u := strings.TrimSpace(string(out)); u != "" && u != "root" {
+			return u
+		}
+	}
+	if u := os.Getenv("USER"); u != "" && u != "root" {
+		return u
+	}
+	return ""
 }

--- a/agent-source-code/cmd/patchmon-agent/commands/version_update.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/version_update.go
@@ -664,6 +664,73 @@ rm -f "$0"
 	}
 
 	// Detect init system and use appropriate restart command
+	if runtime.GOOS == "darwin" {
+		logger.Debug("Detected macOS, scheduling launchd service restart via helper script")
+
+		if err := os.MkdirAll("/etc/patchmon", 0700); err != nil {
+			logger.WithError(err).Warn("Failed to create /etc/patchmon directory, will try anyway")
+		}
+
+		helperScript := `#!/bin/sh
+# Wait a moment for the current process to exit
+sleep 2
+if launchctl print system/net.patchmon.patchmon-agent >/dev/null 2>&1; then
+    launchctl kickstart -k system/net.patchmon.patchmon-agent 2>&1
+elif [ -f "/Library/LaunchDaemons/net.patchmon.patchmon-agent.plist" ]; then
+    launchctl bootstrap system /Library/LaunchDaemons/net.patchmon.patchmon-agent.plist 2>&1 || true
+    launchctl kickstart -k system/net.patchmon.patchmon-agent 2>&1
+fi
+rm -f "$0"
+`
+
+		randomBytes := make([]byte, 8)
+		if _, err := rand.Read(randomBytes); err != nil {
+			randomBytes = []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+		}
+		helperPath := filepath.Join("/etc/patchmon", fmt.Sprintf("restart-%s.sh", hex.EncodeToString(randomBytes)))
+		dirInfo, err := os.Lstat("/etc/patchmon")
+		if err == nil && dirInfo.Mode()&os.ModeSymlink != 0 {
+			logger.Warn("Security: /etc/patchmon is a symlink, refusing to create helper script")
+			os.Exit(0)
+		}
+
+		file, err := os.OpenFile(helperPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0700)
+		if err != nil {
+			logger.WithError(err).Warn("Failed to create restart helper script, exiting to let launchd manage restart")
+			os.Exit(0)
+		}
+		if _, err := file.WriteString(helperScript); err != nil {
+			_ = file.Close()
+			_ = os.Remove(helperPath)
+			os.Exit(0)
+		}
+		_ = file.Close()
+		fileInfo, err := os.Lstat(helperPath)
+		if err != nil || fileInfo.Mode()&os.ModeSymlink != 0 {
+			_ = os.Remove(helperPath)
+			os.Exit(0)
+		}
+
+		var cmd *exec.Cmd
+		if _, nohupErr := exec.LookPath("nohup"); nohupErr == nil {
+			cmd = exec.Command("nohup", helperPath)
+		} else {
+			cmd = exec.Command("/bin/sh", helperPath)
+		}
+		cmd.Stdout = nil
+		cmd.Stderr = nil
+		cmd.SysProcAttr = sysProcAttrForDetach()
+		if err := cmd.Start(); err != nil {
+			_ = os.Remove(helperPath)
+			logger.WithError(err).Warn("Failed to start launchd restart helper, exiting to let launchd manage restart")
+			os.Exit(0)
+		}
+		logger.Info("Scheduled launchd service restart via helper script, exiting now...")
+		time.Sleep(500 * time.Millisecond)
+		os.Exit(0)
+		return nil
+	}
+
 	if _, err := exec.LookPath("systemctl"); err == nil {
 		// Systemd is available
 		// Since we're running inside the service, we can't stop ourselves directly

--- a/agent-source-code/internal/network/network.go
+++ b/agent-source-code/internal/network/network.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -74,6 +75,12 @@ func (m *Manager) getGatewayIP() string {
 	// If no IPv4 gateway found, try IPv6
 	if gw := m.getIPv6GatewayIP(); gw != "" {
 		return gw
+	}
+
+	if runtime.GOOS == "darwin" {
+		if gw := m.getGatewayViaRouteGet(false); gw != "" {
+			return gw
+		}
 	}
 
 	return ""
@@ -185,6 +192,38 @@ func (m *Manager) getGatewayViaNetstat(ipv6 bool) string {
 		}
 	}
 
+	if runtime.GOOS == "darwin" {
+		return m.getGatewayViaRouteGet(ipv6)
+	}
+
+	return ""
+}
+
+func (m *Manager) getGatewayViaRouteGet(ipv6 bool) string {
+	args := []string{"get", "default"}
+	if ipv6 {
+		args = []string{"get", "-inet6", "default"}
+	}
+
+	output, err := exec.Command("route", args...).Output()
+	if err != nil {
+		m.logger.WithError(err).Debug("Failed to run route get default")
+		return ""
+	}
+
+	for _, line := range strings.Split(string(output), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		if fields[0] == "gateway:" {
+			gateway := fields[1]
+			if net.ParseIP(gateway) != nil {
+				return gateway
+			}
+		}
+	}
+
 	return ""
 }
 
@@ -245,17 +284,52 @@ func (m *Manager) getDNSServers() []string {
 
 	// Read /etc/resolv.conf
 	data, err := os.ReadFile("/etc/resolv.conf")
-	if err != nil {
+	if err == nil {
+		for line := range strings.SplitSeq(string(data), "\n") {
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(line, "nameserver") {
+				fields := strings.Fields(line)
+				if len(fields) > 1 {
+					servers = append(servers, fields[1])
+				}
+			}
+		}
+	} else {
 		m.logger.WithError(err).Warn("Failed to read /etc/resolv.conf")
+	}
+
+	if len(servers) == 0 && runtime.GOOS == "darwin" {
+		servers = m.getDNSServersDarwin()
+	}
+
+	return servers
+}
+
+func (m *Manager) getDNSServersDarwin() []string {
+	servers := make([]string, 0, 4)
+	if _, err := exec.LookPath("scutil"); err != nil {
 		return servers
 	}
 
-	for line := range strings.SplitSeq(string(data), "\n") {
+	out, err := exec.Command("scutil", "--dns").Output()
+	if err != nil {
+		m.logger.WithError(err).Debug("Failed to run scutil --dns")
+		return servers
+	}
+
+	seen := make(map[string]struct{})
+	for _, line := range strings.Split(string(out), "\n") {
 		line = strings.TrimSpace(line)
 		if strings.HasPrefix(line, "nameserver") {
-			fields := strings.Fields(line)
-			if len(fields) > 1 {
-				servers = append(servers, fields[1])
+			parts := strings.Fields(line)
+			if len(parts) >= 3 {
+				server := parts[len(parts)-1]
+				if net.ParseIP(server) != nil {
+					if _, exists := seen[server]; !exists {
+						seen[server] = struct{}{}
+						servers = append(servers, server)
+					}
+				}
 			}
 		}
 	}
@@ -383,29 +457,55 @@ func (m *Manager) gatewayTablesByInterface() (ipv4, ipv6 map[string]string) {
 	ipv4 = make(map[string]string)
 	ipv6 = make(map[string]string)
 
-	if _, err := exec.LookPath("ip"); err != nil {
+	if _, err := exec.LookPath("ip"); err == nil {
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			out, err := exec.Command("ip", "route", "show").Output()
+			if err != nil {
+				return
+			}
+			parseIPRouteDefaults(string(out), ipv4)
+		}()
+		go func() {
+			defer wg.Done()
+			out, err := exec.Command("ip", "-6", "route", "show").Output()
+			if err != nil {
+				return
+			}
+			parseIPRouteDefaults(string(out), ipv6)
+		}()
+		wg.Wait()
 		return ipv4, ipv6
 	}
 
-	var wg sync.WaitGroup
-	wg.Add(2)
-	go func() {
-		defer wg.Done()
-		out, err := exec.Command("ip", "route", "show").Output()
-		if err != nil {
-			return
+	if runtime.GOOS == "darwin" {
+		return m.gatewayTablesByInterfaceDarwin()
+	}
+
+	return ipv4, ipv6
+}
+
+func (m *Manager) gatewayTablesByInterfaceDarwin() (map[string]string, map[string]string) {
+	ipv4 := make(map[string]string)
+	ipv6 := make(map[string]string)
+
+	out, err := exec.Command("route", "get", "default").Output()
+	if err == nil {
+		iface, gateway := parseRouteGetOutput(string(out))
+		if iface != "" && gateway != "" {
+			ipv4[iface] = gateway
 		}
-		parseIPRouteDefaults(string(out), ipv4)
-	}()
-	go func() {
-		defer wg.Done()
-		out, err := exec.Command("ip", "-6", "route", "show").Output()
-		if err != nil {
-			return
+	}
+
+	out6, err := exec.Command("route", "get", "-inet6", "default").Output()
+	if err == nil {
+		iface, gateway := parseRouteGetOutput(string(out6))
+		if iface != "" && gateway != "" {
+			ipv6[iface] = gateway
 		}
-		parseIPRouteDefaults(string(out), ipv6)
-	}()
-	wg.Wait()
+	}
 
 	return ipv4, ipv6
 }
@@ -448,6 +548,10 @@ func parseIPRouteDefaults(output string, out map[string]string) {
 // default route. Used as a fallback when the batched `ip route` call didn't
 // populate the interface (e.g. `ip` binary unavailable).
 func (m *Manager) getInterfaceGatewayFromProc(interfaceName string) string {
+	if runtime.GOOS == "darwin" {
+		return m.getInterfaceGatewayDarwin(interfaceName)
+	}
+
 	data, err := os.ReadFile("/proc/net/route")
 	if err != nil {
 		return ""
@@ -461,6 +565,37 @@ func (m *Manager) getInterfaceGatewayFromProc(interfaceName string) string {
 		}
 	}
 	return ""
+}
+
+func (m *Manager) getInterfaceGatewayDarwin(interfaceName string) string {
+	out, err := exec.Command("route", "get", "default").Output()
+	if err != nil {
+		return ""
+	}
+
+	iface, gateway := parseRouteGetOutput(string(out))
+	if iface == interfaceName {
+		return gateway
+	}
+
+	return ""
+}
+
+func parseRouteGetOutput(output string) (string, string) {
+	var iface, gateway string
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		if fields[0] == "interface:" {
+			iface = fields[1]
+		}
+		if fields[0] == "gateway:" {
+			gateway = fields[1]
+		}
+	}
+	return iface, gateway
 }
 
 // getLinkSpeedAndDuplex gets the link speed (in Mbps) and duplex mode for an interface

--- a/agent-source-code/internal/packages/packages.go
+++ b/agent-source-code/internal/packages/packages.go
@@ -68,6 +68,10 @@ func (m *Manager) GetPackages() ([]models.Package, error) {
 		return m.pacmanManager.GetPackages()
 	case "pkg":
 		return m.freebsdManager.GetPackages()
+	case "brew":
+		return CollectPackages()
+	case "darwin":
+		return CollectDarwinPackages()
 	default:
 		return nil, fmt.Errorf("unsupported package manager: %s", packageManager)
 	}
@@ -122,6 +126,14 @@ func (m *Manager) DetectPackageManager() string {
 	// Check for Pacman
 	if _, err := exec.LookPath("pacman"); err == nil {
 		return "pacman"
+	}
+
+	// Check for Homebrew on macOS
+	if runtime.GOOS == "darwin" {
+		if _, err := exec.LookPath("brew"); err == nil {
+			return "brew"
+		}
+		return "darwin"
 	}
 
 	return "unknown"

--- a/agent-source-code/internal/packages/packages.go
+++ b/agent-source-code/internal/packages/packages.go
@@ -130,7 +130,7 @@ func (m *Manager) DetectPackageManager() string {
 
 	// Check for Homebrew on macOS
 	if runtime.GOOS == "darwin" {
-		if _, err := exec.LookPath("brew"); err == nil {
+		if findBrewBinary() != "" {
 			return "brew"
 		}
 		return "darwin"
@@ -151,6 +151,18 @@ func GetPkgBinaryPath() string {
 		}
 	}
 	return "pkg"
+}
+
+func findBrewBinary() string {
+	if path, err := exec.LookPath("brew"); err == nil {
+		return path
+	}
+	for _, p := range []string{"/opt/homebrew/bin/brew", "/usr/local/bin/brew", "/opt/local/bin/brew"} {
+		if info, err := os.Stat(p); err == nil && info.Mode().IsRegular() && (info.Mode()&0111) != 0 {
+			return p
+		}
+	}
+	return ""
 }
 
 // stringMapToPackageMap converts name->version map to name->Package for package managers

--- a/agent-source-code/internal/packages/packages_brew_stub.go
+++ b/agent-source-code/internal/packages/packages_brew_stub.go
@@ -1,0 +1,12 @@
+//go:build !darwin
+
+package packages
+
+import (
+    "fmt"
+    "patchmon-agent/pkg/models"
+)
+
+func CollectPackages() ([]models.Package, error) {
+    return nil, fmt.Errorf("brew package collection unsupported on non-darwin platforms")
+}

--- a/agent-source-code/internal/packages/packages_darwin.go
+++ b/agent-source-code/internal/packages/packages_darwin.go
@@ -1,0 +1,196 @@
+//go:build darwin
+
+package packages
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"patchmon-agent/pkg/models"
+)
+
+// BrewOutdatedEntry matches the JSON output of `brew outdated --json=v2`
+type BrewOutdatedEntry struct {
+	Name              string   `json:"name"`
+	InstalledVersions []string `json:"installed_versions"`
+	CurrentVersion    string   `json:"current_version"`
+	Pinned            bool     `json:"pinned"`
+}
+
+type BrewOutdatedResponse struct {
+	Formulae []BrewOutdatedEntry `json:"formulae"`
+	Casks    []BrewOutdatedEntry `json:"casks"`
+}
+
+// CollectPackages returns all installed Homebrew packages,
+// flagging any that have updates available.
+func CollectPackages() ([]models.Package, error) {
+	return collectDarwinPackages(true)
+}
+
+// CollectDarwinPackages returns available packages for macOS hosts.
+// It includes Homebrew inventory when brew is installed and always adds
+// any pending system updates from softwareupdate.
+func CollectDarwinPackages() ([]models.Package, error) {
+	return collectDarwinPackages(false)
+}
+
+func collectDarwinPackages(requireBrew bool) ([]models.Package, error) {
+	useBrew := true
+	if _, err := exec.LookPath("brew"); err != nil {
+		useBrew = false
+		if requireBrew {
+			return nil, fmt.Errorf("brew not found: %w", err)
+		}
+	}
+
+	packages := make([]models.Package, 0)
+	if useBrew {
+		installed, err := getInstalledPackages()
+		if err != nil {
+			return nil, fmt.Errorf("brew list failed: %w", err)
+		}
+
+		outdated, err := getOutdatedPackages()
+		if err != nil {
+			outdated = map[string]string{}
+		}
+
+		for name, version := range installed {
+			pkg := models.Package{
+				Name:             name,
+				CurrentVersion:   version,
+				SourceRepository: "homebrew",
+				NeedsUpdate:      false,
+			}
+			if newVersion, ok := outdated[name]; ok {
+				pkg.AvailableVersion = newVersion
+				pkg.NeedsUpdate = true
+			}
+			packages = append(packages, pkg)
+		}
+	}
+
+	systemUpdates, err := getAvailableSystemUpdates()
+	if err == nil {
+		packages = append(packages, systemUpdates...)
+	}
+
+	return packages, nil
+}
+
+func getInstalledPackages() (map[string]string, error) {
+	// `brew list --versions` outputs: packagename version [version...]
+	out, err := exec.Command("brew", "list", "--versions").Output()
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]string)
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		parts := strings.Fields(line)
+		if len(parts) >= 2 {
+			result[parts[0]] = parts[len(parts)-1]
+		}
+	}
+	return result, nil
+}
+
+func getOutdatedPackages() (map[string]string, error) {
+	out, err := exec.Command("brew", "outdated", "--json=v2").Output()
+	if err != nil {
+		return nil, err
+	}
+
+	var response BrewOutdatedResponse
+	if err := json.Unmarshal(out, &response); err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]string)
+	for _, entry := range response.Formulae {
+		result[entry.Name] = entry.CurrentVersion
+	}
+	for _, entry := range response.Casks {
+		result[entry.Name] = entry.CurrentVersion
+	}
+	return result, nil
+}
+
+func getAvailableSystemUpdates() ([]models.Package, error) {
+	if _, err := exec.LookPath("softwareupdate"); err != nil {
+		return nil, nil
+	}
+
+	out, err := exec.Command("softwareupdate", "--list", "--all").CombinedOutput()
+	if err != nil && len(out) == 0 {
+		return nil, err
+	}
+
+	labels := parseSoftwareUpdateList(string(out))
+	if len(labels) == 0 {
+		if strings.Contains(string(out), "No new software available.") || strings.Contains(string(out), "No updates are available.") {
+			return nil, nil
+		}
+		return nil, nil
+	}
+
+	packages := make([]models.Package, 0, len(labels))
+	for _, label := range labels {
+		packages = append(packages, models.Package{
+			Name:             label,
+			Description:      "macOS system update",
+			Category:         "macOS Update",
+			CurrentVersion:   "installed",
+			AvailableVersion: "available",
+			NeedsUpdate:      true,
+			SourceRepository: "softwareupdate",
+		})
+	}
+	return packages, nil
+}
+
+func parseSoftwareUpdateList(output string) []string {
+	output = strings.TrimSpace(output)
+	if output == "" {
+		return nil
+	}
+
+	labelPattern := regexp.MustCompile(`(?m)^\s*\*\s*(.+)$`)
+	seen := make(map[string]struct{})
+	result := make([]string, 0)
+
+	for _, match := range labelPattern.FindAllStringSubmatch(output, -1) {
+		label := strings.TrimSpace(match[1])
+		if label == "" {
+			continue
+		}
+		if _, ok := seen[label]; ok {
+			continue
+		}
+		seen[label] = struct{}{}
+		result = append(result, label)
+	}
+
+	if len(result) > 0 {
+		return result
+	}
+
+	labelPattern = regexp.MustCompile(`(?m)^\s*Label:\s*(.+)$`)
+	for _, match := range labelPattern.FindAllStringSubmatch(output, -1) {
+		label := strings.TrimSpace(match[1])
+		if label == "" {
+			continue
+		}
+		if _, ok := seen[label]; ok {
+			continue
+		}
+		seen[label] = struct{}{}
+		result = append(result, label)
+	}
+
+	return result
+}

--- a/agent-source-code/internal/packages/packages_darwin.go
+++ b/agent-source-code/internal/packages/packages_darwin.go
@@ -14,14 +14,37 @@ import (
 	"patchmon-agent/pkg/models"
 )
 
+// getConsoleUser returns the logged-in GUI user. Falls back to stat /dev/console
+// so it works when running as a launchd service (where SUDO_USER is not set).
+func getConsoleUser() string {
+	if u := os.Getenv("SUDO_USER"); u != "" {
+		return u
+	}
+	out, err := exec.Command("stat", "-f", "%Su", "/dev/console").Output()
+	if err == nil {
+		if u := strings.TrimSpace(string(out)); u != "" && u != "root" {
+			return u
+		}
+	}
+	if u := os.Getenv("USER"); u != "" && u != "root" {
+		return u
+	}
+	return ""
+}
+
 func newBrewCommand(args ...string) *exec.Cmd {
 	brewPath := findBrewBinary()
 	if brewPath == "" {
 		brewPath = "brew"
 	}
-	cmd := exec.Command(brewPath, args...)
+	consoleUser := getConsoleUser()
+	var cmd *exec.Cmd
+	if consoleUser != "" {
+		cmd = exec.Command("sudo", append([]string{"-u", consoleUser, brewPath}, args...)...)
+	} else {
+		cmd = exec.Command(brewPath, args...)
+	}
 	cmd.Env = append(os.Environ(),
-		"HOMEBREW_ALLOW_RUN_AS_ROOT=1",
 		"HOMEBREW_NO_AUTO_UPDATE=1",
 	)
 	return cmd

--- a/agent-source-code/internal/packages/packages_darwin.go
+++ b/agent-source-code/internal/packages/packages_darwin.go
@@ -32,6 +32,14 @@ func getConsoleUser() string {
 	return ""
 }
 
+func getConsoleUserUID(consoleUser string) string {
+	out, err := exec.Command("id", "-u", consoleUser).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
 func newBrewCommand(args ...string) *exec.Cmd {
 	brewPath := findBrewBinary()
 	if brewPath == "" {
@@ -40,7 +48,12 @@ func newBrewCommand(args ...string) *exec.Cmd {
 	consoleUser := getConsoleUser()
 	var cmd *exec.Cmd
 	if consoleUser != "" {
-		cmd = exec.Command("sudo", append([]string{"-u", consoleUser, brewPath}, args...)...)
+		uid := getConsoleUserUID(consoleUser)
+		if uid != "" {
+			cmd = exec.Command("launchctl", append([]string{"asuser", uid, brewPath}, args...)...)
+		} else {
+			cmd = exec.Command(brewPath, args...)
+		}
 	} else {
 		cmd = exec.Command(brewPath, args...)
 	}

--- a/agent-source-code/internal/packages/packages_darwin.go
+++ b/agent-source-code/internal/packages/packages_darwin.go
@@ -14,34 +14,14 @@ import (
 	"patchmon-agent/pkg/models"
 )
 
-// getConsoleUser returns the logged-in console user. Falls back to
-// stat /dev/console so it works when running as a launchd service
-// (where SUDO_USER is not set).
-func getConsoleUser() string {
-	if u := os.Getenv("SUDO_USER"); u != "" {
-		return u
-	}
-	out, err := exec.Command("stat", "-f", "%Su", "/dev/console").Output()
-	if err == nil {
-		if u := strings.TrimSpace(string(out)); u != "" && u != "root" {
-			return u
-		}
-	}
-	if u := os.Getenv("USER"); u != "" {
-		return u
-	}
-	return "root"
-}
-
 func newBrewCommand(args ...string) *exec.Cmd {
 	brewPath := findBrewBinary()
 	if brewPath == "" {
 		brewPath = "brew"
 	}
-	sudoUser := getConsoleUser()
-	cmd := exec.Command("sudo", "-u", sudoUser, brewPath)
-	cmd.Args = append(cmd.Args, args...)
+	cmd := exec.Command(brewPath, args...)
 	cmd.Env = append(os.Environ(),
+		"HOMEBREW_ALLOW_RUN_AS_ROOT=1",
 		"HOMEBREW_NO_AUTO_UPDATE=1",
 	)
 	return cmd

--- a/agent-source-code/internal/packages/packages_darwin.go
+++ b/agent-source-code/internal/packages/packages_darwin.go
@@ -32,28 +32,11 @@ func getConsoleUser() string {
 	return ""
 }
 
-func getConsoleUserUID(consoleUser string) string {
-	out, err := exec.Command("id", "-u", consoleUser).Output()
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(out))
-}
-
-func newBrewCommand(args ...string) *exec.Cmd {
-	brewPath := findBrewBinary()
-	if brewPath == "" {
-		brewPath = "brew"
-	}
-	consoleUser := getConsoleUser()
+func newBrewCommand(consoleUser, brewPath string, args ...string) *exec.Cmd {
 	var cmd *exec.Cmd
 	if consoleUser != "" {
-		uid := getConsoleUserUID(consoleUser)
-		if uid != "" {
-			cmd = exec.Command("launchctl", append([]string{"asuser", uid, brewPath}, args...)...)
-		} else {
-			cmd = exec.Command(brewPath, args...)
-		}
+		cmdArgs := append([]string{"-n", "-u", consoleUser, brewPath}, args...)
+		cmd = exec.Command("sudo", cmdArgs...)
 	} else {
 		cmd = exec.Command(brewPath, args...)
 	}
@@ -98,9 +81,11 @@ func collectDarwinPackages(requireBrew bool) ([]models.Package, error) {
 		}
 	}
 
+	consoleUser := getConsoleUser()
+
 	packages := make([]models.Package, 0)
 	if useBrew {
-		installed, err := getInstalledPackages()
+		installed, err := getInstalledPackages(consoleUser, brewPath)
 		if err != nil {
 			if requireBrew {
 				return nil, fmt.Errorf("brew list failed: %w", err)
@@ -108,7 +93,7 @@ func collectDarwinPackages(requireBrew bool) ([]models.Package, error) {
 			installed = map[string]string{}
 		}
 
-		outdated, err := getOutdatedPackages()
+		outdated, err := getOutdatedPackages(consoleUser, brewPath)
 		if err != nil {
 			outdated = map[string]string{}
 		}
@@ -136,13 +121,13 @@ func collectDarwinPackages(requireBrew bool) ([]models.Package, error) {
 	return packages, nil
 }
 
-func getInstalledPackages() (map[string]string, error) {
+func getInstalledPackages(consoleUser, brewPath string) (map[string]string, error) {
 	// `brew list --versions` outputs: packagename version [version...]
 	// Retry a few times on startup when brew may not yet be responsive.
 	var out []byte
 	var err error
 	for attempt := range 3 {
-		cmd := newBrewCommand("list", "--versions")
+		cmd := newBrewCommand(consoleUser, brewPath, "list", "--versions")
 		out, err = cmd.CombinedOutput()
 		if err == nil {
 			break
@@ -165,11 +150,11 @@ func getInstalledPackages() (map[string]string, error) {
 	return result, nil
 }
 
-func getOutdatedPackages() (map[string]string, error) {
+func getOutdatedPackages(consoleUser, brewPath string) (map[string]string, error) {
 	var out []byte
 	var err error
 	for attempt := range 3 {
-		cmd := newBrewCommand("outdated", "--json=v2")
+		cmd := newBrewCommand(consoleUser, brewPath, "outdated", "--json=v2")
 		out, err = cmd.Output()
 		if err == nil {
 			break

--- a/agent-source-code/internal/packages/packages_darwin.go
+++ b/agent-source-code/internal/packages/packages_darwin.go
@@ -5,12 +5,26 @@ package packages
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 	"regexp"
 	"strings"
 
 	"patchmon-agent/pkg/models"
 )
+
+func newBrewCommand(args ...string) *exec.Cmd {
+	brewPath := findBrewBinary()
+	if brewPath == "" {
+		brewPath = "brew"
+	}
+	cmd := exec.Command(brewPath, args...)
+	cmd.Env = append(os.Environ(),
+		"HOMEBREW_ALLOW_RUN_AS_ROOT=1",
+		"HOMEBREW_NO_AUTO_UPDATE=1",
+	)
+	return cmd
+}
 
 // BrewOutdatedEntry matches the JSON output of `brew outdated --json=v2`
 type BrewOutdatedEntry struct {
@@ -28,7 +42,7 @@ type BrewOutdatedResponse struct {
 // CollectPackages returns all installed Homebrew packages,
 // flagging any that have updates available.
 func CollectPackages() ([]models.Package, error) {
-	return collectDarwinPackages(true)
+	return collectDarwinPackages(false)
 }
 
 // CollectDarwinPackages returns available packages for macOS hosts.
@@ -51,7 +65,10 @@ func collectDarwinPackages(requireBrew bool) ([]models.Package, error) {
 	if useBrew {
 		installed, err := getInstalledPackages()
 		if err != nil {
-			return nil, fmt.Errorf("brew list failed: %w", err)
+			if requireBrew {
+				return nil, fmt.Errorf("brew list failed: %w", err)
+			}
+			installed = map[string]string{}
 		}
 
 		outdated, err := getOutdatedPackages()
@@ -84,9 +101,10 @@ func collectDarwinPackages(requireBrew bool) ([]models.Package, error) {
 
 func getInstalledPackages() (map[string]string, error) {
 	// `brew list --versions` outputs: packagename version [version...]
-	out, err := exec.Command("brew", "list", "--versions").Output()
+	cmd := newBrewCommand("list", "--versions")
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("brew list --versions failed: %s: %w", strings.TrimSpace(string(out)), err)
 	}
 
 	result := make(map[string]string)
@@ -100,7 +118,8 @@ func getInstalledPackages() (map[string]string, error) {
 }
 
 func getOutdatedPackages() (map[string]string, error) {
-	out, err := exec.Command("brew", "outdated", "--json=v2").Output()
+	cmd := newBrewCommand("outdated", "--json=v2")
+	out, err := cmd.Output()
 	if err != nil {
 		return nil, err
 	}

--- a/agent-source-code/internal/packages/packages_darwin.go
+++ b/agent-source-code/internal/packages/packages_darwin.go
@@ -18,9 +18,16 @@ func newBrewCommand(args ...string) *exec.Cmd {
 	if brewPath == "" {
 		brewPath = "brew"
 	}
-	cmd := exec.Command(brewPath, args...)
+	sudoUser := os.Getenv("SUDO_USER")
+	if sudoUser == "" {
+		sudoUser = os.Getenv("USER")
+	}
+	if sudoUser == "" {
+		sudoUser = "root"
+	}
+	cmd := exec.Command("sudo", "-u", sudoUser, brewPath)
+	cmd.Args = append(cmd.Args, args...)
 	cmd.Env = append(os.Environ(),
-		"HOMEBREW_ALLOW_RUN_AS_ROOT=1",
 		"HOMEBREW_NO_AUTO_UPDATE=1",
 	)
 	return cmd

--- a/agent-source-code/internal/packages/packages_darwin.go
+++ b/agent-source-code/internal/packages/packages_darwin.go
@@ -184,6 +184,8 @@ func parseSoftwareUpdateList(output string) []string {
 
 	for _, match := range labelPattern.FindAllStringSubmatch(output, -1) {
 		label := strings.TrimSpace(match[1])
+		label = strings.TrimPrefix(label, "Label: ")
+		label = strings.TrimSpace(label)
 		if label == "" {
 			continue
 		}
@@ -201,6 +203,8 @@ func parseSoftwareUpdateList(output string) []string {
 	labelPattern = regexp.MustCompile(`(?m)^\s*Label:\s*(.+)$`)
 	for _, match := range labelPattern.FindAllStringSubmatch(output, -1) {
 		label := strings.TrimSpace(match[1])
+		label = strings.TrimPrefix(label, "Label: ")
+		label = strings.TrimSpace(label)
 		if label == "" {
 			continue
 		}

--- a/agent-source-code/internal/packages/packages_darwin.go
+++ b/agent-source-code/internal/packages/packages_darwin.go
@@ -53,11 +53,11 @@ func CollectDarwinPackages() ([]models.Package, error) {
 }
 
 func collectDarwinPackages(requireBrew bool) ([]models.Package, error) {
-	useBrew := true
-	if _, err := exec.LookPath("brew"); err != nil {
-		useBrew = false
+	brewPath := findBrewBinary()
+	useBrew := brewPath != ""
+	if !useBrew {
 		if requireBrew {
-			return nil, fmt.Errorf("brew not found: %w", err)
+			return nil, fmt.Errorf("brew not found")
 		}
 	}
 

--- a/agent-source-code/internal/packages/packages_darwin.go
+++ b/agent-source-code/internal/packages/packages_darwin.go
@@ -35,7 +35,11 @@ func getConsoleUser() string {
 func newBrewCommand(consoleUser, brewPath string, args ...string) *exec.Cmd {
 	var cmd *exec.Cmd
 	if consoleUser != "" {
-		cmdArgs := append([]string{"-n", "-u", consoleUser, brewPath}, args...)
+		cmdArgs := append([]string{"-n", "-u", consoleUser, "env",
+			"HOMEBREW_NO_AUTO_UPDATE=1",
+			"HOMEBREW_NO_ANALYTICS=1",
+			"HOMEBREW_NO_ENV_HINTS=1",
+			brewPath}, args...)
 		cmd = exec.Command("sudo", cmdArgs...)
 	} else {
 		cmd = exec.Command(brewPath, args...)

--- a/agent-source-code/internal/packages/packages_darwin.go
+++ b/agent-source-code/internal/packages/packages_darwin.go
@@ -5,7 +5,6 @@ package packages
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -14,40 +13,10 @@ import (
 	"patchmon-agent/pkg/models"
 )
 
-// getConsoleUser returns the logged-in GUI user. Falls back to stat /dev/console
-// so it works when running as a launchd service (where SUDO_USER is not set).
-func getConsoleUser() string {
-	if u := os.Getenv("SUDO_USER"); u != "" {
-		return u
-	}
-	out, err := exec.Command("stat", "-f", "%Su", "/dev/console").Output()
-	if err == nil {
-		if u := strings.TrimSpace(string(out)); u != "" && u != "root" {
-			return u
-		}
-	}
-	if u := os.Getenv("USER"); u != "" && u != "root" {
-		return u
-	}
-	return ""
-}
+const brewWrapper = "/usr/local/bin/patchmon-brew"
 
-func newBrewCommand(consoleUser, brewPath string, args ...string) *exec.Cmd {
-	var cmd *exec.Cmd
-	if consoleUser != "" {
-		cmdArgs := append([]string{"-n", "-u", consoleUser, "env",
-			"HOMEBREW_NO_AUTO_UPDATE=1",
-			"HOMEBREW_NO_ANALYTICS=1",
-			"HOMEBREW_NO_ENV_HINTS=1",
-			brewPath}, args...)
-		cmd = exec.Command("sudo", cmdArgs...)
-	} else {
-		cmd = exec.Command(brewPath, args...)
-	}
-	cmd.Env = append(os.Environ(),
-		"HOMEBREW_NO_AUTO_UPDATE=1",
-	)
-	return cmd
+func newBrewCommand(args ...string) *exec.Cmd {
+	return exec.Command(brewWrapper, args...)
 }
 
 // BrewOutdatedEntry matches the JSON output of `brew outdated --json=v2`
@@ -77,19 +46,16 @@ func CollectDarwinPackages() ([]models.Package, error) {
 }
 
 func collectDarwinPackages(requireBrew bool) ([]models.Package, error) {
-	brewPath := findBrewBinary()
-	useBrew := brewPath != ""
+	useBrew := findBrewBinary() != ""
 	if !useBrew {
 		if requireBrew {
 			return nil, fmt.Errorf("brew not found")
 		}
 	}
 
-	consoleUser := getConsoleUser()
-
 	packages := make([]models.Package, 0)
 	if useBrew {
-		installed, err := getInstalledPackages(consoleUser, brewPath)
+		installed, err := getInstalledPackages()
 		if err != nil {
 			if requireBrew {
 				return nil, fmt.Errorf("brew list failed: %w", err)
@@ -97,7 +63,7 @@ func collectDarwinPackages(requireBrew bool) ([]models.Package, error) {
 			installed = map[string]string{}
 		}
 
-		outdated, err := getOutdatedPackages(consoleUser, brewPath)
+		outdated, err := getOutdatedPackages()
 		if err != nil {
 			outdated = map[string]string{}
 		}
@@ -125,13 +91,13 @@ func collectDarwinPackages(requireBrew bool) ([]models.Package, error) {
 	return packages, nil
 }
 
-func getInstalledPackages(consoleUser, brewPath string) (map[string]string, error) {
+func getInstalledPackages() (map[string]string, error) {
 	// `brew list --versions` outputs: packagename version [version...]
 	// Retry a few times on startup when brew may not yet be responsive.
 	var out []byte
 	var err error
 	for attempt := range 3 {
-		cmd := newBrewCommand(consoleUser, brewPath, "list", "--versions")
+		cmd := newBrewCommand("list", "--versions")
 		out, err = cmd.CombinedOutput()
 		if err == nil {
 			break
@@ -154,11 +120,11 @@ func getInstalledPackages(consoleUser, brewPath string) (map[string]string, erro
 	return result, nil
 }
 
-func getOutdatedPackages(consoleUser, brewPath string) (map[string]string, error) {
+func getOutdatedPackages() (map[string]string, error) {
 	var out []byte
 	var err error
 	for attempt := range 3 {
-		cmd := newBrewCommand(consoleUser, brewPath, "outdated", "--json=v2")
+		cmd := newBrewCommand("outdated", "--json=v2")
 		out, err = cmd.Output()
 		if err == nil {
 			break

--- a/agent-source-code/internal/packages/packages_darwin.go
+++ b/agent-source-code/internal/packages/packages_darwin.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
+	"time"
 
 	"patchmon-agent/pkg/models"
 )
@@ -108,8 +109,19 @@ func collectDarwinPackages(requireBrew bool) ([]models.Package, error) {
 
 func getInstalledPackages() (map[string]string, error) {
 	// `brew list --versions` outputs: packagename version [version...]
-	cmd := newBrewCommand("list", "--versions")
-	out, err := cmd.CombinedOutput()
+	// Retry a few times on startup when brew may not yet be responsive.
+	var out []byte
+	var err error
+	for attempt := range 3 {
+		cmd := newBrewCommand("list", "--versions")
+		out, err = cmd.CombinedOutput()
+		if err == nil {
+			break
+		}
+		if attempt < 2 {
+			time.Sleep(time.Duration(attempt+1) * 5 * time.Second)
+		}
+	}
 	if err != nil {
 		return nil, fmt.Errorf("brew list --versions failed: %s: %w", strings.TrimSpace(string(out)), err)
 	}
@@ -125,8 +137,18 @@ func getInstalledPackages() (map[string]string, error) {
 }
 
 func getOutdatedPackages() (map[string]string, error) {
-	cmd := newBrewCommand("outdated", "--json=v2")
-	out, err := cmd.Output()
+	var out []byte
+	var err error
+	for attempt := range 3 {
+		cmd := newBrewCommand("outdated", "--json=v2")
+		out, err = cmd.Output()
+		if err == nil {
+			break
+		}
+		if attempt < 2 {
+			time.Sleep(time.Duration(attempt+1) * 5 * time.Second)
+		}
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/agent-source-code/internal/packages/packages_darwin.go
+++ b/agent-source-code/internal/packages/packages_darwin.go
@@ -14,18 +14,31 @@ import (
 	"patchmon-agent/pkg/models"
 )
 
+// getConsoleUser returns the logged-in console user. Falls back to
+// stat /dev/console so it works when running as a launchd service
+// (where SUDO_USER is not set).
+func getConsoleUser() string {
+	if u := os.Getenv("SUDO_USER"); u != "" {
+		return u
+	}
+	out, err := exec.Command("stat", "-f", "%Su", "/dev/console").Output()
+	if err == nil {
+		if u := strings.TrimSpace(string(out)); u != "" && u != "root" {
+			return u
+		}
+	}
+	if u := os.Getenv("USER"); u != "" {
+		return u
+	}
+	return "root"
+}
+
 func newBrewCommand(args ...string) *exec.Cmd {
 	brewPath := findBrewBinary()
 	if brewPath == "" {
 		brewPath = "brew"
 	}
-	sudoUser := os.Getenv("SUDO_USER")
-	if sudoUser == "" {
-		sudoUser = os.Getenv("USER")
-	}
-	if sudoUser == "" {
-		sudoUser = "root"
-	}
+	sudoUser := getConsoleUser()
 	cmd := exec.Command("sudo", "-u", sudoUser, brewPath)
 	cmd.Args = append(cmd.Args, args...)
 	cmd.Env = append(os.Environ(),

--- a/agent-source-code/internal/packages/packages_darwin_stub.go
+++ b/agent-source-code/internal/packages/packages_darwin_stub.go
@@ -1,0 +1,12 @@
+//go:build !darwin
+
+package packages
+
+import (
+	"fmt"
+	"patchmon-agent/pkg/models"
+)
+
+func CollectDarwinPackages() ([]models.Package, error) {
+	return nil, fmt.Errorf("darwin package collection not supported on this platform")
+}

--- a/agent-source-code/internal/repositories/darwin.go
+++ b/agent-source-code/internal/repositories/darwin.go
@@ -3,7 +3,6 @@
 package repositories
 
 import (
-	"os"
 	"os/exec"
 	"strings"
 
@@ -11,12 +10,7 @@ import (
 )
 
 func newBrewCommand(args ...string) *exec.Cmd {
-	cmd := exec.Command("brew", args...)
-	cmd.Env = append(os.Environ(),
-		"HOMEBREW_ALLOW_RUN_AS_ROOT=1",
-		"HOMEBREW_NO_AUTO_UPDATE=1",
-	)
-	return cmd
+	return exec.Command("/usr/local/bin/patchmon-brew", args...)
 }
 
 // CollectRepositories returns configured Homebrew taps,

--- a/agent-source-code/internal/repositories/darwin.go
+++ b/agent-source-code/internal/repositories/darwin.go
@@ -1,0 +1,32 @@
+//go:build darwin
+
+package repositories
+
+import (
+    "os/exec"
+    "strings"
+
+    "patchmon-agent/pkg/models"
+)
+
+// CollectRepositories returns configured Homebrew taps,
+// which are the macOS equivalent of apt/yum repos.
+func CollectRepositories() ([]models.Repository, error) {
+    out, err := exec.Command("brew", "tap").Output()
+    if err != nil {
+        return nil, err
+    }
+
+    var repos []models.Repository
+    for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+        if line == "" {
+            continue
+        }
+        repos = append(repos, models.Repository{
+            Name:      line,
+            RepoType:  "homebrew-tap",
+            IsEnabled: true,
+        })
+    }
+    return repos, nil
+}

--- a/agent-source-code/internal/repositories/darwin.go
+++ b/agent-source-code/internal/repositories/darwin.go
@@ -3,30 +3,40 @@
 package repositories
 
 import (
-    "os/exec"
-    "strings"
+	"os"
+	"os/exec"
+	"strings"
 
-    "patchmon-agent/pkg/models"
+	"patchmon-agent/pkg/models"
 )
+
+func newBrewCommand(args ...string) *exec.Cmd {
+	cmd := exec.Command("brew", args...)
+	cmd.Env = append(os.Environ(),
+		"HOMEBREW_ALLOW_RUN_AS_ROOT=1",
+		"HOMEBREW_NO_AUTO_UPDATE=1",
+	)
+	return cmd
+}
 
 // CollectRepositories returns configured Homebrew taps,
 // which are the macOS equivalent of apt/yum repos.
 func CollectRepositories() ([]models.Repository, error) {
-    out, err := exec.Command("brew", "tap").Output()
-    if err != nil {
-        return nil, err
-    }
+	out, err := newBrewCommand("tap").Output()
+	if err != nil {
+		return nil, err
+	}
 
-    var repos []models.Repository
-    for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-        if line == "" {
-            continue
-        }
-        repos = append(repos, models.Repository{
-            Name:      line,
-            RepoType:  "homebrew-tap",
-            IsEnabled: true,
-        })
-    }
-    return repos, nil
+	var repos []models.Repository
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line == "" {
+			continue
+		}
+		repos = append(repos, models.Repository{
+			Name:      line,
+			RepoType:  "homebrew-tap",
+			IsEnabled: true,
+		})
+	}
+	return repos, nil
 }

--- a/agent-source-code/internal/repositories/repositories.go
+++ b/agent-source-code/internal/repositories/repositories.go
@@ -55,6 +55,8 @@ func (m *Manager) GetRepositories() ([]models.Repository, error) {
 		return m.pacmanManager.GetRepositories()
 	case "pkg":
 		return m.freebsdManager.GetRepositories()
+	case "brew":
+		return CollectRepositories()
 	default:
 		m.logger.WithField("package_manager", packageManager).Warn("Unsupported package manager")
 		return []models.Repository{}, nil
@@ -107,6 +109,13 @@ func (m *Manager) detectPackageManager() string {
 	}
 	if _, err := exec.LookPath("yum"); err == nil {
 		return "yum"
+	}
+
+	// Check for Homebrew on macOS
+	if runtime.GOOS == "darwin" {
+		if _, err := exec.LookPath("brew"); err == nil {
+			return "brew"
+		}
 	}
 
 	return "unknown"

--- a/agent-source-code/internal/repositories/repositories_brew_stub.go
+++ b/agent-source-code/internal/repositories/repositories_brew_stub.go
@@ -1,0 +1,12 @@
+//go:build !darwin
+
+package repositories
+
+import (
+    "fmt"
+    "patchmon-agent/pkg/models"
+)
+
+func CollectRepositories() ([]models.Repository, error) {
+    return nil, fmt.Errorf("brew repository collection unsupported on non-darwin platforms")
+}

--- a/agent-source-code/internal/system/reboot.go
+++ b/agent-source-code/internal/system/reboot.go
@@ -21,6 +21,11 @@ func (d *Detector) CheckRebootRequired() (bool, string) {
 		return d.checkWindowsRebootRequired()
 	}
 
+	// macOS: use softwareupdate output to infer whether a restart is required
+	if runtime.GOOS == "darwin" {
+		return d.checkDarwinRebootRequired()
+	}
+
 	runningKernel := d.getRunningKernel()
 	latestKernel := d.getLatestInstalledKernel()
 

--- a/agent-source-code/internal/system/system.go
+++ b/agent-source-code/internal/system/system.go
@@ -247,7 +247,7 @@ func (d *Detector) GetSystemInfo() models.SystemInfo {
 	info := models.SystemInfo{
 		KernelVersion: d.GetKernelVersion(),
 		SELinuxStatus: d.getSELinuxStatus(),
-		SystemUptime:  d.getSystemUptime(ctx),
+		SystemUptime:  d.getSystemUptime(),
 		LoadAverage:   d.getLoadAverage(ctx),
 	}
 
@@ -262,31 +262,38 @@ func (d *Detector) GetSystemInfo() models.SystemInfo {
 
 // GetArchitecture returns the system architecture
 func (d *Detector) GetArchitecture() string {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	info, err := host.InfoWithContext(ctx)
-	if err != nil {
+	// On macOS, gopsutil may be slow on cold boot — retry with backoff
+	for attempt := range 3 {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		info, err := host.InfoWithContext(ctx)
+		cancel()
+		if err == nil {
+			return info.KernelArch
+		}
+		if attempt < 2 {
+			time.Sleep(time.Duration(attempt+1) * 5 * time.Second)
+		}
 		d.logger.WithError(err).Warn("Failed to get architecture")
-		return constants.ArchUnknown
 	}
-
-	return info.KernelArch
+	return constants.ArchUnknown
 }
 
 // GetHostname returns the system hostname
 func (d *Detector) GetHostname() (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	info, err := host.InfoWithContext(ctx)
-	if err != nil {
+	// On macOS, gopsutil may be slow on cold boot — retry with backoff
+	for attempt := range 3 {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		info, err := host.InfoWithContext(ctx)
+		cancel()
+		if err == nil {
+			return info.Hostname, nil
+		}
+		if attempt < 2 {
+			time.Sleep(time.Duration(attempt+1) * 5 * time.Second)
+		}
 		d.logger.WithError(err).Warn("Failed to get hostname")
-		// Fallback to os.Hostname
-		return os.Hostname()
 	}
-
-	return info.Hostname, nil
+	return os.Hostname()
 }
 
 // GetIPAddress gets the primary IP address using network interfaces
@@ -383,26 +390,31 @@ func (d *Detector) getSELinuxStatus() string {
 }
 
 // getSystemUptime gets system uptime
-func (d *Detector) getSystemUptime(ctx context.Context) string {
-	info, err := host.InfoWithContext(ctx)
-	if err != nil {
+func (d *Detector) getSystemUptime() string {
+	// On macOS, gopsutil may be slow on cold boot — retry with backoff
+	for attempt := range 3 {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		info, err := host.InfoWithContext(ctx)
+		cancel()
+		if err == nil {
+			uptime := time.Duration(info.Uptime) * time.Second
+			days := int(uptime.Hours() / 24)
+			hours := int(uptime.Hours()) % 24
+			minutes := int(uptime.Minutes()) % 60
+			if days > 0 {
+				return fmt.Sprintf("%d days, %d hours, %d minutes", days, hours, minutes)
+			}
+			if hours > 0 {
+				return fmt.Sprintf("%d hours, %d minutes", hours, minutes)
+			}
+			return fmt.Sprintf("%d minutes", minutes)
+		}
+		if attempt < 2 {
+			time.Sleep(time.Duration(attempt+1) * 5 * time.Second)
+		}
 		d.logger.WithError(err).Warn("Failed to get uptime")
-		return "Unknown"
 	}
-
-	uptime := time.Duration(info.Uptime) * time.Second
-
-	days := int(uptime.Hours() / 24)
-	hours := int(uptime.Hours()) % 24
-	minutes := int(uptime.Minutes()) % 60
-
-	if days > 0 {
-		return fmt.Sprintf("%d days, %d hours, %d minutes", days, hours, minutes)
-	}
-	if hours > 0 {
-		return fmt.Sprintf("%d hours, %d minutes", hours, minutes)
-	}
-	return fmt.Sprintf("%d minutes", minutes)
+	return "Unknown"
 }
 
 // getLoadAverage gets system load average
@@ -458,20 +470,21 @@ func (d *Detector) getDarwinLoadAverage() []float64 {
 
 // GetMachineID returns the system's machine ID using gopsutil
 func (d *Detector) GetMachineID() string {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	// Use gopsutil's HostID which reads from standard locations
-	// (/etc/machine-id, /var/lib/dbus/machine-id, etc.)
-	hostID, err := host.HostIDWithContext(ctx)
-	if err != nil {
-		d.logger.WithError(err).Warn("Failed to get host ID, using hostname as fallback")
-		// Fallback to hostname if we can't get machine ID
-		if hostname, err := os.Hostname(); err == nil {
-			return hostname
+	// On macOS, gopsutil may be slow on cold boot — retry with backoff
+	for attempt := range 3 {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		hostID, err := host.HostIDWithContext(ctx)
+		cancel()
+		if err == nil {
+			return hostID
 		}
-		return "unknown"
+		if attempt < 2 {
+			time.Sleep(time.Duration(attempt+1) * 5 * time.Second)
+		}
+		d.logger.WithError(err).Warn("Failed to get host ID")
 	}
-
-	return hostID
+	if hostname, err := os.Hostname(); err == nil {
+		return hostname
+	}
+	return "unknown"
 }

--- a/agent-source-code/internal/system/system.go
+++ b/agent-source-code/internal/system/system.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -407,12 +408,52 @@ func (d *Detector) getSystemUptime(ctx context.Context) string {
 // getLoadAverage gets system load average
 func (d *Detector) getLoadAverage(ctx context.Context) []float64 {
 	loadAvg, err := load.AvgWithContext(ctx)
-	if err != nil {
-		d.logger.WithError(err).Warn("Failed to get load average")
-		return []float64{0, 0, 0}
+	if err == nil {
+		return []float64{loadAvg.Load1, loadAvg.Load5, loadAvg.Load15}
 	}
 
-	return []float64{loadAvg.Load1, loadAvg.Load5, loadAvg.Load15}
+	if runtime.GOOS == "darwin" {
+		if darwinLoad := d.getDarwinLoadAverage(); len(darwinLoad) == 3 {
+			return darwinLoad
+		}
+	}
+
+	d.logger.WithError(err).Warn("Failed to get load average")
+	return []float64{0, 0, 0}
+}
+
+func (d *Detector) getDarwinLoadAverage() []float64 {
+	out, err := exec.Command("sysctl", "-n", "vm.loadavg").Output()
+	if err != nil {
+		d.logger.WithError(err).Debug("Failed to run sysctl vm.loadavg")
+		return nil
+	}
+
+	// Example output: { 1.23 0.97 0.75 }
+	fields := strings.Fields(string(out))
+	if len(fields) < 3 {
+		return nil
+	}
+
+	var loads []float64
+	for _, field := range fields {
+		field = strings.Trim(field, "{} ")
+		if field == "" {
+			continue
+		}
+		value, err := strconv.ParseFloat(field, 64)
+		if err != nil {
+			d.logger.WithError(err).Debugf("Failed to parse load average value %q", field)
+			return nil
+		}
+		loads = append(loads, value)
+	}
+
+	if len(loads) < 3 {
+		return nil
+	}
+
+	return loads[:3]
 }
 
 // GetMachineID returns the system's machine ID using gopsutil

--- a/agent-source-code/internal/system/system.go
+++ b/agent-source-code/internal/system/system.go
@@ -185,6 +185,11 @@ func (d *Detector) DetectOS() (osType, osVersion string, err error) {
 		return d.getFreeBSDInfo()
 	}
 
+	// Check for macOS first
+	if runtime.GOOS == "darwin" {
+		return d.getDarwinOSInfo()
+	}
+
 	// Try to parse /etc/os-release first
 	osReleaseInfo, err := d.parseOSRelease()
 	if err != nil {
@@ -316,6 +321,10 @@ func (d *Detector) GetIPAddress() string {
 
 // GetKernelVersion gets the kernel version
 func (d *Detector) GetKernelVersion() string {
+	if runtime.GOOS == "darwin" {
+		return d.getDarwinKernelVersion()
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
@@ -330,8 +339,8 @@ func (d *Detector) GetKernelVersion() string {
 
 // getSELinuxStatus gets SELinux status using file reading
 func (d *Detector) getSELinuxStatus() string {
-	// Windows and FreeBSD don't use SELinux
-	if runtime.GOOS == "windows" || d.isFreeBSD() {
+	// Windows, macOS and FreeBSD don't use SELinux
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" || d.isFreeBSD() {
 		return constants.SELinuxDisabled
 	}
 

--- a/agent-source-code/internal/system/system_darwin.go
+++ b/agent-source-code/internal/system/system_darwin.go
@@ -1,0 +1,55 @@
+//go:build darwin
+
+package system
+
+import (
+	"os/exec"
+	"strings"
+
+	"patchmon-agent/internal/constants"
+)
+
+func (d *Detector) getDarwinOSInfo() (osType, osVersion string, err error) {
+	osType = "macOS"
+
+	out, err := exec.Command("sw_vers", "-productVersion").Output()
+	if err != nil {
+		return osType, "Unknown", nil
+	}
+
+	osVersion = strings.TrimSpace(string(out))
+	if osVersion == "" {
+		osVersion = "Unknown"
+	}
+
+	return osType, osVersion, nil
+}
+
+func (d *Detector) checkDarwinRebootRequired() (bool, string) {
+	if _, err := exec.LookPath("softwareupdate"); err != nil {
+		return false, ""
+	}
+
+	out, err := exec.Command("softwareupdate", "--list", "--all").CombinedOutput()
+	if err != nil && len(out) == 0 {
+		return false, ""
+	}
+
+	text := strings.ToLower(string(out))
+	if strings.Contains(text, "restart required") || strings.Contains(text, "restart is required") || strings.Contains(text, "restart now") {
+		return true, "macOS software update requires restart"
+	}
+	if strings.Contains(text, "restart") && strings.Contains(text, "required") {
+		return true, "macOS software update requires restart"
+	}
+	return false, ""
+}
+
+func (d *Detector) getDarwinKernelVersion() string {
+	out, err := exec.Command("uname", "-r").Output()
+	if err != nil {
+		d.logger.WithError(err).Warn("Failed to get Darwin kernel version")
+		return constants.ErrUnknownValue
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/agent-source-code/internal/system/system_darwin_stub.go
+++ b/agent-source-code/internal/system/system_darwin_stub.go
@@ -1,0 +1,15 @@
+//go:build !darwin
+
+package system
+
+func (d *Detector) getDarwinOSInfo() (osType, osVersion string, err error) {
+	return "Unknown", "Unknown", nil
+}
+
+func (d *Detector) checkDarwinRebootRequired() (bool, string) {
+	return false, ""
+}
+
+func (d *Detector) getDarwinKernelVersion() string {
+	return "Unknown"
+}

--- a/agents/patchmon_install.sh
+++ b/agents/patchmon_install.sh
@@ -910,6 +910,9 @@ PLIST_EOF
 
     chmod 644 "$PLIST_PATH"
 
+    # Kill any existing agent processes before loading to avoid duplicates
+    pkill -f "patchmon-agent serve" 2>/dev/null || true
+
     # Load the service
     if launchctl load "$PLIST_PATH"; then
         success "PatchMon Agent launchd service started successfully"
@@ -934,11 +937,13 @@ else
     (crontab -l 2>/dev/null; echo "@reboot /usr/local/bin/patchmon-agent serve >/dev/null 2>&1") | crontab -
     info "Added crontab entry for PatchMon agent"
     
-    # Start the agent manually
-    /usr/local/bin/patchmon-agent serve >/dev/null 2>&1 &
-    success "PatchMon Agent started in background"
-    info "WebSocket connection established"
-    
+    # Start the agent manually (only if launchd is not already managing it)
+    if ! launchctl list net.patchmon.patchmon-agent >/dev/null 2>&1; then
+        /usr/local/bin/patchmon-agent serve >/dev/null 2>&1 &
+        success "PatchMon Agent started in background"
+        info "WebSocket connection established"
+    fi
+
     SERVICE_TYPE="crontab"
 fi
 

--- a/agents/patchmon_install.sh
+++ b/agents/patchmon_install.sh
@@ -870,29 +870,50 @@ elif [ "$(uname -s 2>/dev/null)" = "Darwin" ] || [ "$PATCHMON_OS" = "darwin" ]; 
     # macOS: create and load launchd plist directly
     info "Setting up macOS launchd service..."
 
-    # Grant the launchd daemon (root) permission to invoke brew as the console user.
-    # Without this, sudo in a TTY-less launchd context is rejected.
-    CONSOLE_USER=$(stat -f "%Su" /dev/console 2>/dev/null || echo "")
+    # Write the patchmon-brew wrapper. The agent runs as root (launchd daemon) but
+    # brew must run as the GUI user. This script resolves the console user at runtime
+    # so it works correctly even if the user changes between installs.
+    BREW_WRAPPER="/usr/local/bin/patchmon-brew"
+    cat > "$BREW_WRAPPER" << 'BREW_EOF'
+#!/bin/sh
+CONSOLE_USER=$(stat -f "%Su" /dev/console 2>/dev/null || echo "")
+for BREW_PATH in /opt/homebrew/bin/brew /usr/local/bin/brew; do
+    [ -f "$BREW_PATH" ] || continue
     if [ -n "$CONSOLE_USER" ] && [ "$CONSOLE_USER" != "root" ]; then
-        info "Configuring sudoers for brew access as user: $CONSOLE_USER"
-        BREW_SUDOERS_FILE="/etc/sudoers.d/patchmon"
-        : > "$BREW_SUDOERS_FILE"
-        _found_brew=false
-        for BREW_PATH in /opt/homebrew/bin/brew /usr/local/bin/brew; do
-            if [ -f "$BREW_PATH" ]; then
-                echo "root ALL=($CONSOLE_USER) NOPASSWD: $BREW_PATH" >> "$BREW_SUDOERS_FILE"
-                _found_brew=true
-            fi
-        done
-        if $_found_brew; then
-            chmod 440 "$BREW_SUDOERS_FILE"
-            success "Sudoers entry created for brew access as $CONSOLE_USER"
-        else
-            rm -f "$BREW_SUDOERS_FILE"
-            warning "Homebrew not found - brew update detection may not work until Homebrew is installed"
-        fi
+        exec sudo -n -u "$CONSOLE_USER" env \
+            HOMEBREW_NO_AUTO_UPDATE=1 \
+            HOMEBREW_NO_ANALYTICS=1 \
+            HOMEBREW_NO_ENV_HINTS=1 \
+            "$BREW_PATH" "$@"
     else
-        warning "Could not determine console user - brew update detection may not work"
+        exec env \
+            HOMEBREW_NO_AUTO_UPDATE=1 \
+            HOMEBREW_NO_ANALYTICS=1 \
+            HOMEBREW_NO_ENV_HINTS=1 \
+            "$BREW_PATH" "$@"
+    fi
+done
+exit 1
+BREW_EOF
+    chmod 755 "$BREW_WRAPPER"
+    success "patchmon-brew wrapper written to $BREW_WRAPPER"
+
+    # Grant root permission to invoke brew as any console user via the wrapper.
+    BREW_SUDOERS_FILE="/etc/sudoers.d/patchmon"
+    : > "$BREW_SUDOERS_FILE"
+    _found_brew=false
+    for BREW_PATH in /opt/homebrew/bin/brew /usr/local/bin/brew; do
+        if [ -f "$BREW_PATH" ]; then
+            echo "root ALL=(ALL) NOPASSWD: $BREW_PATH" >> "$BREW_SUDOERS_FILE"
+            _found_brew=true
+        fi
+    done
+    if $_found_brew; then
+        chmod 440 "$BREW_SUDOERS_FILE"
+        success "Sudoers entry created for brew access"
+    else
+        rm -f "$BREW_SUDOERS_FILE"
+        warning "Homebrew not found - brew update detection may not work until Homebrew is installed"
     fi
 
     PLIST_PATH="/Library/LaunchDaemons/net.patchmon.patchmon-agent.plist"

--- a/agents/patchmon_install.sh
+++ b/agents/patchmon_install.sh
@@ -913,9 +913,8 @@ elif [ "$(uname -s 2>/dev/null)" = "Darwin" ] || [ "$PATCHMON_OS" = "darwin" ]; 
     <string>net.patchmon.patchmon-agent</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/sh</string>
-        <string>-c</string>
-        <string>sleep 30 &amp;&amp; /usr/local/bin/patchmon-agent serve</string>
+        <string>/usr/local/bin/patchmon-agent</string>
+        <string>serve</string>
     </array>
     <key>EnvironmentVariables</key>
     <dict>

--- a/agents/patchmon_install.sh
+++ b/agents/patchmon_install.sh
@@ -866,9 +866,62 @@ EOF
         success "PatchMon Agent service configured"
     fi
     SERVICE_TYPE="rc.d"
+elif [ "$(uname -s 2>/dev/null)" = "Darwin" ] || [ "$PATCHMON_OS" = "darwin" ]; then
+    # macOS: create and load launchd plist directly
+    info "Setting up macOS launchd service..."
+
+    PLIST_PATH="/Library/LaunchDaemons/net.patchmon.patchmon-agent.plist"
+
+    # Unload existing service if it is loaded
+    if launchctl list 2>/dev/null | grep -q "net.patchmon.patchmon-agent"; then
+        warning "Stopping existing PatchMon agent service..."
+        launchctl unload "$PLIST_PATH" 2>/dev/null || true
+    fi
+
+    # Write the launchd plist
+    cat > "$PLIST_PATH" << 'PLIST_EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>net.patchmon.patchmon-agent</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/patchmon-agent</string>
+        <string>serve</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:/opt/homebrew/sbin</string>
+    </dict>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/etc/patchmon/logs/patchmon-agent.log</string>
+    <key>StandardErrorPath</key>
+    <string>/etc/patchmon/logs/patchmon-agent.log</string>
+</dict>
+</plist>
+PLIST_EOF
+
+    chmod 644 "$PLIST_PATH"
+
+    # Load the service
+    if launchctl load "$PLIST_PATH"; then
+        success "PatchMon Agent launchd service started successfully"
+        info "WebSocket connection established"
+    else
+        warning "Service may have failed to start. Check status with: launchctl list net.patchmon.patchmon-agent"
+    fi
+
+    SERVICE_TYPE="launchd"
 else
     # No init system detected, use crontab as fallback
-    warning "No init system detected (systemd, OpenRC, or FreeBSD). Using crontab for service management."
+    warning "No init system detected (systemd, OpenRC, FreeBSD, or macOS). Using crontab for service management."
     
     # Clean up old crontab entries if they exist
     if crontab -l 2>/dev/null | grep -q "patchmon-agent"; then
@@ -903,6 +956,8 @@ elif [ "$SERVICE_TYPE" = "openrc" ]; then
     echo "   • OpenRC service configured and running"
 elif [ "$SERVICE_TYPE" = "rc.d" ]; then
     echo "   • FreeBSD rc.d service configured and running"
+elif [ "$SERVICE_TYPE" = "launchd" ]; then
+    echo "   • macOS launchd service configured and running"
 else
     echo "   • Service configured via crontab"
 fi
@@ -939,6 +994,10 @@ elif [ "$SERVICE_TYPE" = "rc.d" ]; then
     echo "   • Service status: service patchmon_agent status"
     echo "   • Service logs: tail -f /etc/patchmon/logs/patchmon-agent.log"
     echo "   • Restart service: service patchmon_agent restart"
+elif [ "$SERVICE_TYPE" = "launchd" ]; then
+    echo "   • Service status: launchctl list net.patchmon.patchmon-agent"
+    echo "   • Service logs: tail -f /etc/patchmon/logs/patchmon-agent.log"
+    echo "   • Restart service: launchctl unload /Library/LaunchDaemons/net.patchmon.patchmon-agent.plist && launchctl load /Library/LaunchDaemons/net.patchmon.patchmon-agent.plist"
 else
     echo "   • Service logs: tail -f /etc/patchmon/logs/patchmon-agent.log"
     echo "   • Restart service: pkill -f 'patchmon-agent serve' && /usr/local/bin/patchmon-agent serve &"

--- a/agents/patchmon_install.sh
+++ b/agents/patchmon_install.sh
@@ -888,8 +888,9 @@ elif [ "$(uname -s 2>/dev/null)" = "Darwin" ] || [ "$PATCHMON_OS" = "darwin" ]; 
     <string>net.patchmon.patchmon-agent</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/usr/local/bin/patchmon-agent</string>
-        <string>serve</string>
+        <string>/bin/sh</string>
+        <string>-c</string>
+        <string>sleep 30 &amp;&amp; /usr/local/bin/patchmon-agent serve</string>
     </array>
     <key>EnvironmentVariables</key>
     <dict>

--- a/agents/patchmon_install.sh
+++ b/agents/patchmon_install.sh
@@ -870,6 +870,31 @@ elif [ "$(uname -s 2>/dev/null)" = "Darwin" ] || [ "$PATCHMON_OS" = "darwin" ]; 
     # macOS: create and load launchd plist directly
     info "Setting up macOS launchd service..."
 
+    # Grant the launchd daemon (root) permission to invoke brew as the console user.
+    # Without this, sudo in a TTY-less launchd context is rejected.
+    CONSOLE_USER=$(stat -f "%Su" /dev/console 2>/dev/null || echo "")
+    if [ -n "$CONSOLE_USER" ] && [ "$CONSOLE_USER" != "root" ]; then
+        info "Configuring sudoers for brew access as user: $CONSOLE_USER"
+        BREW_SUDOERS_FILE="/etc/sudoers.d/patchmon"
+        : > "$BREW_SUDOERS_FILE"
+        _found_brew=false
+        for BREW_PATH in /opt/homebrew/bin/brew /usr/local/bin/brew; do
+            if [ -f "$BREW_PATH" ]; then
+                echo "root ALL=($CONSOLE_USER) NOPASSWD: $BREW_PATH" >> "$BREW_SUDOERS_FILE"
+                _found_brew=true
+            fi
+        done
+        if $_found_brew; then
+            chmod 440 "$BREW_SUDOERS_FILE"
+            success "Sudoers entry created for brew access as $CONSOLE_USER"
+        else
+            rm -f "$BREW_SUDOERS_FILE"
+            warning "Homebrew not found - brew update detection may not work until Homebrew is installed"
+        fi
+    else
+        warning "Could not determine console user - brew update detection may not work"
+    fi
+
     PLIST_PATH="/Library/LaunchDaemons/net.patchmon.patchmon-agent.plist"
 
     # Unload existing service if it is loaded

--- a/agents/patchmon_remove.sh
+++ b/agents/patchmon_remove.sh
@@ -247,6 +247,17 @@ if [ -f "/usr/local/bin/patchmon-agent.sh" ]; then
     AGENTS_REMOVED=1
 fi
 
+# Remove macOS brew wrapper and sudoers entry
+if [ -f "/usr/local/bin/patchmon-brew" ]; then
+    warning "Removing brew wrapper: /usr/local/bin/patchmon-brew"
+    rm -f /usr/local/bin/patchmon-brew
+    AGENTS_REMOVED=1
+fi
+if [ -f "/etc/sudoers.d/patchmon" ]; then
+    warning "Removing sudoers entry: /etc/sudoers.d/patchmon"
+    rm -f /etc/sudoers.d/patchmon
+fi
+
 # Remove backup files for Go agent
 if ls /usr/local/bin/patchmon-agent.backup.* >/dev/null 2>&1; then
     warning "Removing Go agent backup files..."

--- a/frontend/src/components/AddHostWizard.jsx
+++ b/frontend/src/components/AddHostWizard.jsx
@@ -2,7 +2,8 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { CheckCircle, Copy, Download, RefreshCw, Wifi, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { DiWindows } from "react-icons/di";
-import { SiFreebsd, SiLinux, SiMacos } from "react-icons/si";
+import { FaApple } from "react-icons/fa";
+import { SiFreebsd, SiLinux } from "react-icons/si";
 import { useNavigate } from "react-router-dom";
 import {
 	adminHostsAPI,
@@ -376,7 +377,7 @@ const AddHostWizard = ({ isOpen, onClose, onSuccess }) => {
 										: "border-secondary-300 dark:border-secondary-600 hover:border-primary-400"
 								}`}
 							>
-								<SiMacos className="h-12 w-12 text-secondary-700 dark:text-secondary-200 mb-2" />
+								<FaApple className="h-12 w-12 text-secondary-700 dark:text-secondary-200 mb-2" />
 								<span className="text-sm font-medium">macOS</span>
 							</button>
 							<button

--- a/frontend/src/components/AddHostWizard.jsx
+++ b/frontend/src/components/AddHostWizard.jsx
@@ -2,7 +2,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { CheckCircle, Copy, Download, RefreshCw, Wifi, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { DiWindows } from "react-icons/di";
-import { SiFreebsd, SiLinux } from "react-icons/si";
+import { SiFreebsd, SiLinux, SiMacos } from "react-icons/si";
 import { useNavigate } from "react-router-dom";
 import {
 	adminHostsAPI,
@@ -37,7 +37,7 @@ const hasInitialReport = (hostData) => {
 
 const AddHostWizard = ({ isOpen, onClose, onSuccess }) => {
 	const [step, setStep] = useState(1);
-	const [platform, setPlatform] = useState("linux"); // linux | freebsd | windows
+	const [platform, setPlatform] = useState("linux"); // linux | freebsd | windows | darwin
 	const [formData, setFormData] = useState({
 		friendly_name: "",
 		hostGroupIds: [],
@@ -93,6 +93,7 @@ const AddHostWizard = ({ isOpen, onClose, onSuccess }) => {
 		const params = new URLSearchParams();
 		if (platform === "freebsd") params.set("os", "freebsd");
 		if (platform === "windows") params.set("os", "windows");
+		if (platform === "darwin") params.set("os", "darwin");
 		if (force && platform !== "windows") params.set("force", "true");
 		const qs = params.toString();
 		return qs ? `${base}?${qs}` : base;
@@ -368,6 +369,18 @@ const AddHostWizard = ({ isOpen, onClose, onSuccess }) => {
 							</button>
 							<button
 								type="button"
+								onClick={() => setPlatform("darwin")}
+								className={`flex flex-col items-center justify-center p-6 rounded-lg border-2 transition-all ${
+									platform === "darwin"
+										? "border-primary-500 bg-primary-50 dark:bg-primary-900/30"
+										: "border-secondary-300 dark:border-secondary-600 hover:border-primary-400"
+								}`}
+							>
+								<SiMacos className="h-12 w-12 text-secondary-700 dark:text-secondary-200 mb-2" />
+								<span className="text-sm font-medium">macOS</span>
+							</button>
+							<button
+								type="button"
 								onClick={() => setPlatform("windows")}
 								className={`flex flex-col items-center justify-center p-6 rounded-lg border-2 transition-all ${
 									platform === "windows"
@@ -555,8 +568,10 @@ const AddHostWizard = ({ isOpen, onClose, onSuccess }) => {
 							{platform === "windows"
 								? "Windows"
 								: platform === "freebsd"
-									? "FreeBSD"
-									: "Linux"}{" "}
+                                        ? "FreeBSD"
+                                            : platform === "darwin"
+                                                ? "macOS"
+                                                : "Linux"}
 							host to install the agent
 							{platform === "windows"
 								? " (run PowerShell as Administrator)"

--- a/frontend/src/components/SshTerminal.jsx
+++ b/frontend/src/components/SshTerminal.jsx
@@ -238,8 +238,14 @@ const SshTerminal = ({ host, isOpen, onClose, embedded = false }) => {
 		const curlFlags = getCurlFlags();
 		const base = `${serverUrl}/api/v1/hosts/install`;
 		const params = new URLSearchParams();
-		if (host?.expected_platform === "freebsd") params.set("os", "freebsd");
-		if (host?.expected_platform === "darwin" || host?.expected_platform === "macos") params.set("os", "darwin");
+		const osType = (host?.os_type || "").toLowerCase();
+		if (host?.expected_platform === "freebsd" || osType.includes("freebsd")) params.set("os", "freebsd");
+		if (
+			host?.expected_platform === "darwin" ||
+			host?.expected_platform === "macos" ||
+			osType.includes("darwin") ||
+			osType.includes("mac")
+		) params.set("os", "darwin");
 		const installUrl = params.toString() ? `${base}?${params}` : base;
 		const shell_cmd = host?.expected_platform === "freebsd" ? "sh" : "sudo sh";
 		return `curl ${curlFlags} "${installUrl}" -H "X-API-ID: ${host.api_id}" -H "X-API-KEY: ${host.api_key}" | ${shell_cmd}`;

--- a/frontend/src/components/SshTerminal.jsx
+++ b/frontend/src/components/SshTerminal.jsx
@@ -239,6 +239,7 @@ const SshTerminal = ({ host, isOpen, onClose, embedded = false }) => {
 		const base = `${serverUrl}/api/v1/hosts/install`;
 		const params = new URLSearchParams();
 		if (host?.expected_platform === "freebsd") params.set("os", "freebsd");
+		if (host?.expected_platform === "darwin" || host?.expected_platform === "macos") params.set("os", "darwin");
 		const installUrl = params.toString() ? `${base}?${params}` : base;
 		const shell_cmd = host?.expected_platform === "freebsd" ? "sh" : "sudo sh";
 		return `curl ${curlFlags} "${installUrl}" -H "X-API-ID: ${host.api_id}" -H "X-API-KEY: ${host.api_key}" | ${shell_cmd}`;

--- a/frontend/src/pages/hostdetail/CredentialsModal.jsx
+++ b/frontend/src/pages/hostdetail/CredentialsModal.jsx
@@ -79,10 +79,18 @@ const CredentialsModal = ({ host, isOpen, onClose, plaintextApiKey }) => {
 	const getInstallUrl = () => {
 		const base = `${serverUrl}/api/v1/hosts/install`;
 		const params = new URLSearchParams();
-		if (host?.expected_platform === "freebsd") params.set("os", "freebsd");
-		if (host?.expected_platform === "darwin" || host?.expected_platform === "macos") params.set("os", "darwin");
-		if (host?.expected_platform === "windows" || host?.os_type === "windows")
-			params.set("os", "windows");
+		const osType = (host?.os_type || "").toLowerCase();
+		if (host?.expected_platform === "freebsd" || osType.includes("freebsd")) params.set("os", "freebsd");
+		if (
+			host?.expected_platform === "darwin" ||
+			host?.expected_platform === "macos" ||
+			osType.includes("darwin") ||
+			osType.includes("mac")
+		) params.set("os", "darwin");
+		if (
+			host?.expected_platform === "windows" ||
+			osType.includes("windows")
+		) params.set("os", "windows");
 		if (forceInstall && host?.expected_platform !== "windows")
 			params.set("force", "true");
 		const qs = params.toString();

--- a/frontend/src/pages/hostdetail/CredentialsModal.jsx
+++ b/frontend/src/pages/hostdetail/CredentialsModal.jsx
@@ -80,6 +80,7 @@ const CredentialsModal = ({ host, isOpen, onClose, plaintextApiKey }) => {
 		const base = `${serverUrl}/api/v1/hosts/install`;
 		const params = new URLSearchParams();
 		if (host?.expected_platform === "freebsd") params.set("os", "freebsd");
+		if (host?.expected_platform === "darwin" || host?.expected_platform === "macos") params.set("os", "darwin");
 		if (host?.expected_platform === "windows" || host?.os_type === "windows")
 			params.set("os", "windows");
 		if (forceInstall && host?.expected_platform !== "windows")

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "patchmon",
-	"version": "2.0.0",
+	"version": "2.0.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "patchmon",
-			"version": "2.0.0",
+			"version": "2.0.2",
 			"license": "AGPL-3.0",
 			"workspaces": [
 				"frontend"
@@ -23,7 +23,7 @@
 		},
 		"frontend": {
 			"name": "patchmon-frontend",
-			"version": "2.0.0",
+			"version": "2.0.2",
 			"license": "AGPL-3.0",
 			"dependencies": {
 				"@dnd-kit/core": "6.3.1",

--- a/server-source-code/internal/agents/patchmon_install.sh
+++ b/server-source-code/internal/agents/patchmon_install.sh
@@ -139,7 +139,14 @@ get_machine_id() {
         return
     fi
     if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
-        _uuid=$(ioreg -rd1 -c IOPlatformExpertDevice 2>/dev/null | awk -F'"' '/IOPlatformUUID/ {print $4}')
+        _uuid=""
+        _ioreg_retries=5
+        while [ "$_ioreg_retries" -gt 0 ]; do
+            _uuid=$(ioreg -rd1 -c IOPlatformExpertDevice 2>/dev/null | awk -F'"' '/IOPlatformUUID/ {print $4}')
+            [ -n "$_uuid" ] && break
+            _ioreg_retries=$((_ioreg_retries - 1))
+            [ "$_ioreg_retries" -gt 0 ] && sleep 2
+        done
         if [ -n "$_uuid" ]; then
             echo "$_uuid"
             return
@@ -933,6 +940,12 @@ elif [ "$(uname -s 2>/dev/null)" = "Darwin" ] || [ "$PATCHMON_OS" = "darwin" ]; 
     info "Setting up macOS launchd service..."
 
     PLIST_PATH="/Library/LaunchDaemons/net.patchmon.patchmon-agent.plist"
+
+    # Kill any running agent processes to avoid duplicates after reinstall
+    if pkill -f 'patchmon-agent serve' 2>/dev/null; then
+        warning "Killed existing PatchMon agent process"
+        sleep 1
+    fi
 
     # Unload existing service if it is loaded
     if launchctl list 2>/dev/null | grep -q "net.patchmon.patchmon-agent"; then

--- a/server-source-code/internal/agents/patchmon_install.sh
+++ b/server-source-code/internal/agents/patchmon_install.sh
@@ -674,12 +674,37 @@ if [ -f "/usr/local/bin/patchmon-agent.sh" ]; then
 fi
 
 # Download the binary
-curl $CURL_FLAGS \
+TMP_AGENT_BINARY=$(mktemp /tmp/patchmon-agent.XXXXXX)
+HTTP_STATUS=$(curl -sS $CURL_FLAGS \
     -H "X-API-ID: $API_ID" \
     -H "X-API-KEY: $API_KEY" \
+    -w "%{http_code}" \
     "$PATCHMON_URL/api/v1/hosts/agent/download?arch=$ARCHITECTURE&os=$PATCHMON_OS&force=binary" \
-    -o /usr/local/bin/patchmon-agent
+    -o "$TMP_AGENT_BINARY")
 
+if [ "$HTTP_STATUS" != "200" ]; then
+    printf "%b\n" "${RED}ERROR: Agent binary download failed with HTTP status $HTTP_STATUS:${NC}" >&2
+    if [ -s "$TMP_AGENT_BINARY" ]; then
+        cat "$TMP_AGENT_BINARY" >&2
+    fi
+    rm -f "$TMP_AGENT_BINARY"
+    error "Failed to download PatchMon agent binary for $PATCHMON_OS/$ARCHITECTURE. Verify the server has the matching binary."
+fi
+
+if [ ! -s "$TMP_AGENT_BINARY" ]; then
+    rm -f "$TMP_AGENT_BINARY"
+    error "Downloaded agent binary is empty. Please verify the server package bundle."
+fi
+
+# Detect error payloads returned as JSON instead of a binary
+if [ "$(head -c 1 "$TMP_AGENT_BINARY" 2>/dev/null)" = "{" ]; then
+    printf "%b\n" "${RED}ERROR: Received error response when downloading agent binary:${NC}" >&2
+    cat "$TMP_AGENT_BINARY" >&2
+    rm -f "$TMP_AGENT_BINARY"
+    error "Agent binary download failed"
+fi
+
+mv "$TMP_AGENT_BINARY" /usr/local/bin/patchmon-agent
 chmod +x /usr/local/bin/patchmon-agent
 
 # Get the agent version from the binary

--- a/server-source-code/internal/agents/patchmon_install.sh
+++ b/server-source-code/internal/agents/patchmon_install.sh
@@ -939,6 +939,31 @@ elif [ "$(uname -s 2>/dev/null)" = "Darwin" ] || [ "$PATCHMON_OS" = "darwin" ]; 
     # macOS: create and load launchd plist directly
     info "Setting up macOS launchd service..."
 
+    # Grant the launchd daemon (root) permission to invoke brew as the console user.
+    # Without this, sudo in a TTY-less launchd context is rejected.
+    CONSOLE_USER=$(stat -f "%Su" /dev/console 2>/dev/null || echo "")
+    if [ -n "$CONSOLE_USER" ] && [ "$CONSOLE_USER" != "root" ]; then
+        info "Configuring sudoers for brew access as user: $CONSOLE_USER"
+        BREW_SUDOERS_FILE="/etc/sudoers.d/patchmon"
+        : > "$BREW_SUDOERS_FILE"
+        _found_brew=false
+        for BREW_PATH in /opt/homebrew/bin/brew /usr/local/bin/brew; do
+            if [ -f "$BREW_PATH" ]; then
+                echo "root ALL=($CONSOLE_USER) NOPASSWD: $BREW_PATH" >> "$BREW_SUDOERS_FILE"
+                _found_brew=true
+            fi
+        done
+        if $_found_brew; then
+            chmod 440 "$BREW_SUDOERS_FILE"
+            success "Sudoers entry created for brew access as $CONSOLE_USER"
+        else
+            rm -f "$BREW_SUDOERS_FILE"
+            warning "Homebrew not found - brew update detection may not work until Homebrew is installed"
+        fi
+    else
+        warning "Could not determine console user - brew update detection may not work"
+    fi
+
     PLIST_PATH="/Library/LaunchDaemons/net.patchmon.patchmon-agent.plist"
 
     # Kill any running agent processes to avoid duplicates after reinstall

--- a/server-source-code/internal/agents/patchmon_install.sh
+++ b/server-source-code/internal/agents/patchmon_install.sh
@@ -963,8 +963,9 @@ elif [ "$(uname -s 2>/dev/null)" = "Darwin" ] || [ "$PATCHMON_OS" = "darwin" ]; 
     <string>net.patchmon.patchmon-agent</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/usr/local/bin/patchmon-agent</string>
-        <string>serve</string>
+        <string>/bin/sh</string>
+        <string>-c</string>
+        <string>sleep 30 &amp;&amp; /usr/local/bin/patchmon-agent serve</string>
     </array>
     <key>EnvironmentVariables</key>
     <dict>

--- a/server-source-code/internal/agents/patchmon_install.sh
+++ b/server-source-code/internal/agents/patchmon_install.sh
@@ -939,29 +939,50 @@ elif [ "$(uname -s 2>/dev/null)" = "Darwin" ] || [ "$PATCHMON_OS" = "darwin" ]; 
     # macOS: create and load launchd plist directly
     info "Setting up macOS launchd service..."
 
-    # Grant the launchd daemon (root) permission to invoke brew as the console user.
-    # Without this, sudo in a TTY-less launchd context is rejected.
-    CONSOLE_USER=$(stat -f "%Su" /dev/console 2>/dev/null || echo "")
+    # Write the patchmon-brew wrapper. The agent runs as root (launchd daemon) but
+    # brew must run as the GUI user. This script resolves the console user at runtime
+    # so it works correctly even if the user changes between installs.
+    BREW_WRAPPER="/usr/local/bin/patchmon-brew"
+    cat > "$BREW_WRAPPER" << 'BREW_EOF'
+#!/bin/sh
+CONSOLE_USER=$(stat -f "%Su" /dev/console 2>/dev/null || echo "")
+for BREW_PATH in /opt/homebrew/bin/brew /usr/local/bin/brew; do
+    [ -f "$BREW_PATH" ] || continue
     if [ -n "$CONSOLE_USER" ] && [ "$CONSOLE_USER" != "root" ]; then
-        info "Configuring sudoers for brew access as user: $CONSOLE_USER"
-        BREW_SUDOERS_FILE="/etc/sudoers.d/patchmon"
-        : > "$BREW_SUDOERS_FILE"
-        _found_brew=false
-        for BREW_PATH in /opt/homebrew/bin/brew /usr/local/bin/brew; do
-            if [ -f "$BREW_PATH" ]; then
-                echo "root ALL=($CONSOLE_USER) NOPASSWD: $BREW_PATH" >> "$BREW_SUDOERS_FILE"
-                _found_brew=true
-            fi
-        done
-        if $_found_brew; then
-            chmod 440 "$BREW_SUDOERS_FILE"
-            success "Sudoers entry created for brew access as $CONSOLE_USER"
-        else
-            rm -f "$BREW_SUDOERS_FILE"
-            warning "Homebrew not found - brew update detection may not work until Homebrew is installed"
-        fi
+        exec sudo -n -u "$CONSOLE_USER" env \
+            HOMEBREW_NO_AUTO_UPDATE=1 \
+            HOMEBREW_NO_ANALYTICS=1 \
+            HOMEBREW_NO_ENV_HINTS=1 \
+            "$BREW_PATH" "$@"
     else
-        warning "Could not determine console user - brew update detection may not work"
+        exec env \
+            HOMEBREW_NO_AUTO_UPDATE=1 \
+            HOMEBREW_NO_ANALYTICS=1 \
+            HOMEBREW_NO_ENV_HINTS=1 \
+            "$BREW_PATH" "$@"
+    fi
+done
+exit 1
+BREW_EOF
+    chmod 755 "$BREW_WRAPPER"
+    success "patchmon-brew wrapper written to $BREW_WRAPPER"
+
+    # Grant root permission to invoke brew as any console user via the wrapper.
+    BREW_SUDOERS_FILE="/etc/sudoers.d/patchmon"
+    : > "$BREW_SUDOERS_FILE"
+    _found_brew=false
+    for BREW_PATH in /opt/homebrew/bin/brew /usr/local/bin/brew; do
+        if [ -f "$BREW_PATH" ]; then
+            echo "root ALL=(ALL) NOPASSWD: $BREW_PATH" >> "$BREW_SUDOERS_FILE"
+            _found_brew=true
+        fi
+    done
+    if $_found_brew; then
+        chmod 440 "$BREW_SUDOERS_FILE"
+        success "Sudoers entry created for brew access"
+    else
+        rm -f "$BREW_SUDOERS_FILE"
+        warning "Homebrew not found - brew update detection may not work until Homebrew is installed"
     fi
 
     PLIST_PATH="/Library/LaunchDaemons/net.patchmon.patchmon-agent.plist"

--- a/server-source-code/internal/agents/patchmon_install.sh
+++ b/server-source-code/internal/agents/patchmon_install.sh
@@ -1009,11 +1009,13 @@ else
     (crontab -l 2>/dev/null; echo "@reboot /usr/local/bin/patchmon-agent serve >/dev/null 2>&1") | crontab -
     info "Added crontab entry for PatchMon agent"
     
-    # Start the agent manually
-    /usr/local/bin/patchmon-agent serve >/dev/null 2>&1 &
-    success "PatchMon Agent started in background"
-    info "WebSocket connection established"
-    
+    # Start the agent manually (only if launchd is not already managing it)
+    if ! launchctl list net.patchmon.patchmon-agent >/dev/null 2>&1; then
+        /usr/local/bin/patchmon-agent serve >/dev/null 2>&1 &
+        success "PatchMon Agent started in background"
+        info "WebSocket connection established"
+    fi
+
     SERVICE_TYPE="crontab"
 fi
 

--- a/server-source-code/internal/agents/patchmon_install.sh
+++ b/server-source-code/internal/agents/patchmon_install.sh
@@ -929,15 +929,57 @@ EOF
     fi
     SERVICE_TYPE="rc.d"
 elif [ "$(uname -s 2>/dev/null)" = "Darwin" ] || [ "$PATCHMON_OS" = "darwin" ]; then
-    # macOS: install launchd service using the agent install-service command
+    # macOS: create and load launchd plist directly
     info "Setting up macOS launchd service..."
-    if /usr/local/bin/patchmon-agent install-service >/dev/null 2>/dev/null; then
-        success "macOS launchd service installed successfully"
+
+    PLIST_PATH="/Library/LaunchDaemons/net.patchmon.patchmon-agent.plist"
+
+    # Unload existing service if it is loaded
+    if launchctl list 2>/dev/null | grep -q "net.patchmon.patchmon-agent"; then
+        warning "Stopping existing PatchMon agent service..."
+        launchctl unload "$PLIST_PATH" 2>/dev/null || true
+    fi
+
+    # Write the launchd plist
+    cat > "$PLIST_PATH" << 'PLIST_EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>net.patchmon.patchmon-agent</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/patchmon-agent</string>
+        <string>serve</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:/opt/homebrew/sbin</string>
+    </dict>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>/etc/patchmon/logs/patchmon-agent.log</string>
+    <key>StandardErrorPath</key>
+    <string>/etc/patchmon/logs/patchmon-agent.log</string>
+</dict>
+</plist>
+PLIST_EOF
+
+    chmod 644 "$PLIST_PATH"
+
+    # Load the service
+    if launchctl load "$PLIST_PATH"; then
+        success "PatchMon Agent launchd service started successfully"
         info "WebSocket connection established"
     else
-        warning "Could not install launchd service automatically."
-        warning "Run '/usr/local/bin/patchmon-agent install-service' manually on macOS."
+        warning "Service may have failed to start. Check status with: launchctl list net.patchmon.patchmon-agent"
     fi
+
     SERVICE_TYPE="launchd"
 else
     # No init system detected, use crontab as fallback
@@ -1015,9 +1057,9 @@ elif [ "$SERVICE_TYPE" = "rc.d" ]; then
     echo "   • Service logs: tail -f /etc/patchmon/logs/patchmon-agent.log"
     echo "   • Restart service: service patchmon_agent restart"
 elif [ "$SERVICE_TYPE" = "launchd" ]; then
-    echo "   • Service status: launchctl print system/net.patchmon.patchmon-agent"
-    echo "   • Service logs: tail -f /etc/patchmon/logs/patchmon-agent.out.log /etc/patchmon/logs/patchmon-agent.err.log"
-    echo "   • Restart service: launchctl kickstart -k system/net.patchmon.patchmon-agent"
+    echo "   • Service status: launchctl list net.patchmon.patchmon-agent"
+    echo "   • Service logs: tail -f /etc/patchmon/logs/patchmon-agent.log"
+    echo "   • Restart service: launchctl unload /Library/LaunchDaemons/net.patchmon.patchmon-agent.plist && launchctl load /Library/LaunchDaemons/net.patchmon.patchmon-agent.plist"
 else
     echo "   • Service logs: tail -f /etc/patchmon/logs/patchmon-agent.log"
     echo "   • Restart service: pkill -f 'patchmon-agent serve' && /usr/local/bin/patchmon-agent serve &"

--- a/server-source-code/internal/agents/patchmon_install.sh
+++ b/server-source-code/internal/agents/patchmon_install.sh
@@ -138,6 +138,15 @@ get_machine_id() {
         echo "patchmon-freebsd-$(hostname 2>/dev/null)-$(date +%s 2>/dev/null)"
         return
     fi
+    if [ "$(uname -s 2>/dev/null)" = "Darwin" ]; then
+        _uuid=$(ioreg -rd1 -c IOPlatformExpertDevice 2>/dev/null | awk -F'"' '/IOPlatformUUID/ {print $4}')
+        if [ -n "$_uuid" ]; then
+            echo "$_uuid"
+            return
+        fi
+        echo "patchmon-darwin-$(hostname 2>/dev/null)-$(date +%s 2>/dev/null)"
+        return
+    fi
     # Linux: try multiple sources
     if [ -f /etc/machine-id ]; then
         cat /etc/machine-id
@@ -154,8 +163,20 @@ if [ -z "$PATCHMON_URL" ] || [ -z "$API_ID" ] || [ -z "$API_KEY" ]; then
     error "Missing required parameters. This script should be called via the PatchMon web interface."
 fi
 
-# Default PATCHMON_OS to linux if not set (backward compatibility when os param not in URL)
-PATCHMON_OS="${PATCHMON_OS:-linux}"
+# Default PATCHMON_OS based on environment or runtime if not set
+if [ -z "$PATCHMON_OS" ]; then
+    case "$(uname -s 2>/dev/null)" in
+        Darwin)
+            PATCHMON_OS="darwin"
+            ;;
+        FreeBSD)
+            PATCHMON_OS="freebsd"
+            ;;
+        *)
+            PATCHMON_OS="linux"
+            ;;
+    esac
+fi
 
 # Auto-detect architecture if not explicitly set
 if [ -z "$ARCHITECTURE" ]; then
@@ -471,6 +492,21 @@ elif command -v apk >/dev/null 2>&1; then
     echo ""
     info "Installing curl..."
     install_apk_packages curl
+elif [ "$(uname -s 2>/dev/null)" = "Darwin" ] || [ "$PATCHMON_OS" = "darwin" ]; then
+    # macOS: curl should be available, otherwise attempt Homebrew install
+    info "Detected macOS"
+    echo ""
+    if ! command -v curl >/dev/null 2>&1; then
+        info "curl is not installed. Attempting to install via Homebrew..."
+        if command -v brew >/dev/null 2>&1; then
+            brew install curl || true
+        else
+            warning "curl not found and Homebrew is not installed."
+            warning "Install Homebrew and run: brew install curl"
+        fi
+    else
+        success "curl already installed"
+    fi
 elif [ "$(uname -s 2>/dev/null)" = "FreeBSD" ] || [ "$PATCHMON_OS" = "freebsd" ]; then
     # FreeBSD/pfSense: only curl is required. Skip pkg if curl already present
     # (on pfSense, pkg repos may be unconfigured and "pkg install curl" can fail with "no match")
@@ -867,9 +903,20 @@ EOF
         success "PatchMon Agent service configured"
     fi
     SERVICE_TYPE="rc.d"
+elif [ "$(uname -s 2>/dev/null)" = "Darwin" ] || [ "$PATCHMON_OS" = "darwin" ]; then
+    # macOS: install launchd service using the agent install-service command
+    info "Setting up macOS launchd service..."
+    if /usr/local/bin/patchmon-agent install-service >/dev/null 2>/dev/null; then
+        success "macOS launchd service installed successfully"
+        info "WebSocket connection established"
+    else
+        warning "Could not install launchd service automatically."
+        warning "Run '/usr/local/bin/patchmon-agent install-service' manually on macOS."
+    fi
+    SERVICE_TYPE="launchd"
 else
     # No init system detected, use crontab as fallback
-    warning "No init system detected (systemd, OpenRC, or FreeBSD). Using crontab for service management."
+    warning "No init system detected (systemd, OpenRC, FreeBSD, or macOS). Using crontab for service management."
     
     # Clean up old crontab entries if they exist
     if crontab -l 2>/dev/null | grep -q "patchmon-agent"; then
@@ -904,6 +951,8 @@ elif [ "$SERVICE_TYPE" = "openrc" ]; then
     echo "   • OpenRC service configured and running"
 elif [ "$SERVICE_TYPE" = "rc.d" ]; then
     echo "   • FreeBSD rc.d service configured and running"
+elif [ "$SERVICE_TYPE" = "launchd" ]; then
+    echo "   • macOS launchd service configured and running"
 else
     echo "   • Service configured via crontab"
 fi
@@ -940,6 +989,10 @@ elif [ "$SERVICE_TYPE" = "rc.d" ]; then
     echo "   • Service status: service patchmon_agent status"
     echo "   • Service logs: tail -f /etc/patchmon/logs/patchmon-agent.log"
     echo "   • Restart service: service patchmon_agent restart"
+elif [ "$SERVICE_TYPE" = "launchd" ]; then
+    echo "   • Service status: launchctl print system/net.patchmon.patchmon-agent"
+    echo "   • Service logs: tail -f /etc/patchmon/logs/patchmon-agent.out.log /etc/patchmon/logs/patchmon-agent.err.log"
+    echo "   • Restart service: launchctl kickstart -k system/net.patchmon.patchmon-agent"
 else
     echo "   • Service logs: tail -f /etc/patchmon/logs/patchmon-agent.log"
     echo "   • Restart service: pkill -f 'patchmon-agent serve' && /usr/local/bin/patchmon-agent serve &"

--- a/server-source-code/internal/agents/patchmon_install.sh
+++ b/server-source-code/internal/agents/patchmon_install.sh
@@ -988,9 +988,8 @@ elif [ "$(uname -s 2>/dev/null)" = "Darwin" ] || [ "$PATCHMON_OS" = "darwin" ]; 
     <string>net.patchmon.patchmon-agent</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/bin/sh</string>
-        <string>-c</string>
-        <string>sleep 30 &amp;&amp; /usr/local/bin/patchmon-agent serve</string>
+        <string>/usr/local/bin/patchmon-agent</string>
+        <string>serve</string>
     </array>
     <key>EnvironmentVariables</key>
     <dict>

--- a/server-source-code/internal/handler/install.go
+++ b/server-source-code/internal/handler/install.go
@@ -142,7 +142,7 @@ func (h *InstallHandler) ServeInstall(w http.ResponseWriter, r *http.Request) {
 		architecture = ""
 	}
 	osParam := r.URL.Query().Get("os")
-	if osParam != "linux" && osParam != "freebsd" && osParam != "windows" {
+	if osParam != "linux" && osParam != "freebsd" && osParam != "windows" && osParam != "darwin" {
 		osParam = "linux"
 	}
 
@@ -537,6 +537,8 @@ func (h *InstallHandler) ServeAgentVersion(w http.ResponseWriter, r *http.Reques
 			osParam = "windows"
 		} else if strings.Contains(ep, "freebsd") || strings.Contains(ep, "pfsense") {
 			osParam = "freebsd"
+		} else if ep == "darwin" || strings.Contains(ep, "mac") {
+			osParam = "darwin"
 		} else {
 			osParam = "linux"
 		}
@@ -547,6 +549,8 @@ func (h *InstallHandler) ServeAgentVersion(w http.ResponseWriter, r *http.Reques
 			osParam = "windows"
 		} else if strings.Contains(reported, "freebsd") || strings.Contains(reported, "pfsense") {
 			osParam = "freebsd"
+		} else if strings.Contains(reported, "darwin") || strings.Contains(reported, "mac") {
+			osParam = "darwin"
 		} else {
 			osParam = "linux"
 		}
@@ -555,9 +559,9 @@ func (h *InstallHandler) ServeAgentVersion(w http.ResponseWriter, r *http.Reques
 		osParam = "linux"
 	}
 
-	validOss := map[string]bool{"linux": true, "freebsd": true, "windows": true}
+	validOss := map[string]bool{"linux": true, "freebsd": true, "windows": true, "darwin": true}
 	if !validOss[osParam] {
-		JSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid os. Must be one of: linux, freebsd, windows"})
+		JSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid os. Must be one of: linux, freebsd, windows, darwin"})
 		return
 	}
 
@@ -721,6 +725,8 @@ func (h *InstallHandler) ServeAgentDownload(w http.ResponseWriter, r *http.Reque
 			osParam = "windows"
 		} else if strings.Contains(ep, "freebsd") || strings.Contains(ep, "pfsense") {
 			osParam = "freebsd"
+		} else if ep == "darwin" || strings.Contains(ep, "mac") {
+			osParam = "darwin"
 		} else {
 			osParam = "linux"
 		}
@@ -731,6 +737,8 @@ func (h *InstallHandler) ServeAgentDownload(w http.ResponseWriter, r *http.Reque
 			osParam = "windows"
 		} else if strings.Contains(reported, "freebsd") || strings.Contains(reported, "pfsense") {
 			osParam = "freebsd"
+		} else if strings.Contains(reported, "darwin") || strings.Contains(reported, "mac") {
+			osParam = "darwin"
 		} else {
 			osParam = "linux"
 		}
@@ -739,9 +747,9 @@ func (h *InstallHandler) ServeAgentDownload(w http.ResponseWriter, r *http.Reque
 		osParam = "linux"
 	}
 
-	validOss := map[string]bool{"linux": true, "freebsd": true, "windows": true}
+	validOss := map[string]bool{"linux": true, "freebsd": true, "windows": true, "darwin": true}
 	if !validOss[osParam] {
-		JSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid os. Must be one of: linux, freebsd, windows"})
+		JSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid os. Must be one of: linux, freebsd, windows, darwin"})
 		return
 	}
 

--- a/server-source-code/internal/handler/install.go
+++ b/server-source-code/internal/handler/install.go
@@ -142,8 +142,8 @@ func (h *InstallHandler) ServeInstall(w http.ResponseWriter, r *http.Request) {
 		architecture = ""
 	}
 	osParam := r.URL.Query().Get("os")
-	if osParam != "linux" && osParam != "freebsd" && osParam != "windows" && osParam != "darwin" {
-		osParam = "linux"
+	if osParam != "" && osParam != "linux" && osParam != "freebsd" && osParam != "windows" && osParam != "darwin" {
+		osParam = ""
 	}
 
 	// Windows: serve PowerShell script with env vars
@@ -192,11 +192,14 @@ func (h *InstallHandler) ServeInstall(w http.ResponseWriter, r *http.Request) {
 	if forceInstall {
 		forceStr = "true"
 	}
+	osExport := ""
+	if osParam != "" {
+		osExport = fmt.Sprintf("export PATCHMON_OS=\"%s\"\n", osParam)
+	}
 
 	envBlock := fmt.Sprintf(`#!/bin/sh
 export PATCHMON_URL="%s"
-export PATCHMON_OS="%s"
-export BOOTSTRAP_TOKEN="%s"
+%sexport BOOTSTRAP_TOKEN="%s"
 export CURL_FLAGS="%s"
 export SKIP_SSL_VERIFY="%s"
 export FORCE_INSTALL="%s"
@@ -222,7 +225,7 @@ fetch_credentials() {
     fi
 }
 fetch_credentials
-`, serverURL, osParam, token, curlFlags, skipSSLVerify, forceStr, archExport)
+`, serverURL, osExport, token, curlFlags, skipSSLVerify, forceStr, archExport)
 
 	// Remove shebang from original script and prepend env block
 	script := h.scriptBase

--- a/server-source-code/internal/handler/patching.go
+++ b/server-source-code/internal/handler/patching.go
@@ -29,7 +29,7 @@ import (
 
 const patchRunJobIDPrefix = "patch-run-"
 
-var packageNameRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9.+-_]*$`)
+var packageNameRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9.+-_@]*$`)
 
 // deletablePatchRunStatuses are statuses where the run can be deleted (not yet executed or cancelled).
 var deletablePatchRunStatuses = map[string]bool{

--- a/server-source-code/internal/handler/patching.go
+++ b/server-source-code/internal/handler/patching.go
@@ -29,7 +29,7 @@ import (
 
 const patchRunJobIDPrefix = "patch-run-"
 
-var packageNameRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9.+-_@]*$`)
+var packageNameRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9.+\-_ @]*$`)
 
 // deletablePatchRunStatuses are statuses where the run can be deleted (not yet executed or cancelled).
 var deletablePatchRunStatuses = map[string]bool{


### PR DESCRIPTION
## Summary

This PR adds initial macOS (darwin) agent support to PatchMon, enabling macOS hosts to be monitored and patched via the PatchMon server.

## What problem does this PR solve?

PatchMon previously supported Linux, FreeBSD, and Windows agents only. This PR extends support to macOS (darwin/arm64), allowing macOS hosts to install the PatchMon agent, report installed packages, and receive patch runs.

## How does it solve it?

### Frontend
- Added macOS option with Apple icon to the Add Host Wizard (`AddHostWizard.jsx`)
- Updated package name validation regex to allow spaces, required for macOS package names (e.g. `Command Line Tools for Xcode 26.5-26.5`)

### Backend (server)
- Added `darwin` to the valid OS list in `install.go`
- Fixed `PATCHMON_OS` defaulting to `linux` when no OS parameter is provided — the install script now falls back to local `uname` detection on the client, ensuring macOS hosts correctly detect their platform
- Updated package name validation regex in `patching.go` to allow spaces for macOS-style package names

### Agent
- Added darwin/macOS platform detection
- Added macOS package collection via `softwareupdate` (system/OS updates) and Homebrew (`brew list`, `brew outdated`)
- Added `launchd` service setup for macOS (replaces systemd), with correct `EnvironmentVariables` in the plist including full `PATH`
- Fixed Homebrew privilege handling — macOS Homebrew blocks root execution. Resolved by installing a `/usr/local/bin/patchmon-brew` wrapper script during agent install that drops privileges to the console user via `sudo -n -u` with `HOMEBREW_NO_AUTO_UPDATE=1`, `HOMEBREW_NO_ANALYTICS=1`, and `HOMEBREW_NO_ENV_HINTS=1`. This wrapper is called by the agent instead of invoking brew directly, working around a Go `exec.Command` + launchd security context interaction that caused direct `sudo` calls to hang
- Added `/etc/sudoers.d/patchmon` entry during install to allow passwordless brew execution as the console user
- Fixed `Label:` prefix being included in package names from `softwareupdate` output
- Fixed install script to correctly detect darwin platform and not override `PATCHMON_OS` when no OS is specified
- Fixed install script to use launchd exclusively on macOS, removing fallback cron/background process spawning that caused duplicate agent processes after reboot

### Install script
- Added darwin platform detection
- Added `launchd` plist generation and service management
- Added `/usr/local/bin/patchmon-brew` wrapper script creation
- Added `/etc/sudoers.d/patchmon` sudoers entry
- Fixed duplicate process issue — removed background `serve` fallback when launchd is available

## How was this tested?

- Deployed a development PatchMon server instance using `docker-compose.dev.yml` on an Ubuntu 24.04 VM in a Proxmox homelab
- Built the macOS agent binary (`patchmon-agent-darwin-arm64`) locally on Apple M1
- Installed the agent on an Apple M1 MacBook Pro running macOS 26.5
- Verified agent installs correctly, registers with launchd, and starts as a single process
- Verified agent connects via WebSocket and sends package reports
- Verified 28 packages collected correctly (27 Homebrew + 1 softwareupdate) on both manual reports and scheduled hourly reports
- Verified 28 packages collected correctly on the **startup report immediately after a cold reboot** — the key test for the launchd + brew privilege fix
- Verified patch runs execute correctly via Homebrew (dry-run and live)
- Verified agent survives multiple reboots with single process and correct package collection
- Verified no duplicate processes after reinstall or reboot

## Known limitations / follow-up work

- macOS compliance scanning (CIS/SCAP) is not yet implemented — out of scope for this initial PR
- softwareupdate patching for macOS OS upgrades (e.g. macOS Tahoe) is not supported — Apple requires interactive authentication for major OS upgrades via softwareupdate even when running as root, which cannot be automated non-interactively. This is an Apple security restriction. Minor updates via softwareupdate (e.g. Command Line Tools for Xcode) patch successfully without issue. Homebrew package patching also works correctly and fully.
- Only `arm64` (Apple Silicon) has been tested; `amd64` (Intel Mac) binary is not included
- `isSecurityUpdate` field for macOS packages is not yet populated
- `ioreg` hardware ID lookup may time out on cold boot (non-critical — falls back to hostname, all package collection still works correctly)

---

## AI Disclosure

- **Used AI:** yes
- **Model(s):** Claude Sonnet 4.6, GitHub Copilot (multiple agents)
- **Harness / tool:** Claude.ai web interface, Claude Code (VS Code extension), GitHub Copilot (VS Code extension)
- **Scope:** AI assisted with code generation across agent source, server handler, 
  frontend components, install script, and debugging during development and testing
- **Human review completed:** yes — all changes reviewed, tested end-to-end on 
  physical Apple M1 hardware and a Linux VM, verified against PatchMon server 
  logs and UI across multiple reboot cycles

Closes #789 