### PR TITLE
fix(agent): Change compare version processing #814 #831

### DIFF
--- a/agent-source-code/internal/system/reboot.go
+++ b/agent-source-code/internal/system/reboot.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 	"runtime"
 	"sort"
 	"strconv"
 	"strings"
-	"regexp"
 
 	"patchmon-agent/internal/logutil"
 )
@@ -227,15 +227,16 @@ func compareKernelVersions(v1, v2 string) int {
 			if n1 > n2 {
 				return 1
 			}
-		} else {
-			// At least one is not a number, compare as strings
-			if p1 < p2 {
-				return -1
-			}
-			if p1 > p2 {
-				return 1
-			}
+			continue
 		}
+		// At least one is not a number, compare as strings
+		if p1 < p2 {
+			return -1
+		}
+		if p1 > p2 {
+			return 1
+		}
+
 	}
 
 	return 0
@@ -244,14 +245,74 @@ func compareKernelVersions(v1, v2 string) int {
 // parseKernelVersion parses a kernel version string into comparable parts
 // "6.14.11-2-pve" -> ["6", "14", "11", "2", "pve"]
 func parseKernelVersion(version string) []string {
-    //Extract MAJOR.MINOR.PATCH version and extra (all char after the PATCH digit)
+	// Extract MAJOR.MINOR.PATCH version and extra (all char after the PATCH digit)
 	versionRegex := regexp.MustCompile(`^(\d+)\.(\d+)\.(\d+)(.*)$`)
 	matches := versionRegex.FindStringSubmatch(version)
+	if matches == nil {
+		return removeTrailingArchToken(splitKernelVersionParts(version))
+	}
 
-    //remove the first element
-    matches = matches[1:]
+	parts := append([]string{}, matches[1:4]...)
+	parts = append(parts, splitKernelVersionParts(matches[4])...)
 
-	return matches
+	return removeTrailingArchToken(parts)
+}
+
+func splitKernelVersionParts(version string) []string {
+	return strings.FieldsFunc(version, func(r rune) bool {
+		return r == '.' || r == '-' || r == '+'
+	})
+}
+
+func removeTrailingArchToken(parts []string) []string {
+	if len(parts) == 0 {
+		return parts
+	}
+
+	if isKernelArchToken(parts[len(parts)-1]) {
+		return parts[:len(parts)-1]
+	}
+
+	return parts
+}
+
+func isKernelArchToken(part string) bool {
+	switch strings.ToLower(part) {
+	case
+		"2712",
+		"aarch64",
+		"alpha",
+		"amd64",
+		"arm",
+		"arm64",
+		"armel",
+		"armhf",
+		"armv7l",
+		"i386",
+		"i486",
+		"i586",
+		"i686",
+		"ia64",
+		"m68k",
+		"mips",
+		"mipsel",
+		"mips64el",
+		"powerpc",
+		"ppc64",
+		"ppc64le",
+		"ppc64el",
+		"riscv64",
+		"s390x",
+		"sh4",
+		"sparc64",
+		"v7l",
+		"v8",
+		"x64",
+		"x86_64":
+		return true
+	default:
+		return false
+	}
 }
 
 // getLatestKernelFromRPM queries RPM for installed kernel packages

--- a/agent-source-code/internal/system/reboot.go
+++ b/agent-source-code/internal/system/reboot.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"regexp"
 
 	"patchmon-agent/internal/logutil"
 )
@@ -243,11 +244,14 @@ func compareKernelVersions(v1, v2 string) int {
 // parseKernelVersion parses a kernel version string into comparable parts
 // "6.14.11-2-pve" -> ["6", "14", "11", "2", "pve"]
 func parseKernelVersion(version string) []string {
-	// Replace dots and dashes with spaces, then split
-	version = strings.ReplaceAll(version, ".", " ")
-	version = strings.ReplaceAll(version, "-", " ")
-	parts := strings.Fields(version)
-	return parts
+    //Extract MAJOR.MINOR.PATCH version and extra (all char after the PATCH digit)
+	versionRegex := regexp.MustCompile(`^(\d+)\.(\d+)\.(\d+)(.*)$`)
+	matches := versionRegex.FindStringSubmatch(version)
+
+    //remove the first element
+    matches = matches[1:]
+
+	return matches
 }
 
 // getLatestKernelFromRPM queries RPM for installed kernel packages

--- a/agent-source-code/internal/system/reboot_test.go
+++ b/agent-source-code/internal/system/reboot_test.go
@@ -1,0 +1,74 @@
+package system
+
+import (
+	"testing"
+)
+
+func TestCompareKernelVersions(t *testing.T) {
+	// Définition des cas de test
+	tests := []struct {
+		name     string
+		v1       string
+		v2       string
+		expected int
+	}{
+		{
+			name:     "Same version with extra",
+			v1:       "6.14.11-2-pve",
+			v2:       "6.14.11-2-pve",
+			expected: 0,
+		},
+		{
+			name:     "v1 newest (major version)",
+			v1:       "6.14.11-2-pve",
+			v2:       "5.19.0-1-generic",
+			expected: 1,
+		},
+		{
+			name:     "v1 oldest (minor version)",
+			v1:       "6.8.12-9-pve",
+			v2:       "6.14.11-2-pve",
+			expected: -1,
+		},
+		{
+			name:     "v1 newest (patch)",
+			v1:       "6.8.15-1-pve",
+			v2:       "6.8.12-9-pve",
+			expected: 1,
+		},
+		{
+			name:     "v1 oldest (build)",
+			v1:       "6.8.12-2-pve",
+			v2:       "6.8.12-9-pve",
+			expected: -1,
+		},
+		{
+			name:     "Same versions in Debian format",
+			v1:       "6.12.90+deb13.1-amd64",
+			v2:       "6.12.90+deb13.1-amd64",
+			expected: 0,
+		},
+		{
+			name:     "v1 oldest, versions in Debian format with Debian patch",
+			v1:       "6.12.90+deb13-amd64",
+			v2:       "6.12.90+deb13.1-amd64",
+			expected: -1,
+		},
+		{
+			name:     "v1 newest versions in Debian format",
+			v1:       "6.12.90+deb13.2-amd64",
+			v2:       "6.12.90+deb13.1-amd64",
+			expected: 1,
+		},
+	}
+
+	// Exécution des cas de test
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := compareKernelVersions(tt.v1, tt.v2)
+			if got != tt.expected {
+				t.Errorf("compareKernelVersions(%q, %q) = %d; got %d", tt.v1, tt.v2, tt.expected, got)
+			}
+		})
+	}
+}

