### PR TITLE
fix: point direct enrollment guide to api docs

### DIFF
--- a/frontend/src/pages/settings/Integrations.jsx
+++ b/frontend/src/pages/settings/Integrations.jsx
@@ -1066,7 +1066,7 @@ const Integrations = () => {
 										infrastructure.
 									</p>
 									<a
-										href="https://patchmon.net/docs/patchmon-api-integrations-guide#proxmox-lxc-auto-enrollment-guide"
+										href="https://patchmon.net/docs/patchmon-api-integrations-guide#auto-enrolment-api-docs"
 										target="_blank"
 										rel="noopener noreferrer"
 										className="inline-flex items-center gap-2 px-3 py-2 bg-primary-600 hover:bg-primary-700 dark:bg-primary-500 dark:hover:bg-primary-600 text-white rounded-lg text-sm transition-colors"


### PR DESCRIPTION
## What changed

The Direct Host Auto-Enrollment documentation card now links to the direct auto-enrolment API docs anchor instead of the Proxmox LXC auto-enrollment guide.

Closes #791

## Validation

- `git diff --check`
- `npx biome check frontend/src/pages/settings/Integrations.jsx`
- `npm run build:frontend`

## AI disclosure

AI-assisted contribution created with OpenAI GPT-5 and manually reviewed.

