### PR TITLE
Fix : RedHat with subscription - handle dnf output 'Updating Subscription' #415

### DIFF
--- a/agent-source-code/internal/packages/dnf.go
+++ b/agent-source-code/internal/packages/dnf.go
@@ -304,7 +304,8 @@ func (m *DNFManager) parseUpgradablePackages(output string, packageManager strin
 
 		// Skip header lines and empty lines
 		if line == "" || strings.Contains(line, "Loaded plugins") ||
-			strings.Contains(line, "Last metadata") || strings.HasPrefix(line, "Loading") {
+			strings.Contains(line, "Last metadata") || strings.HasPrefix(line, "Loading") ||
+            strings.HasPrefix(line, "Updating Subscription") {
 			continue
 		}
 


### PR DESCRIPTION
Cf #415 

Example :
```
[root@patchmon]# dnf list --installed | grep -A 4 -B 2 'Updating Subscription'  
Updating Subscription Management repositories.  
Installed Packages  
ModemManager-glib.x86_64                       1.20.2-1.el9                     @rhel-9-for-x86_64-baseos-rpms             
NetworkManager.x86_64                          1:1.54.3-3.el9_8                 @rhel-9-for-x86_64-baseos-rpms             
NetworkManager-libnm.x86_64                    1:1.54.3-3.el9_8                 @rhel-9-for-x86_64-baseos-rpms             
[root@patchmon]#  dnf check-update  
Updating Subscription Management repositories.  
Last metadata expiration check: 0:02:41 ago on Fri 05 Jun 2026 03:13:39 PM CEST.  
```