--- a/agent-source-code/internal/system/reboot_test.go
+++ b/agent-source-code/internal/system/reboot_test.go
@@ -60,6 +60,18 @@ func TestCompareKernelVersions(t *testing.T) {
 			v2:       "6.12.90+deb13.1-amd64",
 			expected: 1,
 		},
+		{
+			name:     "v1 newest major versions in Debian format",
+			v1:       "7.0.10+deb13-amd64",
+			v2:       "6.12.90+deb13.1-amd64",
+			expected: 1,
+		},
+		{
+			name:     "v1 newest minor versions in Debian format",
+			v1:       "7.0.10+deb13-amd64",
+			v2:       "7.0.7+deb13-amd64",
+			expected: 1,
+		},
 	}
 
 	// Exécution des cas de test

--- a/agent-source-code/internal/system/reboot_test.go
+++ b/agent-source-code/internal/system/reboot_test.go
@@ -72,6 +72,12 @@ func TestCompareKernelVersions(t *testing.T) {
 			v2:       "7.0.7+deb13-amd64",
 			expected: 1,
 		},
+		{
+			name:     "same versions in Arch Linux",
+			v1:       "7.0.9-hardened1-1-hardened",
+			v2:       "7.0.9-hardened1-1-hardened",
+			expected: 0,
+		},
 	}
 
 	// Exécution des cas de test

--- a/agent-source-code/internal/system/reboot_test.go
+++ b/agent-source-code/internal/system/reboot_test.go
@@ -78,6 +78,30 @@ func TestCompareKernelVersions(t *testing.T) {
 			v2:       "7.0.9-hardened1-1-hardened",
 			expected: 0,
 		},
+		{
+			name:     "Same versions in Raspbian Linux only arch change",
+			v1:       "6.12.62+rpt-rpi-2712",
+			v2:       "6.12.62+rpt-rpi-v8",
+			expected: 0,
+		},
+		{
+			name:     "v1 newest minor versions in Raspbian Linux",
+			v1:       "6.12.93+rpt-rpi-2712",
+			v2:       "6.12.62+rpt-rpi-v8",
+			expected: 1,
+		},
+		{
+			name:     "v1 is unknow versions in Raspbian Linux",
+			v1:       "unknow",
+			v2:       "6.12.62+rpt-rpi-v8",
+			expected: 1,
+		},
+		{
+			name:     "v1 empty versions in Raspbian Linux",
+			v1:       "",
+			v2:       "6.12.62+rpt-rpi-v8",
+			expected: -1,
+		},
 	}
 
 	// Exécution des cas de test

--- a/agent-source-code/internal/system/reboot_test.go
+++ b/agent-source-code/internal/system/reboot_test.go
@@ -73,6 +73,12 @@ func TestCompareKernelVersions(t *testing.T) {
 			expected: 1,
 		},
 		{
+			name:     "v1 newest minor versions in Debian format",
+			v1:       "6.12.101+deb13-amd64",
+			v2:       "6.12.95+deb13-amd64",
+			expected: 1,
+		},
+		{
 			name:     "same versions in Arch Linux",
 			v1:       "7.0.9-hardened1-1-hardened",
 			v2:       "7.0.9-hardened1-1-hardened",


### PR DESCRIPTION
This PR change the Linux kernel version comparaison behavior.

The MAJOR.MINOR.PATCH and extra version are extracted with a Regex.
Each element is compared with other version.

In GO the string `+deb13-amd64` is lower `+deb13.1-amd64`

Issue #814, #831, #553, #647