### PR TITLE
feat(security) generate attestation for release

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -14,6 +14,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 env:
   TAG_NAME: ${{ github.event.release.tag_name }}
@@ -172,6 +174,10 @@ jobs:
               echo "✅ No GLIBC version requirements found (statically linked)"
             fi
           fi
+      - name: Generate artifact attestation
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 #v4.1.0
+        with:
+          subject-path: agent-source-code/patchmon-agent-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.goos == 'windows' && '.exe' || '' }}
 
       - name: Upload agent binary to release
         uses: softprops/action-gh-release@b25b93d384199fc0fc8c2e126b2d937a0cbeb2ae
@@ -255,6 +261,11 @@ jobs:
             -ldflags="-s -w -X 'github.com/PatchMon/PatchMon/server-source-code/internal/config.DefaultVersion=${VERSION}'" \
             -o "${OUTPUT_NAME}" ./cmd/server
           mv "${OUTPUT_NAME}" ../
+
+      - name: Generate artifact attestation
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 #v4.1.0
+        with:
+          subject-path: patchmon-server-${{ matrix.goos }}-${{ matrix.goarch }}
 
       - name: Upload patchmon-server to release
         uses: softprops/action-gh-release@b25b93d384199fc0fc8c2e126b2d937a0cbeb2ae

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,6 +26,8 @@ permissions:
   contents: read
   packages: write
   pull-requests: write
+  id-token: write
+  attestations: write
 
 jobs:
   build-agents:
@@ -232,7 +234,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=server
           cache-to: type=gha,mode=max,scope=server
-          provenance: false
+          provenance: true
           # Force gzip on all layers (including base image layers from dhi.io/alpine-base
           # which ship as zstd). Without force-compression, mixed zstd/gzip manifests
           # break Podman <5.7 and Docker without the containerd image store.


### PR DESCRIPTION
To accordly with the European legal requirement from the Cyber Resilience Act (CRA), we must provide the build origin attestation and the SBOM (which is not the subject of this PR) for each build.

See #898

# AI Disclosure

No AI used.