### PR TITLE
feat: add Prometheus exporter integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The core of PatchMon - orchestrate updates across your fleet with validation, ap
 |---|---|
 | **Integrations** | 33+ integrations including Proxmox LXC auto-enrolment, getHomepage, Ansible and more. |
 | **REST API** | Full `/api/v1` with JWT authentication and interactive Swagger / OpenAPI docs at `/api-docs`. |
+| **Prometheus Exporter** | Built-in `/metrics` endpoint in Prometheus text format. Exposes fleet-wide and per-host pending update counts (regular and security), host health status, reboot flags and last-seen timestamps. Enable in **Settings → Metrics**. |
 
 ---
 

--- a/frontend/src/pages/settings/SettingsMetrics.jsx
+++ b/frontend/src/pages/settings/SettingsMetrics.jsx
@@ -1,5 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
+	Activity,
 	AlertCircle,
 	BarChart3,
 	BookOpen,
@@ -59,6 +60,20 @@ const metricsAPI = {
 		}).then(parseJSONResponse),
 };
 
+const prometheusAPI = {
+	getSettings: () =>
+		fetch("/api/v1/prometheus/settings", {
+			credentials: "include",
+		}).then((res) => res.json()),
+	updateSettings: (data) =>
+		fetch("/api/v1/prometheus/settings", {
+			method: "PUT",
+			headers: { "Content-Type": "application/json" },
+			credentials: "include",
+			body: JSON.stringify(data),
+		}).then((res) => res.json()),
+};
+
 const SettingsMetrics = () => {
 	const queryClient = useQueryClient();
 	const [showFullId, setShowFullId] = useState(false);
@@ -71,6 +86,12 @@ const SettingsMetrics = () => {
 	} = useQuery({
 		queryKey: ["metrics-settings"],
 		queryFn: () => metricsAPI.getSettings(),
+	});
+
+	// Fetch Prometheus exporter settings
+	const { data: prometheusSettings, isLoading: prometheusLoading } = useQuery({
+		queryKey: ["prometheus-settings"],
+		queryFn: () => prometheusAPI.getSettings(),
 	});
 
 	// Toggle metrics mutation
@@ -95,6 +116,15 @@ const SettingsMetrics = () => {
 		mutationFn: () => metricsAPI.sendNow(),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: ["metrics-settings"] });
+		},
+	});
+
+	// Toggle Prometheus exporter mutation
+	const togglePrometheusMutation = useMutation({
+		mutationFn: (enabled) =>
+			prometheusAPI.updateSettings({ prometheus_enabled: enabled }),
+		onSuccess: () => {
+			queryClient.invalidateQueries(["prometheus-settings"]);
 		},
 	});
 
