### PR TITLE
fix(server): cancel stalled patch runs that never reported started_at

### DIFF
--- a/server-source-code/internal/db/patching.sql.go
+++ b/server-source-code/internal/db/patching.sql.go
@@ -15,7 +15,7 @@ const cancelStalledPatchRuns = `-- name: CancelStalledPatchRuns :execrows
 UPDATE patch_runs
 SET status = 'cancelled', error_message = $2, completed_at = NOW(), updated_at = NOW()
 WHERE status = 'running'
-  AND started_at < $1
+  AND (started_at < $1 OR (started_at IS NULL AND created_at < $1))
 `
 
 type CancelStalledPatchRunsParams struct {
@@ -23,6 +23,11 @@ type CancelStalledPatchRunsParams struct {
 	ErrorMessage *string          `json:"error_message"`
 }
 
+// started_at IS NULL must be handled explicitly: a run whose agent died
+// before reporting the "started" stage (e.g. killed by a service restart
+// mid-run) sits at status='running' with NULL started_at, and `NULL < $1`
+// never matches - leaving a ghost row that blocks schedulers which treat
+// the host as busy. Fall back to created_at for those rows.
 func (q *Queries) CancelStalledPatchRuns(ctx context.Context, arg CancelStalledPatchRunsParams) (int64, error) {
 	result, err := q.db.Exec(ctx, cancelStalledPatchRuns, arg.StartedAt, arg.ErrorMessage)
 	if err != nil {

--- a/server-source-code/internal/db/querier.go
+++ b/server-source-code/internal/db/querier.go
@@ -89,6 +89,11 @@ type Querier interface {
 	// Re-parsing the JSON here is cheap (kilobytes, in-memory) and avoids a
 	// per-row round-trip — the alternative was a SELECT loop in Go.
 	BulkUpsertPackages(ctx context.Context, payload []byte) ([]BulkUpsertPackagesRow, error)
+	// started_at IS NULL must be handled explicitly: a run whose agent died
+	// before reporting the "started" stage (e.g. killed by a service restart
+	// mid-run) sits at status='running' with NULL started_at, and `NULL < $1`
+	// never matches - leaving a ghost row that blocks schedulers which treat
+	// the host as busy. Fall back to created_at for those rows.
 	CancelStalledPatchRuns(ctx context.Context, arg CancelStalledPatchRunsParams) (int64, error)
 	ClearScheduledAt(ctx context.Context, id string) error
 	CountActiveAdmins(ctx context.Context) (int64, error)

--- a/server-source-code/internal/sqlc/queries/patching.sql
+++ b/server-source-code/internal/sqlc/queries/patching.sql
@@ -303,7 +303,12 @@ VALUES ($1, $2, $3, NOW(), NOW());
 DELETE FROM patch_policy_exclusions WHERE patch_policy_id = $1 AND host_id = $2;
 
 -- name: CancelStalledPatchRuns :execrows
+-- started_at IS NULL must be handled explicitly: a run whose agent died
+-- before reporting the "started" stage (e.g. killed by a service restart
+-- mid-run) sits at status='running' with NULL started_at, and `NULL < $1`
+-- never matches - leaving a ghost row that blocks schedulers which treat
+-- the host as busy. Fall back to created_at for those rows.
 UPDATE patch_runs
 SET status = 'cancelled', error_message = $2, completed_at = NOW(), updated_at = NOW()
 WHERE status = 'running'
-  AND started_at < $1;
+  AND (started_at < $1 OR (started_at IS NULL AND created_at < $1));


### PR DESCRIPTION
Closes #810

## Problem

A patch run can get stuck in `status='running'` forever, and the host then looks permanently busy to anything that checks for active runs (auto-patch dispatch, etc.), so it silently stops being patched.

Observed in the field: a run stuck in `running` with `started_at = NULL` since the agent restarted mid-run ten days earlier. The host was skipped by scheduling from then on.

## Root cause

`CancelStalledPatchRuns` matched only:

```sql
WHERE status = 'running' AND started_at < $threshold
```

A run whose agent died **before** reporting the "started" stage (service restart mid-run, crash, host reboot) keeps `status='running'` with `started_at` NULL — and `NULL < threshold` never matches. So the daily cleanup skipped it forever.

## Fix

Fall back to `created_at` for rows with NULL `started_at`, so the 30-minute stall window applies to them too:

```sql
WHERE status = 'running'
  AND (started_at < $threshold OR (started_at IS NULL AND created_at < $threshold))
```