### PR TITLE
feat(dashboard): add Host Security Update Status chart

### DIFF
--- a/frontend/src/components/DashboardSettingsModal.jsx
+++ b/frontend/src/components/DashboardSettingsModal.jsx
@@ -196,6 +196,7 @@ const DashboardSettingsModal = ({ isOpen, onClose }) => {
 				if (cardId === "osDistributionBar") return "Bar chart";
 				if (cardId === "osDistributionDoughnut") return "Doughnut chart";
 				if (cardId === "updateStatus") return "Pie chart";
+				if (cardId === "hostSecurityUpdateStatus") return "Pie chart";
 				if (cardId === "packagePriority") return "Pie chart";
 				if (cardId === "recentUsers") return "Table";
 				if (cardId === "recentCollection") return "Table";

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -350,6 +350,23 @@ const Dashboard = () => {
 		}
 	};
 
+   	const handleSecurityUpdateChartClick = (_, elements) => {
+    	if (elements.length > 0 && stats?.charts?.securityUpdateDistribution) {
+            const elementIndex = elements[0].index;
+            const statusItem = stats.charts.securityUpdateDistribution[elementIndex];
+            if (!statusItem?.name) return;
+
+			const statusName = statusItem.name.toLowerCase();
+			if (statusName.includes("up to date")) {
+			    navigate("/hosts?filter=upToDate", { replace: true });
+			} else if (statusName.includes("security")) {
+				navigate("/hosts?filter=securityUpdates", { replace: true });
+			} else {
+				navigate("/hosts?filter=regularUpdates", { replace: true });
+			}
+		}
+	};
+
 	const handlePackagePriorityChartClick = (_, elements) => {
 		if (elements.length > 0 && stats?.charts?.packageUpdateDistribution) {
 			const elementIndex = elements[0].index;
@@ -821,6 +838,7 @@ const Dashboard = () => {
 				"packagePriority",
 				"recentUsers",
 				"recentCollection",
+				"hostSecurityUpdateStatus",
 				...COMPLIANCE_WIDGET_CARD_IDS,
 				...PATCHING_WIDGET_CARD_IDS,
 				...ALERTING_WIDGET_CARD_IDS,
@@ -1356,6 +1374,33 @@ const Dashboard = () => {
 						</div>
 					</button>
 				);
+
+                       case "hostSecurityUpdateStatus":
+                               return (
+                                       <button
+                                               type="button"
+                                               className="card p-4 sm:p-6 cursor-pointer hover:shadow-card-hover dark:hover:shadow-card-hover-dark transition-shadow duration-200 w-full text-left h-full flex flex-col"
+                                               onClick={handleSecurityUpdateChartClick}
+                                               onKeyDown={(e) => {
+												   if (e.key === "Enter" || e.key === " ") {
+													   e.preventDefault();
+													   handleSecurityUpdateChartClick();
+												   }
+											   }}
+                                       >
+                                               <h3 className="text-lg font-medium text-secondary-900 dark:text-white mb-4 flex-shrink-0">
+                                                       Host Security Update Status
+                                               </h3>
+                                               <div className="h-56 w-full flex items-center justify-center flex-1 min-h-0">
+                                                       <div className="w-full h-full max-w-sm">
+                                                               <Pie
+                                                                       data={securityUpdateChartData}
+                                                                       options={securityUpdateChartOptions}
+                                                               />
+                                                       </div>
+                                               </div>
+                                       </button>
+                               );
 
 			case "packagePriority":
 				return (
@@ -1965,6 +2010,34 @@ const Dashboard = () => {
 		onClick: handleUpdateStatusChartClick,
 	};
 
+       const securityUpdateChartOptions = {
+               responsive: true,
+               maintainAspectRatio: false,
+               elements: {
+                       arc: { borderRadius: 5 },
+               },
+               plugins: {
+                       legend: {
+                               position: "right",
+                               labels: {
+                                       color: isDark ? "#ffffff" : "#374151",
+                                       font: {
+                                               size: 12,
+                                       },
+                                       padding: 15,
+                                       usePointStyle: true,
+                                       pointStyle: "circle",
+                               },
+                       },
+               },
+               layout: {
+                       padding: {
+                               right: 20,
+                       },
+               },
+               onClick: handleSecurityUpdateChartClick,
+       };
+
 	const packagePriorityChartOptions = {
 		responsive: true,
 		maintainAspectRatio: false,
@@ -2304,6 +2377,21 @@ const Dashboard = () => {
 			},
 		],
 	};
+
+       const securityUpdateChartData = {
+               labels: (stats.charts.securityUpdateDistribution || []).map((item) => item.name),
+               datasets: [
+                       {
+                               data: (stats.charts.securityUpdateDistribution || []).map((item) => item.count),
+                               backgroundColor: [
+                                       "#EF4444", // Red - Security updates to pass
+                                       "#F59E0B", // Orange/yellow - Updates to pass
+                                       "#10B981", // Green - Up to date
+                               ],
+                               borderWidth: 0,
+                       },
+               ],
+       };
 
 	const packagePriorityChartData = {
 		labels: stats.charts.packageUpdateDistribution.map((item) => item.name),

--- a/frontend/src/pages/Hosts.jsx
+++ b/frontend/src/pages/Hosts.jsx
@@ -97,6 +97,14 @@ const Hosts = () => {
 			setShowFilters(true);
 			setStatusFilter("all");
 			// We'll filter hosts with updates > 0 in the filtering logic
+		} else if (filter === "securityUpdates") {
+			setShowFilters(true);
+			setStatusFilter("all");
+			// We'll filter hosts with security updates > 0 in the filtering logic
+		} else if (filter === "regularUpdates") {
+			setShowFilters(true);
+			setStatusFilter("all");
+			// We'll filter hosts with only regular (non-security) updates in the filtering logic
 		} else if (filter === "inactive") {
 			setShowFilters(true);
 			setStatusFilter("inactive");
@@ -648,6 +656,10 @@ const Hosts = () => {
 			const matchesUrlFilter =
 				(filter !== "needsUpdates" ||
 					(host.updatesCount && host.updatesCount > 0)) &&
+				(filter !== "securityUpdates" ||
+					(host.securityUpdatesCount && host.securityUpdatesCount > 0)) &&
+				(filter !== "regularUpdates" ||
+					(host.updatesCount > 0 && !(host.securityUpdatesCount > 0))) &&
 				(filter !== "inactive" ||
 					(host.effectiveStatus || host.status) === "inactive") &&
 				(filter !== "upToDate" || (!host.isStale && host.updatesCount === 0)) &&

--- a/server-source-code/internal/db/dashboard.sql.go
+++ b/server-source-code/internal/db/dashboard.sql.go
@@ -34,6 +34,7 @@ WITH host_counts AS (
 hp_package_counts AS (
     SELECT
         COUNT(DISTINCT host_id)::int AS hosts_needing_updates,
+        COUNT(DISTINCT host_id) FILTER (WHERE is_security_update = true)::int AS hosts_with_security_updates,
         COUNT(DISTINCT package_id)::int AS total_outdated_packages,
         COUNT(DISTINCT package_id) FILTER (WHERE is_security_update)::int AS security_updates
     FROM host_packages
@@ -43,6 +44,7 @@ SELECT
     hc.total_hosts,
     hpc.hosts_needing_updates,
     hpc.total_outdated_packages,
+       hpc.hosts_with_security_updates,
     hc.errored_hosts,
     hpc.security_updates,
     hc.offline_hosts,
@@ -63,6 +65,7 @@ type GetDashboardStatsRow struct {
 	TotalHosts            int32 `json:"total_hosts"`
 	HostsNeedingUpdates   int32 `json:"hosts_needing_updates"`
 	TotalOutdatedPackages int32 `json:"total_outdated_packages"`
+       HostsWithSecurityUpdates int32 `json:"hosts_with_security_updates"`
 	ErroredHosts          int32 `json:"errored_hosts"`
 	SecurityUpdates       int32 `json:"security_updates"`
 	OfflineHosts          int32 `json:"offline_hosts"`
@@ -79,6 +82,7 @@ func (q *Queries) GetDashboardStats(ctx context.Context, arg GetDashboardStatsPa
 		&i.TotalHosts,
 		&i.HostsNeedingUpdates,
 		&i.TotalOutdatedPackages,
+               &i.HostsWithSecurityUpdates,
 		&i.ErroredHosts,
 		&i.SecurityUpdates,
 		&i.OfflineHosts,

--- a/server-source-code/internal/handler/dashboard_preferences.go
+++ b/server-source-code/internal/handler/dashboard_preferences.go
@@ -90,6 +90,7 @@ var defaultCardLayout = []struct {
 	{CardID: "recentAlerts", RequiredPermission: "can_view_hosts", Order: 36, Enabled: true, ColSpan: 1},
 	{CardID: "alertResponderWorkload", RequiredPermission: "can_view_hosts", Order: 37, Enabled: true, ColSpan: 1},
 	{CardID: "deliveryByDestination", RequiredPermission: "can_view_hosts", Order: 38, Enabled: true, ColSpan: 2},
+	{CardID: "hostSecurityUpdateStatus", RequiredPermission: "can_view_hosts", Order: 39, Enabled: true, ColSpan: 1},
 }
 
 // Card metadata (matches Node CARD_METADATA).

--- a/server-source-code/internal/sqlc/queries/dashboard.sql
+++ b/server-source-code/internal/sqlc/queries/dashboard.sql
@@ -10,6 +10,7 @@ WITH host_counts AS (
 hp_package_counts AS (
     SELECT
         COUNT(DISTINCT host_id)::int AS hosts_needing_updates,
+        COUNT(DISTINCT host_id) FILTER (WHERE is_security_update = true)::int AS hosts_with_security_updates,
         COUNT(DISTINCT package_id)::int AS total_outdated_packages,
         COUNT(DISTINCT package_id) FILTER (WHERE is_security_update)::int AS security_updates
     FROM host_packages
@@ -19,6 +20,7 @@ SELECT
     hc.total_hosts,
     hpc.hosts_needing_updates,
     hpc.total_outdated_packages,
+    hpc.hosts_with_security_updates,
     hc.errored_hosts,
     hpc.security_updates,
     hc.offline_hosts,

--- a/server-source-code/internal/store/dashboard.go
+++ b/server-source-code/internal/store/dashboard.go
@@ -47,6 +47,7 @@ func (s *DashboardStore) GetStats(ctx context.Context) (map[string]interface{}, 
 
 	totalHosts := int(stats.TotalHosts)
 	hostsNeedingUpdates := int(stats.HostsNeedingUpdates)
+       hostsWithSecurityUpdates := int(stats.HostsWithSecurityUpdates)
 	totalOutdatedPackages := int(stats.TotalOutdatedPackages)
 	erroredHosts := int(stats.ErroredHosts)
 	securityUpdates := int(stats.SecurityUpdates)
@@ -60,6 +61,10 @@ func (s *DashboardStore) GetStats(ctx context.Context) (map[string]interface{}, 
 	if upToDateHosts < 0 {
 		upToDateHosts = 0
 	}
+       regularUpdateHosts := hostsNeedingUpdates - hostsWithSecurityUpdates
+       if regularUpdateHosts < 0 {
+               regularUpdateHosts = 0
+       }
 
 	osRows, _ := d.Queries.GetOSDistributionByTypeAndVersion(ctx)
 	osDistribution := make([]map[string]interface{}, len(osRows))
@@ -75,6 +80,12 @@ func (s *DashboardStore) GetStats(ctx context.Context) (map[string]interface{}, 
 		{"name": "Needs updates", "count": hostsNeedingUpdates},
 		{"name": "Errored", "count": erroredHosts},
 	}
+
+       securityUpdateDistribution := []map[string]interface{}{
+               {"name": "Security updates to pass", "count": hostsWithSecurityUpdates},
+               {"name": "Updates to pass", "count": regularUpdateHosts},
+               {"name": "Up to date", "count": upToDateHosts},
+       }
 
 	regularUpdates := totalOutdatedPackages - securityUpdates
 	if regularUpdates < 0 {
@@ -119,6 +130,7 @@ func (s *DashboardStore) GetStats(ctx context.Context) (map[string]interface{}, 
 		"charts": map[string]interface{}{
 			"osDistribution":            osDistribution,
 			"updateStatusDistribution":  updateStatusDistribution,
+                       "securityUpdateDistribution":  securityUpdateDistribution,
 			"packageUpdateDistribution": packageUpdateDistribution,
 		},
 		"trends":      trends,


### PR DESCRIPTION
## Add Host Security Update Status chart

### Summary
This PR adds a new optional dashboard chart **Host Security Update Status** that breaks down hosts into three categories:
- 🔴 Security updates to pass
- 🟡 Regular updates to pass
- 🟢 Up to date

> ✨ Developed with the assistance of GitHub Copilot.