@@ -407,6 +437,194 @@ const SettingsMetrics = () => {
 								</a>
 							</li>
 						</ul>
+					</div>
+				</div>
+			</div>
+
+			{/* ── Prometheus Exporter ───────────────────────────────────────────── */}
+			<div className="border-t border-secondary-200 dark:border-secondary-700 pt-8">
+				{/* Section Header */}
+				<div className="flex items-center mb-6">
+					<Activity className="h-6 w-6 text-primary-600 mr-3" />
+					<div>
+						<h2 className="text-xl font-semibold text-secondary-900 dark:text-white">
+							Prometheus Exporter
+						</h2>
+						<p className="text-sm text-secondary-600 dark:text-white mt-1">
+							Expose a{" "}
+							<code className="font-mono bg-secondary-100 dark:bg-secondary-700 px-1 rounded">
+								/metrics
+							</code>{" "}
+							endpoint for Prometheus scraping
+						</p>
+					</div>
+				</div>
+
+				{/* Toggle card */}
+				<div className="bg-white dark:bg-secondary-800 rounded-lg border border-secondary-200 dark:border-secondary-700 p-6">
+					<div className="flex items-start justify-between">
+						<div className="flex-1">
+							<h3 className="text-lg font-medium text-secondary-900 dark:text-white mb-2">
+								Enable Prometheus Exporter
+							</h3>
+							<p className="text-sm text-secondary-600 dark:text-white">
+								When enabled, PatchMon exposes{" "}
+								<code className="font-mono bg-secondary-100 dark:bg-secondary-700 px-1 rounded text-xs">
+									GET /metrics
+								</code>{" "}
+								in Prometheus text format. This endpoint is public — no
+								authentication is required, so restrict access via your firewall
+								or reverse proxy if needed.
+							</p>
+						</div>
+						<button
+							type="button"
+							onClick={() =>
+								togglePrometheusMutation.mutate(
+									!prometheusSettings?.prometheus_enabled,
+								)
+							}
+							disabled={prometheusLoading || togglePrometheusMutation.isPending}
+							className={`ml-4 relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-md border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 ${
+								prometheusSettings?.prometheus_enabled
+									? "bg-primary-600"
+									: "bg-secondary-200 dark:bg-secondary-700"
+							} ${prometheusLoading || togglePrometheusMutation.isPending ? "opacity-50" : ""}`}
+						>
+							<span
+								className={`inline-block h-5 w-5 transform rounded-md bg-white shadow ring-0 transition duration-200 ease-in-out ${
+									prometheusSettings?.prometheus_enabled
+										? "translate-x-5"
+										: "translate-x-0"
+								}`}
+							/>
+						</button>
+					</div>
+
+					{/* Status */}
+					<div className="mt-4 pt-4 border-t border-secondary-200 dark:border-secondary-700">
+						<div className="flex items-center text-sm">
+							{prometheusSettings?.prometheus_enabled ? (
+								<>
+									<CheckCircle className="h-4 w-4 text-green-500 mr-2" />
+									<span className="text-green-700 dark:text-green-400">
+										Exporter active — scrape{" "}
+										<code className="font-mono bg-secondary-100 dark:bg-secondary-700 px-1 rounded">
+											/metrics
+										</code>{" "}
+										from your Prometheus server
+									</span>
+								</>
+							) : (
+								<>
+									<EyeOff className="h-4 w-4 text-secondary-500 mr-2" />
+									<span className="text-secondary-600 dark:text-white">
+										Exporter disabled —{" "}
+										<code className="font-mono bg-secondary-100 dark:bg-secondary-700 px-1 rounded">
+											/metrics
+										</code>{" "}
+										returns 503
+									</span>
+								</>
+							)}
+						</div>
+					</div>
+				</div>
+
+				{/* Available metrics info */}
+				<div className="mt-4 bg-secondary-50 dark:bg-secondary-800/50 border border-secondary-200 dark:border-secondary-700 rounded-lg p-6">
+					<div className="flex">
+						<Info className="h-5 w-5 text-secondary-500 dark:text-white flex-shrink-0 mt-0.5" />
+						<div className="ml-3 text-sm text-secondary-700 dark:text-white">
+							<h4 className="font-medium mb-2">Exported metrics</h4>
+							<ul className="space-y-1 font-mono text-xs">
+								<li>
+									<span className="text-primary-600 dark:text-primary-400">
+										patchmon_hosts_total
+									</span>{" "}
+									— total monitored hosts
+								</li>
+								<li>
+									<span className="text-primary-600 dark:text-primary-400">
+										patchmon_hosts_needing_updates_total
+									</span>{" "}
+									— hosts with ≥1 pending update
+								</li>
+								<li>
+									<span className="text-primary-600 dark:text-primary-400">
+										patchmon_hosts_needing_security_updates_total
+									</span>{" "}
+									— hosts with ≥1 pending security update
+								</li>
+								<li>
+									<span className="text-primary-600 dark:text-primary-400">
+										patchmon_hosts_errored_total
+									</span>{" "}
+									— hosts not seen for 2× update interval
+								</li>
+								<li>
+									<span className="text-primary-600 dark:text-primary-400">
+										patchmon_hosts_offline_total
+									</span>{" "}
+									— hosts not seen for 3× update interval
+								</li>
+								<li>
+									<span className="text-primary-600 dark:text-primary-400">
+										patchmon_hosts_needing_reboot_total
+									</span>{" "}
+									— hosts with a pending reboot
+								</li>
+								<li>
+									<span className="text-primary-600 dark:text-primary-400">
+										patchmon_pending_updates_total&#123;type&#125;
+									</span>{" "}
+									— unique packages pending update, by <em>regular</em> /{" "}
+									<em>security</em>
+								</li>
+								<li>
+									<span className="text-primary-600 dark:text-primary-400">
+										patchmon_installed_packages_total
+									</span>{" "}
+									— total installed packages across all hosts
+								</li>
+								<li>
+									<span className="text-primary-600 dark:text-primary-400">
+										patchmon_host_pending_updates&#123;host_id,name,…,os_version&#125;
+									</span>{" "}
+									— per-host regular pending updates
+								</li>
+								<li>
+									<span className="text-primary-600 dark:text-primary-400">
+										patchmon_host_security_updates&#123;host_id,name,…,os_version&#125;
+									</span>{" "}
+									— per-host security pending updates
+								</li>
+								<li>
+									<span className="text-primary-600 dark:text-primary-400">
+										patchmon_host_installed_packages_total&#123;host_id,name,…,os_version&#125;
+									</span>{" "}
+									— per-host total installed packages
+								</li>
+								<li>
+									<span className="text-primary-600 dark:text-primary-400">
+										patchmon_host_last_seen_seconds&#123;host_id,name,…,os_version&#125;
+									</span>{" "}
+									— last agent check-in (unix timestamp)
+								</li>
+								<li>
+									<span className="text-primary-600 dark:text-primary-400">
+										patchmon_host_pending_reboot&#123;host_id,name,…,os_version&#125;
+									</span>{" "}
+									— reboot required: <em>1</em> = yes, <em>0</em> = no
+								</li>
+								<li>
+									<span className="text-primary-600 dark:text-primary-400">
+										patchmon_scrape_timestamp_seconds
+									</span>{" "}
+									— time these metrics were collected
+								</li>
+							</ul>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/server-source-code/internal/db/models.go
+++ b/server-source-code/internal/db/models.go
@@ -661,6 +661,7 @@ type Setting struct {
 	PasswordRateLimitWindowMs       *int32           `json:"password_rate_limit_window_ms"`
 	PasswordRateLimitMax            *int32           `json:"password_rate_limit_max"`
 	AuthBrowserSessionCookies       *bool            `json:"auth_browser_session_cookies"`
+	PrometheusEnabled               bool             `json:"prometheus_enabled"`
 }
 
 type SystemStatistic struct {

--- a/server-source-code/internal/db/settings.sql.go
+++ b/server-source-code/internal/db/settings.sql.go
@@ -12,7 +12,7 @@ import (
 )
 
 const getFirstSettings = `-- name: GetFirstSettings :one
-SELECT id, server_url, server_protocol, server_host, server_port, created_at, updated_at, update_interval, auto_update, default_compliance_mode, compliance_scan_interval, package_cache_refresh_mode, package_cache_refresh_max_age, github_repo_url, ssh_key_path, repository_type, last_update_check, latest_version, update_available, signup_enabled, default_user_role, ignore_ssl_self_signed, logo_dark, logo_light, favicon, logo_dark_data, logo_light_data, favicon_data, logo_dark_content_type, logo_light_content_type, favicon_content_type, metrics_enabled, metrics_anonymous_id, metrics_last_sent, show_github_version_on_login, ai_enabled, ai_provider, ai_model, ai_api_key, alerts_enabled, discord_oauth_enabled, discord_client_id, discord_client_secret, discord_redirect_uri, discord_button_text, oidc_enabled, oidc_issuer_url, oidc_client_id, oidc_client_secret, oidc_redirect_uri, oidc_scopes, oidc_auto_create_users, oidc_default_role, oidc_disable_local_auth, oidc_button_text, oidc_sync_roles, oidc_admin_group, oidc_superadmin_group, oidc_host_manager_group, oidc_readonly_group, oidc_user_group, oidc_enforce_https, oidc_trust_unverified_email, max_login_attempts, lockout_duration_minutes, session_inactivity_timeout_minutes, patch_run_stall_timeout_minutes, agent_reports_retention_days, tfa_max_remember_sessions, password_min_length, password_require_uppercase, password_require_lowercase, password_require_number, password_require_special, enable_hsts, json_body_limit, agent_update_body_limit, db_transaction_long_timeout, cors_origin, enable_logging, log_level, timezone, jwt_expires_in, max_tfa_attempts, tfa_lockout_duration_minutes, tfa_remember_me_expires_in, trust_proxy, rate_limit_window_ms, rate_limit_max, auth_rate_limit_window_ms, auth_rate_limit_max, agent_rate_limit_window_ms, agent_rate_limit_max, password_rate_limit_window_ms, password_rate_limit_max, auth_browser_session_cookies FROM settings LIMIT 1
+SELECT id, server_url, server_protocol, server_host, server_port, created_at, updated_at, update_interval, auto_update, default_compliance_mode, compliance_scan_interval, package_cache_refresh_mode, package_cache_refresh_max_age, github_repo_url, ssh_key_path, repository_type, last_update_check, latest_version, update_available, signup_enabled, default_user_role, ignore_ssl_self_signed, logo_dark, logo_light, favicon, logo_dark_data, logo_light_data, favicon_data, logo_dark_content_type, logo_light_content_type, favicon_content_type, metrics_enabled, metrics_anonymous_id, metrics_last_sent, show_github_version_on_login, ai_enabled, ai_provider, ai_model, ai_api_key, alerts_enabled, discord_oauth_enabled, discord_client_id, discord_client_secret, discord_redirect_uri, discord_button_text, oidc_enabled, oidc_issuer_url, oidc_client_id, oidc_client_secret, oidc_redirect_uri, oidc_scopes, oidc_auto_create_users, oidc_default_role, oidc_disable_local_auth, oidc_button_text, oidc_sync_roles, oidc_admin_group, oidc_superadmin_group, oidc_host_manager_group, oidc_readonly_group, oidc_user_group, oidc_enforce_https, oidc_trust_unverified_email, max_login_attempts, lockout_duration_minutes, session_inactivity_timeout_minutes, patch_run_stall_timeout_minutes, agent_reports_retention_days, tfa_max_remember_sessions, password_min_length, password_require_uppercase, password_require_lowercase, password_require_number, password_require_special, enable_hsts, json_body_limit, agent_update_body_limit, db_transaction_long_timeout, cors_origin, enable_logging, log_level, timezone, jwt_expires_in, max_tfa_attempts, tfa_lockout_duration_minutes, tfa_remember_me_expires_in, trust_proxy, rate_limit_window_ms, rate_limit_max, auth_rate_limit_window_ms, auth_rate_limit_max, agent_rate_limit_window_ms, agent_rate_limit_max, password_rate_limit_window_ms, password_rate_limit_max, auth_browser_session_cookies, prometheus_enabled FROM settings LIMIT 1
 `
 
 func (q *Queries) GetFirstSettings(ctx context.Context) (Setting, error) {
@@ -115,6 +115,7 @@ func (q *Queries) GetFirstSettings(ctx context.Context) (Setting, error) {
 		&i.PasswordRateLimitWindowMs,
 		&i.PasswordRateLimitMax,
 		&i.AuthBrowserSessionCookies,
+		&i.PrometheusEnabled,
 	)
 	return i, err
 }
@@ -181,8 +182,9 @@ UPDATE settings SET
     compliance_scan_interval = $57,
     package_cache_refresh_mode = $58,
     package_cache_refresh_max_age = $59,
-    oidc_trust_unverified_email = $60
-WHERE id = $61
+    oidc_trust_unverified_email = $60,
+    prometheus_enabled = $61
+WHERE id = $62
 `
 
 type UpdateSettingsParams struct {
@@ -246,6 +248,7 @@ type UpdateSettingsParams struct {
 	PackageCacheRefreshMode   string           `json:"package_cache_refresh_mode"`
 	PackageCacheRefreshMaxAge int32            `json:"package_cache_refresh_max_age"`
 	OidcTrustUnverifiedEmail  bool             `json:"oidc_trust_unverified_email"`
+	PrometheusEnabled         bool             `json:"prometheus_enabled"`
 	ID                        string           `json:"id"`
 }
 
@@ -311,6 +314,7 @@ func (q *Queries) UpdateSettings(ctx context.Context, arg UpdateSettingsParams) 
 		arg.PackageCacheRefreshMode,
 		arg.PackageCacheRefreshMaxAge,
 		arg.OidcTrustUnverifiedEmail,
+		arg.PrometheusEnabled,
 		arg.ID,
 	)
 	return err

--- a/server-source-code/internal/handler/prometheus_exporter.go
+++ b/server-source-code/internal/handler/prometheus_exporter.go
@@ -1,0 +1,311 @@
+package handler
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/PatchMon/PatchMon/server-source-code/internal/database"
+	"github.com/PatchMon/PatchMon/server-source-code/internal/db"
+	"github.com/PatchMon/PatchMon/server-source-code/internal/models"
+	"github.com/PatchMon/PatchMon/server-source-code/internal/pgtime"
+	"github.com/PatchMon/PatchMon/server-source-code/internal/store"
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
+// PrometheusExporterHandler serves Prometheus metrics at GET /metrics.
+// The endpoint is public (no session required) but returns 404 when disabled.
+type PrometheusExporterHandler struct {
+	settings *store.SettingsStore
+	hosts    *store.HostsStore
+	dbp      database.DBProvider
+}
+
+// NewPrometheusExporterHandler creates a new Prometheus exporter handler.
+func NewPrometheusExporterHandler(settings *store.SettingsStore, hosts *store.HostsStore, dbp database.DBProvider) *PrometheusExporterHandler {
+	return &PrometheusExporterHandler{settings: settings, hosts: hosts, dbp: dbp}
+}
+
+// hostUpdateRow holds per-host update counts fetched by a raw query.
+type hostUpdateRow struct {
+	HostID         string
+	FriendlyName   string
+	Hostname       string
+	OSType         string
+	OSVersion      string
+	LastUpdate     time.Time
+	Regular        int
+	Security       int
+	TotalInstalled int
+	NeedsReboot    bool
+}
+
+// prometheusSettings holds Prometheus-related settings returned to the UI.
+type prometheusSettings struct {
+	Enabled bool `json:"prometheus_enabled"`
+}
+
+// GetSettings handles GET /api/v1/prometheus/settings.
+func (h *PrometheusExporterHandler) GetSettings(w http.ResponseWriter, r *http.Request) {
+	s, err := h.settings.GetFirst(r.Context())
+	if err != nil {
+		Error(w, http.StatusInternalServerError, "Failed to load settings")
+		return
+	}
+	JSON(w, http.StatusOK, prometheusSettings{Enabled: s.PrometheusEnabled})
+}
+
+// UpdateSettings handles PUT /api/v1/prometheus/settings.
+func (h *PrometheusExporterHandler) UpdateSettings(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Enabled *bool `json:"prometheus_enabled"`
+	}
+	if err := decodeJSON(r, &req); err != nil {
+		Error(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+	if req.Enabled == nil {
+		Error(w, http.StatusBadRequest, "prometheus_enabled is required")
+		return
+	}
+
+	s, err := h.settings.GetFirst(r.Context())
+	if err != nil {
+		Error(w, http.StatusInternalServerError, "Failed to load settings")
+		return
+	}
+
+	s.PrometheusEnabled = *req.Enabled
+	if err := h.settings.Update(r.Context(), s); err != nil {
+		Error(w, http.StatusInternalServerError, "Failed to update settings")
+		return
+	}
+
+	JSON(w, http.StatusOK, prometheusSettings{Enabled: s.PrometheusEnabled})
+}
+
+// ServeMetrics handles GET /metrics — the Prometheus scrape endpoint.
+func (h *PrometheusExporterHandler) ServeMetrics(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	s, err := h.settings.GetFirst(ctx)
+	if err != nil || !s.PrometheusEnabled {
+		http.Error(w, `Exporter disabled`, http.StatusServiceUnavailable)
+		return
+	}
+
+	data, err := h.collectMetrics(ctx, s)
+	if err != nil {
+		http.Error(w, "Error collecting metrics", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+	_, _ = w.Write([]byte(data))
+}
+
+// collectMetrics queries the database and formats the Prometheus exposition text.
+func (h *PrometheusExporterHandler) collectMetrics(ctx context.Context, s *models.Settings) (string, error) {
+	d := h.dbp.DB(ctx)
+
+	// ── Aggregate dashboard stats ──────────────────────────────────────────
+	updateIntervalMinutes := s.UpdateInterval
+	if updateIntervalMinutes <= 0 {
+		updateIntervalMinutes = 60
+	}
+	now := time.Now()
+	thresholdTime := now.Add(-time.Duration(updateIntervalMinutes*2) * time.Minute)
+	offlineThreshold := now.Add(-time.Duration(updateIntervalMinutes*3) * time.Minute)
+
+	agg, err := d.Queries.GetDashboardStats(ctx, db.GetDashboardStatsParams{
+		LastUpdate:   pgtime.From(thresholdTime),
+		LastUpdate_2: pgtime.From(offlineThreshold),
+	})
+	if err != nil {
+		return "", fmt.Errorf("get dashboard stats: %w", err)
+	}
+
+	// ── Per-host update counts ─────────────────────────────────────────────
+	perHost, err := h.queryPerHostMetrics(ctx)
+	if err != nil {
+		return "", fmt.Errorf("per-host metrics: %w", err)
+	}
+
+	// ── Build output ───────────────────────────────────────────────────────
+	var b strings.Builder
+
+	// patchmon_hosts_total
+	writeHelp(&b, "patchmon_hosts_total", "gauge", "Total number of monitored hosts.")
+	fmt.Fprintf(&b, "patchmon_hosts_total %d\n\n", agg.TotalHosts)
+
+	// patchmon_hosts_needing_updates_total
+	writeHelp(&b, "patchmon_hosts_needing_updates_total", "gauge",
+		"Number of hosts with at least one pending package update.")
+	fmt.Fprintf(&b, "patchmon_hosts_needing_updates_total %d\n\n", agg.HostsNeedingUpdates)
+
+	// patchmon_hosts_needing_security_updates_total (derived from per-host data)
+	var hostsWithSecurity int32
+	for _, row := range perHost {
+		if row.Security > 0 {
+			hostsWithSecurity++
+		}
+	}
+	writeHelp(&b, "patchmon_hosts_needing_security_updates_total", "gauge",
+		"Number of hosts with at least one pending security update.")
+	fmt.Fprintf(&b, "patchmon_hosts_needing_security_updates_total %d\n\n", hostsWithSecurity)
+
+	// patchmon_hosts_errored_total
+	writeHelp(&b, "patchmon_hosts_errored_total", "gauge",
+		"Number of hosts that have not reported within 2x the configured update interval.")
+	fmt.Fprintf(&b, "patchmon_hosts_errored_total %d\n\n", agg.ErroredHosts)
+
+	// patchmon_hosts_offline_total
+	writeHelp(&b, "patchmon_hosts_offline_total", "gauge",
+		"Number of hosts that have not reported within 3x the configured update interval.")
+	fmt.Fprintf(&b, "patchmon_hosts_offline_total %d\n\n", agg.OfflineHosts)
+
+	// patchmon_hosts_needing_reboot_total
+	writeHelp(&b, "patchmon_hosts_needing_reboot_total", "gauge",
+		"Number of hosts with a pending reboot.")
+	fmt.Fprintf(&b, "patchmon_hosts_needing_reboot_total %d\n\n", agg.HostsNeedingReboot)
+
+	// patchmon_pending_updates_total{type}
+	regularUpdates := agg.TotalOutdatedPackages - agg.SecurityUpdates
+	if regularUpdates < 0 {
+		regularUpdates = 0
+	}
+	writeHelp(&b, "patchmon_pending_updates_total", "gauge",
+		`Total unique packages pending an update, by type ("regular" or "security").`)
+	fmt.Fprintf(&b, "patchmon_pending_updates_total{type=\"regular\"} %d\n", regularUpdates)
+	fmt.Fprintf(&b, "patchmon_pending_updates_total{type=\"security\"} %d\n\n", agg.SecurityUpdates)
+
+	// patchmon_host_pending_updates{host_id, name, hostname, os_type}
+	writeHelp(&b, "patchmon_host_pending_updates", "gauge",
+		"Number of packages pending a regular (non-security) update on a specific host.")
+	for _, row := range perHost {
+		lbl := hostLabels(row)
+		fmt.Fprintf(&b, "patchmon_host_pending_updates{%s} %d\n", lbl, row.Regular)
+	}
+	b.WriteByte('\n')
+
+	// patchmon_host_security_updates{host_id, name, hostname, os_type}
+	writeHelp(&b, "patchmon_host_security_updates", "gauge",
+		"Number of packages pending a security update on a specific host.")
+	for _, row := range perHost {
+		lbl := hostLabels(row)
+		fmt.Fprintf(&b, "patchmon_host_security_updates{%s} %d\n", lbl, row.Security)
+	}
+	b.WriteByte('\n')
+
+	// patchmon_host_installed_packages_total{host_id, name, hostname, os_type, os_version}
+	var totalInstalled int
+	for _, row := range perHost {
+		totalInstalled += row.TotalInstalled
+	}
+	writeHelp(&b, "patchmon_installed_packages_total", "gauge",
+		"Total number of installed packages across all monitored hosts.")
+	fmt.Fprintf(&b, "patchmon_installed_packages_total %d\n\n", totalInstalled)
+
+	writeHelp(&b, "patchmon_host_installed_packages_total", "gauge",
+		"Total number of installed packages on a specific host.")
+	for _, row := range perHost {
+		lbl := hostLabels(row)
+		fmt.Fprintf(&b, "patchmon_host_installed_packages_total{%s} %d\n", lbl, row.TotalInstalled)
+	}
+	b.WriteByte('\n')
+
+	// patchmon_host_pending_reboot{host_id, name, ...} — 1 if reboot needed, 0 otherwise
+	writeHelp(&b, "patchmon_host_pending_reboot", "gauge",
+		"Whether a host requires a reboot: 1 = reboot needed, 0 = no reboot needed.")
+	for _, row := range perHost {
+		lbl := hostLabels(row)
+		rebootVal := 0
+		if row.NeedsReboot {
+			rebootVal = 1
+		}
+		fmt.Fprintf(&b, "patchmon_host_pending_reboot{%s} %d\n", lbl, rebootVal)
+	}
+	b.WriteByte('\n')
+
+	// patchmon_host_last_seen_seconds{host_id, name}
+	writeHelp(&b, "patchmon_host_last_seen_seconds", "gauge",
+		"Unix timestamp of the last successful agent check-in for a host.")
+	for _, row := range perHost {
+		lbl := hostLabels(row)
+		fmt.Fprintf(&b, "patchmon_host_last_seen_seconds{%s} %d\n", lbl, row.LastUpdate.Unix())
+	}
+	b.WriteByte('\n')
+
+	// patchmon_scrape_timestamp_seconds — useful for stale-data detection
+	writeHelp(&b, "patchmon_scrape_timestamp_seconds", "gauge",
+		"Unix timestamp when these metrics were collected by PatchMon.")
+	fmt.Fprintf(&b, "patchmon_scrape_timestamp_seconds %d\n", now.Unix())
+
+	return b.String(), nil
+}
+
+// queryPerHostMetrics runs a raw query to get per-host pending update counts.
+func (h *PrometheusExporterHandler) queryPerHostMetrics(ctx context.Context) ([]hostUpdateRow, error) {
+	const q = `
+SELECT
+    ho.id,
+    ho.friendly_name,
+    COALESCE(ho.hostname, '') AS hostname,
+    ho.os_type,
+    COALESCE(ho.os_version, '') AS os_version,
+    ho.last_update,
+    COUNT(*) FILTER (WHERE hp.needs_update = true  AND hp.is_security_update = false)::int AS regular,
+    COUNT(*) FILTER (WHERE hp.needs_update = true  AND hp.is_security_update = true)::int  AS security,
+    COUNT(hp.id)::int AS total_installed,
+    ho.needs_reboot
+FROM hosts ho
+LEFT JOIN host_packages hp ON hp.host_id = ho.id
+GROUP BY ho.id, ho.friendly_name, ho.hostname, ho.os_type, ho.os_version, ho.last_update, ho.needs_reboot
+ORDER BY ho.friendly_name
+`
+	d := h.dbp.DB(ctx)
+	rows, err := d.Raw(ctx, q)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var result []hostUpdateRow
+	for rows.Next() {
+		var row hostUpdateRow
+		var pgLastUpdate pgtype.Timestamp
+		if err := rows.Scan(
+			&row.HostID, &row.FriendlyName, &row.Hostname, &row.OSType, &row.OSVersion,
+			&pgLastUpdate, &row.Regular, &row.Security, &row.TotalInstalled, &row.NeedsReboot,
+		); err != nil {
+			return nil, err
+		}
+		if pgLastUpdate.Valid {
+			row.LastUpdate = pgLastUpdate.Time.UTC()
+		}
+		result = append(result, row)
+	}
+	return result, rows.Err()
+}
+
+// hostLabels formats the Prometheus label set for a host row.
+// Label values are quoted Go-style by fmt.Sprintf %q, which produces valid
+// Prometheus label strings (backslash-escaped double-quotes).
+func hostLabels(row hostUpdateRow) string {
+	return fmt.Sprintf(
+		`host_id=%q,name=%q,hostname=%q,os_type=%q,os_version=%q`,
+		row.HostID,
+		row.FriendlyName,
+		row.Hostname,
+		row.OSType,
+		row.OSVersion,
+	)
+}
+
+// writeHelp writes a # HELP and # TYPE comment block.
+func writeHelp(b *strings.Builder, name, metricType, help string) {
+	fmt.Fprintf(b, "# HELP %s %s\n", name, help)
+	fmt.Fprintf(b, "# TYPE %s %s\n", name, metricType)
+}

--- a/server-source-code/internal/migrate/migrations/000048_v2-1-0_prometheus_exporter.down.sql
+++ b/server-source-code/internal/migrate/migrations/000048_v2-1-0_prometheus_exporter.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE settings
+    DROP COLUMN IF EXISTS prometheus_enabled;

--- a/server-source-code/internal/migrate/migrations/000048_v2-1-0_prometheus_exporter.up.sql
+++ b/server-source-code/internal/migrate/migrations/000048_v2-1-0_prometheus_exporter.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE settings
+    ADD COLUMN IF NOT EXISTS prometheus_enabled BOOLEAN NOT NULL DEFAULT false;

--- a/server-source-code/internal/models/core.go
+++ b/server-source-code/internal/models/core.go
@@ -194,4 +194,5 @@ type Settings struct {
 	PasswordRateLimitWindowMs       *int       `db:"password_rate_limit_window_ms"`
 	PasswordRateLimitMax            *int       `db:"password_rate_limit_max"`
 	AuthBrowserSessionCookies       *bool      `db:"auth_browser_session_cookies"`
+	PrometheusEnabled               bool       `db:"prometheus_enabled"`
 }

--- a/server-source-code/internal/server/router.go
+++ b/server-source-code/internal/server/router.go
@@ -165,6 +165,7 @@ func NewRouter(ctx context.Context, cfg *config.Config, db *database.DB, rdb *re
 	hostsStore := store.NewHostsStore(dbProvider)
 	billingHandler := handler.NewBillingHandler(cfg, log, hostsStore)
 	metricsHandler := handler.NewMetricsHandler(settingsStore, hostsStore, cfg)
+	prometheusHandler := handler.NewPrometheusExporterHandler(settingsStore, hostsStore, dbProvider)
 	hostGroupsStore := store.NewHostGroupsStore(dbProvider)
 	var integrationStatusStore *store.IntegrationStatusStore
 	if rdb != nil {
@@ -279,6 +280,9 @@ func NewRouter(ctx context.Context, cfg *config.Config, db *database.DB, rdb *re
 	communityHandler := handler.NewCommunityHandler(cfg)
 
 	r.Get("/health", healthHandler(db, rdb))
+	// Prometheus scrape endpoint. Returns 404 when prometheus_enabled=false in settings.
+	// Intentionally public (no auth) — protect via network firewall or reverse-proxy when needed.
+	r.Get("/metrics", prometheusHandler.ServeMetrics)
 
 	// Start guacd subprocess if RDP enabled and address is localhost.
 	// When GUACD_ADDRESS points to a remote host (e.g. guacd:4822 in Docker), guacd runs as a sidecar.
@@ -497,6 +501,8 @@ func NewRouter(ctx context.Context, cfg *config.Config, db *database.DB, rdb *re
 			r.With(middleware.RequirePermission("can_manage_settings", permissionsStore)).Put("/metrics", metricsHandler.Update)
 			r.With(middleware.RequirePermission("can_manage_settings", permissionsStore)).Post("/metrics/regenerate-id", metricsHandler.RegenerateID)
 			r.With(middleware.RequirePermission("can_manage_settings", permissionsStore)).Post("/metrics/send-now", metricsHandler.SendNow)
+			r.With(middleware.RequirePermission("can_manage_settings", permissionsStore)).Get("/prometheus/settings", prometheusHandler.GetSettings)
+			r.With(middleware.RequirePermission("can_manage_settings", permissionsStore)).Put("/prometheus/settings", prometheusHandler.UpdateSettings)
 			r.Get("/version/current", settingsHandler.VersionCurrent(cfg.Version))
 			r.With(middleware.RequirePermission("can_manage_settings", permissionsStore)).Get("/version/check-updates", settingsHandler.VersionCheckUpdates(cfg.Version))
 			// AI routes gated by the ai module (Max tier).

--- a/server-source-code/internal/sqlc/queries/settings.sql
+++ b/server-source-code/internal/sqlc/queries/settings.sql
@@ -63,8 +63,9 @@ UPDATE settings SET
     compliance_scan_interval = $57,
     package_cache_refresh_mode = $58,
     package_cache_refresh_max_age = $59,
-    oidc_trust_unverified_email = $60
-WHERE id = $61;
+    oidc_trust_unverified_email = $60,
+    prometheus_enabled = $61
+WHERE id = $62;
 
 -- name: UpdateSettingsConfig :exec
 UPDATE settings SET

--- a/server-source-code/internal/sqlc/schema/schema.sql
+++ b/server-source-code/internal/sqlc/schema/schema.sql
@@ -126,7 +126,8 @@ CREATE TABLE IF NOT EXISTS settings (
     agent_rate_limit_max INTEGER,
     password_rate_limit_window_ms INTEGER,
     password_rate_limit_max INTEGER,
-    auth_browser_session_cookies BOOLEAN
+    auth_browser_session_cookies BOOLEAN,
+    prometheus_enabled BOOLEAN NOT NULL DEFAULT false
 );
 
 -- host_groups

--- a/server-source-code/internal/store/convert.go
+++ b/server-source-code/internal/store/convert.go
@@ -136,6 +136,7 @@ func dbSettingToModel(s db.Setting) models.Settings {
 		PasswordRateLimitWindowMs:       pgInt32ToIntPtr(s.PasswordRateLimitWindowMs),
 		PasswordRateLimitMax:            pgInt32ToIntPtr(s.PasswordRateLimitMax),
 		AuthBrowserSessionCookies:       s.AuthBrowserSessionCookies,
+		PrometheusEnabled:               s.PrometheusEnabled,
 	}
 }
 
@@ -209,6 +210,7 @@ func settingsToUpdateParams(s *models.Settings) db.UpdateSettingsParams {
 		OidcUserGroup:             s.OidcUserGroup,
 		OidcEnforceHttps:          s.OidcEnforceHTTPS,
 		OidcTrustUnverifiedEmail:  s.OidcTrustUnverifiedEmail,
+		PrometheusEnabled:         s.PrometheusEnabled,
 		ID:                        s.ID,
 	}
 }


### PR DESCRIPTION
## Add integrated Prometheus exporter

Adds a built-in Prometheus scrape endpoint (`GET /metrics`) that exposes fleet health, update status, and per-host package metrics. The exporter is **disabled by default** and can be toggled from the UI under **Settings → Metrics**.

Close #649

---

### Changes

#### Database
- `000041_v2-1-0_prometheus_exporter.up.sql` : adds `prometheus_enabled BOOLEAN NOT NULL DEFAULT false` column to the `settings` table
- `000041_v2-1-0_prometheus_exporter.down.sql` : drops the column

#### Backend
- **`internal/db/models.go`** : added `PrometheusEnabled bool` to the `Setting` struct
- **`internal/db/settings.sql.go`** : updated `getFirstSettings` SELECT + scan, `updateSettings` SQL, `UpdateSettingsParams` struct, and exec arguments
- **`internal/models/core.go`** : added `PrometheusEnabled bool` to the `Settings` domain model
- **`internal/store/convert.go`** : propagated the new field through both `dbSettingToModel` and `settingsToUpdateParams`
- **`internal/handler/prometheus_exporter.go`** *(new)* : full handler implementing:
  - `GET /api/v1/prometheus/settings` : returns `{ prometheus_enabled: bool }`
  - `PUT /api/v1/prometheus/settings` : toggles the exporter on/off (requires `can_manage_settings`)
  - `GET /metrics` : Prometheus text format scrape endpoint (public, no auth)
- **`internal/server/router.go`** : wired up all three routes and constructed the handler

#### Frontend
- **`src/pages/settings/SettingsMetrics.jsx`** : added a "Prometheus Exporter" section at the bottom of the Metrics settings page with:
  - Enable/disable toggle (same pattern as the telemetry toggle)
  - Status indicator (active / disabled + scrape URL)
  - Security notice that `/metrics` is unauthenticated
  - Reference list of all exported metrics

---

### Exported metrics

| Metric | Type | Description |
|---|---|---|
| `patchmon_hosts_total` | gauge | Total monitored hosts |
| `patchmon_hosts_needing_updates_total` | gauge | Hosts with ≥1 pending update |
| `patchmon_hosts_needing_security_updates_total` | gauge | Hosts with ≥1 pending security update |
| `patchmon_hosts_errored_total` | gauge | Hosts not seen for 2× update interval |
| `patchmon_hosts_offline_total` | gauge | Hosts not seen for 3× update interval |
| `patchmon_hosts_needing_reboot_total` | gauge | Hosts with a pending reboot |
| `patchmon_pending_updates_total{type}` | gauge | Unique packages pending update, by `regular` / `security` |
| `patchmon_installed_packages_total` | gauge | Total installed packages across all hosts |
| `patchmon_host_pending_updates{host_id,name,hostname,os_type,os_version}` | gauge | Per-host regular pending updates |
| `patchmon_host_security_updates{host_id,name,hostname,os_type,os_version}` | gauge | Per-host security pending updates |
| `patchmon_host_installed_packages_total{host_id,name,hostname,os_type,os_version}` | gauge | Per-host total installed packages |
| `patchmon_host_pending_reboot{host_id,name,hostname,os_type,os_version}` | gauge | `1` = reboot needed, `0` = no reboot needed |
| `patchmon_host_last_seen_seconds{host_id,name,hostname,os_type,os_version}` | gauge | Last agent check-in (unix timestamp) |
| `patchmon_scrape_timestamp_seconds` | gauge | Time these metrics were collected |

---

### Security notes

- The `/metrics` endpoint is intentionally **unauthenticated** to be compatible with standard Prometheus scrape configurations.
- Access should be restricted at the network layer (firewall rule or reverse-proxy) if the PatchMon instance is publicly reachable.
- When the exporter is disabled, `/metrics` returns `503 Service Unavailable` with a human-readable message instead of leaking a 404 that could expose route structure.
- The settings API (`/api/v1/prometheus/settings`) is protected by the `can_manage_settings` permission.