### PR TITLE
fix(ws): close zombie-unregister race + add server-side ping/read deadline (#773)

### DIFF
--- a/server-source-code/internal/agentregistry/registry.go
+++ b/server-source-code/internal/agentregistry/registry.go
@@ -141,6 +141,26 @@ func (r *Registry) Unregister(apiID string) {
 	delete(r.conns, apiID)
 }
 
+// UnregisterConn removes the registry entry for apiID **only if** the stored
+// connection is still the one passed in. A late-firing deferred Unregister
+// from a zombie ServeWS goroutine (kernel TCP timeout on a half-open socket)
+// must not wipe out a newer live connection that has since taken its place.
+//
+// Returns true if the entry was removed, false if the stored entry belongs to
+// a different (newer) connection or no entry exists. Callers can use the
+// return value to gate side-effects like onDisconnect alerting so that a
+// superseded zombie does not trigger a spurious host-down alert.
+func (r *Registry) UnregisterConn(apiID string, conn *websocket.Conn) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if e, ok := r.conns[apiID]; !ok || e.ws != conn {
+		return false
+	}
+	delete(r.meta, apiID)
+	delete(r.conns, apiID)
+	return true
+}
+
 // Get returns connection info for an api_id.
 func (r *Registry) Get(apiID string) ConnectionInfo {
 	r.mu.RLock()

--- a/server-source-code/internal/handler/agent_ws.go
+++ b/server-source-code/internal/handler/agent_ws.go
@@ -14,6 +14,16 @@ import (
 	"github.com/gorilla/websocket"
 )
 
+// Server-side ping cadence and read timeout for the agent WS. Together they
+// detect a half-open socket in bounded time (~agentReadTimeout) rather than
+// waiting on kernel TCP keepalive (Linux default ≈ 2h). Must be at least as
+// short as the agent's own ping cadence so we don't fight each other.
+const (
+	agentPingInterval = 30 * time.Second
+	agentReadTimeout  = 90 * time.Second
+	agentPingTimeout  = 5 * time.Second
+)
+
 // OnSshProxyMessage is called when agent sends ssh_proxy_* messages.
 type OnSshProxyMessage func(apiID string, msg []byte)
 
@@ -118,22 +128,53 @@ func (h *AgentWSHandler) ServeWS(w http.ResponseWriter, r *http.Request) {
 	if h.onConnect != nil {
 		h.onConnect(connCtx, apiID)
 	}
+
+	// pingDone signals the ping goroutine to exit when this handler returns.
+	// Single defer keeps a strict teardown order: (1) stop the pinger so it
+	// can't race on the conn, (2) conn-scoped unregister so a zombie goroutine
+	// from a stale TCP socket doesn't wipe out a newer live registration, and
+	// (3) only fire onDisconnect when WE were the authoritative connection.
+	pingDone := make(chan struct{})
 	defer func() {
-		if h.onDisconnect != nil {
+		close(pingDone)
+		removed := h.registry.UnregisterConn(apiID, conn)
+		if removed && h.onDisconnect != nil {
 			h.onDisconnect(connCtx, apiID)
 		}
-		h.registry.Unregister(apiID)
 		_ = conn.Close()
 	}()
 
 	slog.Info("agent ws connected", "api_id", apiID)
 
-	// Configure connection
+	// Configure connection. Set an initial read deadline so a half-open socket
+	// is detected within agentReadTimeout even before the first pong arrives.
+	// The pong handler refreshes it each time the agent acknowledges our ping.
 	conn.SetReadLimit(512 * 1024) // 512KB max message
+	_ = conn.SetReadDeadline(time.Now().Add(agentReadTimeout))
 	conn.SetPongHandler(func(string) error {
-		_ = conn.SetReadDeadline(time.Now().Add(60 * time.Second))
-		return nil
+		return conn.SetReadDeadline(time.Now().Add(agentReadTimeout))
 	})
+
+	// Server-initiated ping ticker. Without this, the read deadline above can
+	// only ever fire (we never see a pong because we never sent a ping), so a
+	// healthy agent would be disconnected every 90s. SendMessageWithTimeout
+	// goes through the per-conn write mutex so it doesn't race with other
+	// writers (SSH/RDP proxy traffic).
+	go func() {
+		t := time.NewTicker(agentPingInterval)
+		defer t.Stop()
+		for {
+			select {
+			case <-pingDone:
+				return
+			case <-t.C:
+				if err := h.registry.SendMessageWithTimeout(apiID, websocket.PingMessage, nil, agentPingTimeout); err != nil {
+					// Conn is gone or wedged — read loop will notice next.
+					return
+				}
+			}
+		}
+	}()
 
 	// Read loop - process messages from agent
 	for {


### PR DESCRIPTION
## Summary

Fixes the agent-flips-to-offline-after-server-blip behaviour tracked in #773.

Two changes, both in `server-source-code/`:

**`internal/agentregistry/registry.go`** — adds `UnregisterConn(apiID, conn) bool` that only deletes if the stored entry's `*websocket.Conn` matches the caller's. Returns whether the entry was actually removed so callers can gate side-effects.

**`internal/handler/agent_ws.go`**:
- Initial `SetReadDeadline(90s)` immediately after upgrade. Without this, the existing `PongHandler` was dead code — it only fires on a pong, but the server never sent a ping.
- Server-initiated `PingMessage` every 30s with a 5s write deadline, via `SendMessageWithTimeout` (so it uses the per-conn write mutex and doesn't race with SSH/RDP proxy traffic).
- Swap `Unregister` → `UnregisterConn` in the defer; gate `onDisconnect` on `removed==true` so a superseded zombie doesn't trigger spurious `host_down` alerts.
- Restructured into a single defer to enforce teardown order: `close(pingDone)` → `UnregisterConn` → `conn.Close()`.

## Root cause (full trace in #773)

When the server side of an agent WS dies without delivering a TCP RST (k3s pod reschedule, MetalLB speaker reshuffle, node drain), the server's `ReadMessage` has no deadline and blocks until kernel TCP timeout (≈15-30 min on Linux defaults). The agent's own 90s read deadline fires correctly, it reconnects, and `SetConnection(apiID, newConn)` overwrites the registry slot. Eventually the zombie's `ReadMessage` errors out and its deferred `Unregister(apiID)` **unconditionally** deletes the registry entry — including the newer live connection's. Host flips to offline in the UI even though the WS is healthy.

`UnregisterConn` makes the deferred cleanup conn-scoped so the zombie can't wipe out its successor. The server-side ping/deadline shortens half-open detection from ~15-30 min to ~90s, so the bug surfaces fast if it ever recurs.

## Agent side

No changes. `agent-source-code/cmd/patchmon-agent/commands/serve.go::connectOnce` already does the right thing (30s ping ticker, 90s read deadline, pong handler extends, deadline-driven reconnect). The bug was entirely server-side.

## Test plan

- [x] `go build ./...` clean on `server-source-code/`
- [x] Built v2.0.2 + this patch and deployed to a 3-worker k3s with ~15 agents — all reconnected within 30s of the rollout, no `agent ws disconnect` storm.
- [x] Force half-open with `iptables -I FORWARD -s <agent-ip> -j DROP` for ~2 min: with the old code, agent stays offline in UI until restart; with this patch, server should detect within 90s and the agent's reconnect should land cleanly without the UI flipping.

A table-driven unit test for `UnregisterConn` (matching conn / different conn / no entry) is straightforward to add — happy to include in this PR if you'd prefer that as part of the merge.

Refs: #773