### PR TITLE
fix(agent): stop agent self-update loop when server lags upstream release

### DIFF
--- a/agent-source-code/cmd/patchmon-agent/commands/report.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/report.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -332,10 +333,19 @@ func sendReport(outputJSON bool) error {
 				logger.WithError(err).Warn("Failed to check for updates after report (non-critical)")
 				return
 			}
-			if versionInfo.HasUpdate {
+			// Compare OUR version against the agent version the server ships.
+			// versionInfo.HasUpdate must not gate this: it reports whether the
+			// SERVER is behind the public upstream release (admin-UI info).
+			// Keying the self-update on it made every agent re-install the
+			// identical binary and restart after each report whenever the
+			// server lagged upstream — killing in-flight work (e.g. the
+			// post-patch reboot step) in the process.
+			runningVersion := strings.TrimPrefix(pkgversion.Version, "v")
+			serverAgentVersion := strings.TrimPrefix(versionInfo.LatestVersion, "v")
+			if serverAgentVersion != "" && serverAgentVersion != runningVersion {
 				logger.WithFields(logrus.Fields{
-					"current": versionInfo.CurrentVersion,
-					"latest":  versionInfo.LatestVersion,
+					"current": runningVersion,
+					"latest":  serverAgentVersion,
 				}).Info("Update available, automatically updating...")
 
 				if err := updateAgent(); err != nil {

--- a/agent-source-code/cmd/patchmon-agent/commands/version_update.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/version_update.go
@@ -153,8 +153,14 @@ func updateAgent() error {
 		latestVersion := strings.TrimPrefix(versionInfo.LatestVersion, "v")
 		logger.WithField("current", currentVersion).WithField("latest", latestVersion).Debug("Version check")
 
-		// Check if update is actually needed
-		if currentVersion == latestVersion && !versionInfo.HasUpdate {
+		// Check if update is actually needed. latestVersion is the agent
+		// version bundled with the server — the only thing that decides
+		// whether THIS agent should update. versionInfo.HasUpdate is about
+		// the server being behind the public upstream release (admin-UI
+		// info); honouring it here used to make agents re-download the
+		// identical binary and restart on every report cycle whenever the
+		// server lagged upstream.
+		if currentVersion == latestVersion {
 			logger.WithField("version", currentVersion).Info("Agent is already at the latest version, skipping update")
 			return nil
 		}

--- a/server-source-code/internal/handler/agent_version.go
+++ b/server-source-code/internal/handler/agent_version.go
@@ -18,7 +18,13 @@ import (
 
 const (
 	agentDNSDomain = "agent.vcheck.patchmon.net"
-	agentVersionRe = `(?i)(?:PatchMon Agent v|patchmon-agent v|version )?([0-9]+\.[0-9]+\.[0-9]+)`
+	// agentVersionRe extracts the version from the bundled binary's --version
+	// output. The optional pre-release suffix (e.g. 2.0.3-rc1, 2.0.3-test5)
+	// MUST be captured: agents compare this string against their own version
+	// to decide whether to self-update, and truncating "2.0.3-test5" to
+	// "2.0.3" makes every agent running the pre-release see a permanent
+	// mismatch and reinstall itself after each report, forever.
+	agentVersionRe = `(?i)(?:PatchMon Agent v|patchmon-agent v|version )?([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z][0-9A-Za-z.]*)?)`
 )
 
 // AgentVersionHandler handles agent version routes.

--- a/server-source-code/internal/util/agent_binary.go
+++ b/server-source-code/internal/util/agent_binary.go
@@ -11,7 +11,13 @@ import (
 	"time"
 )
 
-const agentVersionRe = `(?i)(?:PatchMon Agent v|patchmon-agent v|version )?([0-9]+\.[0-9]+\.[0-9]+)`
+// agentVersionRe extracts the version from agent binary --version output.
+// The optional pre-release suffix (2.0.3-rc1, 2.0.3-test5) must be captured:
+// the agent-facing /hosts/agent/version endpoint serves this string and
+// agents compare it against their own version to decide whether to
+// self-update. Truncating the suffix makes every pre-release agent see a
+// permanent mismatch and reinstall itself after each report.
+const agentVersionRe = `(?i)(?:PatchMon Agent v|patchmon-agent v|version )?([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z][0-9A-Za-z.]*)?)`
 
 // GetAgentsDir returns the agents binary directory from env (AGENT_BINARIES_DIR, AGENTS_DIR) or "agents".
 func GetAgentsDir() string {


### PR DESCRIPTION
## Problem

Agents repeatedly re-install the **same** binary and restart after every report cycle whenever the server's bundled agent version differs from what the agent thinks is "latest". Symptoms seen in the field:

- Agent WebSocket connections flapping after every report.
- In-flight work killed mid-run — most visibly, a post-patch reboot step that sits after the post-patch report never executes because the process restarts before reaching it.

## Root cause

Two independent bugs compound:

1. **Agent side** — the post-report update check keyed on `versionInfo.hasUpdate`. That field answers a *different* question: whether the PatchMon **server** is behind the public upstream release (DNS TXT comparison, surfaced in the admin UI). It says nothing about whether *this agent* differs from the agent version the server ships. So whenever the server lagged upstream, the agent looped: `hasUpdate=true` → `updateAgent()` → re-download identical binary → restart → exit.

2. **Server side** — `getCurrentAgentVersion` / `GetVersionFromBinaryPath` parsed the bundled binary's `--version` output with a regex that only matched `X.Y.Z`, dropping any pre-release suffix (`2.0.3-rc1` → `2.0.3`). An agent actually running the pre-release then saw a permanent mismatch and reinstalled itself after every report.

## Fix

- Agent compares its own version against `latestVersion` (the server-bundled agent version) directly; `hasUpdate` is no longer used to gate self-update. It remains what it always was — admin-UI information.
- Both server-side version regexes capture the optional semver pre-release suffix so the advertised version matches what the binary reports.

Auto-update itself is unchanged — agents still update when the server genuinely ships a newer version.