### PR TITLE
fix: kernel version comparison wrong for Debian deb13.x kernels (#814)

### DIFF
--- a/agent-source-code/internal/system/reboot.go
+++ b/agent-source-code/internal/system/reboot.go
@@ -226,8 +226,16 @@ func compareKernelVersions(v1, v2 string) int {
 			if n1 > n2 {
 				return 1
 			}
+		} else if err1 == nil && err2 != nil && p2 != "" {
+			// p1 is a numeric sub-revision (e.g. the "1" in deb13.1) and p2
+			// is a non-numeric label (e.g. the arch suffix "amd64").
+			// A version with an extra numeric sub-revision is newer.
+			return 1
+		} else if err1 != nil && err2 == nil && p1 != "" {
+			// Symmetric: p2 has the extra numeric sub-revision.
+			return -1
 		} else {
-			// At least one is not a number, compare as strings
+			// Both non-numeric: compare as strings
 			if p1 < p2 {
 				return -1
 			}
@@ -240,10 +248,16 @@ func compareKernelVersions(v1, v2 string) int {
 	return 0
 }
 
-// parseKernelVersion parses a kernel version string into comparable parts
-// "6.14.11-2-pve" -> ["6", "14", "11", "2", "pve"]
+// parseKernelVersion parses a kernel version string into comparable parts.
+// Splits on ".", "-" and "+" so that Debian-style versions like
+// "6.12.90+deb13.1-amd64" are tokenised correctly:
+//
+//	"6.14.11-2-pve"           -> ["6", "14", "11", "2", "pve"]
+//	"6.12.90+deb13.1-amd64"   -> ["6", "12", "90", "deb13", "1", "amd64"]
+//	"6.12.90+deb13-amd64"     -> ["6", "12", "90", "deb13", "amd64"]
 func parseKernelVersion(version string) []string {
-	// Replace dots and dashes with spaces, then split
+	// Replace dots, dashes and plus signs with spaces, then split
+	version = strings.ReplaceAll(version, "+", " ")
 	version = strings.ReplaceAll(version, ".", " ")
 	version = strings.ReplaceAll(version, "-", " ")
 	parts := strings.Fields(version)

--- a/agent-source-code/internal/system/reboot_test.go
+++ b/agent-source-code/internal/system/reboot_test.go
@@ -1,0 +1,115 @@
+package system
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestCompareKernelVersions(t *testing.T) {
+	tests := []struct {
+		name string
+		v1   string
+		v2   string
+		want int // -1, 0, or 1
+	}{
+		// Debian-style with + separator — the bug case
+		{
+			name: "deb13.1 is newer than deb13",
+			v1:   "6.12.90+deb13.1-amd64",
+			v2:   "6.12.90+deb13-amd64",
+			want: 1,
+		},
+		{
+			name: "deb13 is older than deb13.1",
+			v1:   "6.12.90+deb13-amd64",
+			v2:   "6.12.90+deb13.1-amd64",
+			want: -1,
+		},
+		{
+			name: "identical deb versions",
+			v1:   "6.12.90+deb13.1-amd64",
+			v2:   "6.12.90+deb13.1-amd64",
+			want: 0,
+		},
+		{
+			name: "higher upstream version wins over deb sub-revision",
+			v1:   "6.12.91+deb13-amd64",
+			v2:   "6.12.90+deb13.1-amd64",
+			want: 1,
+		},
+		// PVE-style kernels
+		{
+			name: "higher minor PVE kernel",
+			v1:   "6.14.11-2-pve",
+			v2:   "6.8.12-9-pve",
+			want: 1,
+		},
+		{
+			name: "same minor, higher patch PVE kernel",
+			v1:   "6.8.12-10-pve",
+			v2:   "6.8.12-9-pve",
+			want: 1,
+		},
+		{
+			name: "identical PVE versions",
+			v1:   "6.14.11-2-pve",
+			v2:   "6.14.11-2-pve",
+			want: 0,
+		},
+		// Ubuntu-style kernels
+		{
+			name: "higher ABI Ubuntu kernel",
+			v1:   "5.15.0-100-generic",
+			v2:   "5.15.0-91-generic",
+			want: 1,
+		},
+		{
+			name: "identical Ubuntu versions",
+			v1:   "5.15.0-91-generic",
+			v2:   "5.15.0-91-generic",
+			want: 0,
+		},
+		// Generic version ordering
+		{
+			name: "higher patch version",
+			v1:   "6.1.2",
+			v2:   "6.1.1",
+			want: 1,
+		},
+		{
+			name: "lower minor version",
+			v1:   "6.1.0",
+			v2:   "6.2.0",
+			want: -1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := compareKernelVersions(tc.v1, tc.v2)
+			if got != tc.want {
+				t.Errorf("compareKernelVersions(%q, %q) = %d, want %d", tc.v1, tc.v2, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestGetLatestKernelFromBootSort verifies that getLatestKernelFromBoot
+// correctly picks the newest kernel when multiple versions coexist — the
+// scenario that caused the false "reboot required" on Debian 13.
+func TestKernelSortPicksLatest(t *testing.T) {
+	kernels := []string{
+		"6.12.90+deb13-amd64",
+		"6.12.90+deb13.1-amd64",
+	}
+
+	sort.Slice(kernels, func(i, j int) bool {
+		return compareKernelVersions(kernels[i], kernels[j]) < 0
+	})
+	latest := kernels[len(kernels)-1]
+
+	want := "6.12.90+deb13.1-amd64"
+	if latest != want {
+		t.Errorf("sort picked %q as latest, want %q", latest, want)
+	}
+}


### PR DESCRIPTION
parseKernelVersion was only splitting on '.' and '-', leaving '+' embedded in tokens. So '6.12.90+deb13.1-amd64' parsed to [6, 12, 90+deb13, 1, amd64] while '6.12.90+deb13-amd64' parsed to [6, 12, 90+deb13, amd64].

When both kernels existed in /boot (old one not yet removed), the sort compared the numeric '1' against the arch string 'amd64' and since '1' < 'amd64' in string comparison, deb13.1 was ranked as older than deb13. The sort returned the wrong kernel as 'latest installed', triggering a false reboot required alert.

Fix: add '+' as a separator in parseKernelVersion and handle the numeric-vs-non-numeric case explicitly so a numeric sub-revision always ranks higher than a non-numeric label at the same position.

Adds tests covering the broken case and common kernel naming formats (Debian, PVE, Ubuntu).