### PR TITLE
fix(agent): pass -y to dnf makecache so GPG key imports don't hang the run

### DIFF
--- a/agent-source-code/cmd/patchmon-agent/commands/serve.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/serve.go
@@ -2321,7 +2321,10 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 				stepErr = err
 			}
 		default:
-			if err, abort := runStep(false, upgradeBin+" makecache", upgradeBin+" makecache failed: %w", upgradeBin, "makecache", "-q"); abort {
+			// -y/--assumeyes accepts new GPG key imports non-interactively.
+			// Without it, dnf prompts "Is this ok [y/N]:" for keys like the
+			// PostgreSQL pgdg repo and the patch run hangs/fails.
+			if err, abort := runStep(false, upgradeBin+" makecache", upgradeBin+" makecache failed: %w", upgradeBin, "makecache", "-q", "-y"); abort {
 				stepErr = err
 			}
 		}


### PR DESCRIPTION
## Problem

On a yum/dnf host, when a repo introduces a new GPG key (e.g. the PostgreSQL pgdg repo), the first `makecache` hits an interactive prompt:

```
Importing GPG key 0x...:
Is this ok [y/N]:
Error: Failed to download metadata for repo 'pgdg-common':
repomd.xml GPG signature verification error: Signing key not found
```

The agent runs non-interactively, so empty input is read as "N", the key import is refused, and the whole patch run aborts.

## Fix

`dnf/yum upgrade` and `install` already pass `-y`; `makecache` was the only step without it. Add `-y`/`--assumeyes` to `makecache` for parity, so trusted-repo key rotations no longer break patching.