### PR TITLE
Fix the placeholder issue

### DIFF
--- a/docker/server.Dockerfile
+++ b/docker/server.Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /app/frontend
 COPY frontend/package*.json ./
 RUN npm install --ignore-scripts --legacy-peer-deps 2>/dev/null || true
 COPY frontend/ ./
-RUN npm run build 2>/dev/null || mkdir -p dist && echo '<!DOCTYPE html><html><body>Build frontend first</body></html>' > dist/index.html
+RUN npm run build
 
 WORKDIR /app/server
 COPY server-source-code/ ./


### PR DESCRIPTION
## Summary

Fixes the `Build frontend first` placeholder being served instead of the PatchMon UI when running the development Docker stack.

## What problem does this PR solve?

When following the development setup in `CONTRIBUTING.md` and running `docker compose -f docker/docker-compose.dev.yml up`, `localhost:3000` displays a `Build frontend first` placeholder page instead of the PatchMon UI.

Closes #840 

## Root cause

Line 17 of `docker/server.Dockerfile` used the following pattern:

```dockerfile
RUN npm run build 2>/dev/null || mkdir -p dist && echo '<!DOCTYPE html><html><body>Build frontend first</body></html>' > dist/index.html
```

The `2>/dev/null` suppresses all npm build output including errors. If the build fails for any reason (e.g. disk space, missing dependencies, npm errors), the `||` fallback silently writes the placeholder `index.html` instead. The Docker build succeeds, the server starts, and the developer is left with no indication that the frontend build failed.

## Fix

Remove the silent failure and placeholder fallback:

```dockerfile
RUN npm run build
```

If the frontend build fails, the Docker build now fails loudly with the full npm error output visible, making the root cause immediately obvious to the developer.

## How was this tested?

This fix was validated during development of the macOS agent (PR #790) where this exact issue was encountered and resolved. The development stack was run successfully multiple times after applying this change.

---

## AI Disclosure

No AI used.