### PR TITLE
feat(hosts): remote reboot — single host and bulk, for hosts that need it

### DIFF
--- a/agent-source-code/cmd/patchmon-agent/commands/serve.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/serve.go
@@ -409,6 +409,15 @@ func runServiceLoop(stopCh <-chan struct{}) error {
 						logger.Info("run_patch completed successfully")
 					}
 				}(m)
+			case "reboot_host":
+				go func(msg wsMsg) {
+					// ExecuteReboot clamps delay_minutes to [0, 60] defensively.
+					if err := system.New(logger).ExecuteReboot(msg.rebootDelayMinutes, msg.rebootReason); err != nil {
+						logger.WithError(err).Warn("reboot_host failed to schedule")
+					} else {
+						logger.WithField("delay_minutes", msg.rebootDelayMinutes).Info("reboot_host scheduled")
+					}
+				}(m)
 			case "compliance_scan":
 				logger.WithFields(logutil.SanitizeMap(map[string]interface{}{
 					"profile_type":       m.profileType,
@@ -1175,6 +1184,9 @@ type wsMsg struct {
 	packageNames []string
 	dryRun       bool
 	sshProxyData string // SSH input data
+	// reboot_host fields
+	rebootDelayMinutes int
+	rebootReason       string
 	// RDP proxy fields
 	rdpProxySessionID string // Unique session ID for RDP proxy
 	rdpProxyHost      string // RDP target host (default localhost)
@@ -1702,6 +1714,9 @@ func connectOnce(out chan<- wsMsg, dockerEvents <-chan interface{}, backoff *tim
 			PackageName  string   `json:"package_name"`
 			PackageNames []string `json:"package_names"`
 			DryRun       bool     `json:"dry_run"`
+			// reboot_host fields
+			RebootDelayMinutes int    `json:"reboot_delay_minutes"`
+			RebootReason       string `json:"reboot_reason"`
 		}
 		if err := json.Unmarshal(data, &payload); err != nil {
 			logger.WithError(err).WithField("message_bytes", len(data)).Warn("Failed to parse WebSocket message")
@@ -1808,6 +1823,28 @@ func connectOnce(out chan<- wsMsg, dockerEvents <-chan interface{}, backoff *tim
 			}
 			logger.WithField("patch_run_id", logutil.Sanitize(payload.PatchRunID)).Info("patch_run_stop received")
 			dispatchWSMessage(out, wsMsg{kind: "patch_run_stop", patchRunID: payload.PatchRunID})
+		case "reboot_host":
+			// delay_minutes is clamped agent-side in ExecuteReboot; we accept
+			// any non-negative integer here. Reason is free-form but trimmed
+			// to a reasonable length so a malicious server message cannot
+			// inject a multi-MB string into wall(1).
+			delay := payload.RebootDelayMinutes
+			if delay < 0 {
+				delay = 0
+			}
+			reason := payload.RebootReason
+			if len(reason) > 200 {
+				reason = reason[:200]
+			}
+			logger.WithFields(logutil.SanitizeMap(map[string]interface{}{
+				"delay_minutes": delay,
+				"reason":        reason,
+			})).Info("reboot_host received")
+			dispatchWSMessage(out, wsMsg{
+				kind:               "reboot_host",
+				rebootDelayMinutes: delay,
+				rebootReason:       reason,
+			})
 		case "upgrade_ssg":
 			logger.WithField("version", payload.Version).Info("upgrade_ssg received from WebSocket")
 			dispatchWSMessage(out, wsMsg{kind: "upgrade_ssg", version: payload.Version})

--- a/agent-source-code/internal/system/reboot.go
+++ b/agent-source-code/internal/system/reboot.go
@@ -513,3 +513,54 @@ func (d *Detector) resolveMetaPackage(metaPkg string) string {
 
 	return ""
 }
+
+// ExecuteReboot schedules a system reboot. delayMinutes is clamped to [0, 60]
+// to bound the operator surprise window. delayMinutes=0 reboots immediately.
+// The shutdown command is fire-and-forget — we do not wait for it to complete
+// because the process gets killed by the reboot itself. The function returns
+// once shutdown has been scheduled (or returns the error from spawning it).
+//
+// On Linux/BSD it shells out to `shutdown -r +N` so that any running tty
+// users see the broadcast wall and the system passes through normal
+// signal-everyone -> stop-services -> reboot ordering. On Windows it uses
+// `shutdown /r /t <seconds>`.
+//
+// Reason is appended to the broadcast so logs/wall messages explain why the
+// host is rebooting. Empty reason falls back to a generic string.
+func (d *Detector) ExecuteReboot(delayMinutes int, reason string) error {
+	if delayMinutes < 0 {
+		delayMinutes = 0
+	}
+	if delayMinutes > 60 {
+		delayMinutes = 60
+	}
+	if strings.TrimSpace(reason) == "" {
+		reason = "Triggered by PatchMon"
+	}
+
+	if runtime.GOOS == "windows" {
+		// /r reboot, /t seconds, /c comment (max 512 chars; truncate defensively)
+		comment := reason
+		if len(comment) > 500 {
+			comment = comment[:500]
+		}
+		cmd := exec.Command("shutdown", "/r", "/t", strconv.Itoa(delayMinutes*60), "/c", comment)
+		if err := cmd.Start(); err != nil {
+			return fmt.Errorf("shutdown /r failed to start: %w", err)
+		}
+		d.logger.WithField("delay_minutes", delayMinutes).WithField("reason", logutil.Sanitize(reason)).Info("Reboot scheduled via shutdown /r")
+		return nil
+	}
+
+	// Linux/BSD: shutdown -r accepts "+N" minutes or "now".
+	timeArg := "+" + strconv.Itoa(delayMinutes)
+	if delayMinutes == 0 {
+		timeArg = "now"
+	}
+	cmd := exec.Command("shutdown", "-r", timeArg, reason)
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("shutdown -r %s failed to start: %w", timeArg, err)
+	}
+	d.logger.WithField("delay_minutes", delayMinutes).WithField("reason", logutil.Sanitize(reason)).Info("Reboot scheduled via shutdown -r")
+	return nil
+}

--- a/frontend/src/pages/Hosts.jsx
+++ b/frontend/src/pages/Hosts.jsx
@@ -25,6 +25,7 @@ import {
 	FolderPlus,
 	GripVertical,
 	Plus,
+	Power,
 	RefreshCw,
 	RotateCcw,
 	Search,
@@ -146,6 +147,7 @@ const Hosts = () => {
 	);
 	const [showBulkAssignModal, setShowBulkAssignModal] = useState(false);
 	const [showBulkDeleteModal, setShowBulkDeleteModal] = useState(false);
+	const [showBulkRebootModal, setShowBulkRebootModal] = useState(false);
 	const [bulkFetchReportMessage, setBulkFetchReportMessage] = useState({
 		text: "",
 		type: "success", // "success" or "error"
@@ -797,6 +799,35 @@ const Hosts = () => {
 		},
 	});
 
+	const bulkRebootMutation = useMutation({
+		mutationFn: (hostIds) =>
+			adminHostsAPI
+				.bulkRebootHosts(hostIds, { delayMinutes: 1 })
+				.then((res) => res.data),
+		onSuccess: (data) => {
+			queryClient.invalidateQueries(["hosts"]);
+			setShowBulkRebootModal(false);
+			setBulkFetchReportMessage({
+				text: data?.message || `Reboot queued for ${data?.queued || 0} host(s)`,
+				type: "success",
+			});
+			setTimeout(
+				() => setBulkFetchReportMessage({ text: "", type: "success" }),
+				5000,
+			);
+		},
+		onError: (error) => {
+			setBulkFetchReportMessage({
+				text: error.response?.data?.error || "Failed to queue reboots",
+				type: "error",
+			});
+			setTimeout(
+				() => setBulkFetchReportMessage({ text: "", type: "error" }),
+				5000,
+			);
+		},
+	});
+
 	const bulkFetchReportMutation = useMutation({
 		mutationFn: (hostIds) =>
 			adminHostsAPI.fetchReportBulk(hostIds).then((res) => res.data),
@@ -876,6 +907,18 @@ const Hosts = () => {
 	const handleBulkFetchReport = () => {
 		bulkFetchReportMutation.mutate(selectedHosts);
 	};
+
+	// Hosts in the current selection that the agent has flagged as needing a
+	// reboot. Bulk reboot only acts on these — we never reboot a host that
+	// didn't ask for it, even if the operator selected it by accident. The
+	// confirm modal surfaces this filtered count.
+	const selectedRebootCandidates = useMemo(() => {
+		if (!hosts || selectedHosts.length === 0) return [];
+		const selSet = new Set(selectedHosts);
+		return hosts.filter((h) => selSet.has(h.id) && h.needs_reboot === true);
+	}, [hosts, selectedHosts]);
+	const selectedRebootSkipped =
+		selectedHosts.length - selectedRebootCandidates.length;
 
 	// Resolve selected host IDs for filter=selected (from URL or state)
 	const selectedHostIdsForFilter = useMemo(() => {
@@ -1975,6 +2018,28 @@ const Hosts = () => {
 								</button>
 								<button
 									type="button"
+									onClick={() => setShowBulkRebootModal(true)}
+									disabled={selectedRebootCandidates.length === 0}
+									className="btn-outline flex items-center gap-1.5 sm:gap-2 px-3 sm:px-4 py-2 min-h-[44px] text-xs sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+									title={
+										selectedRebootCandidates.length === 0
+											? "No selected hosts are flagged as needing a reboot"
+											: selectedRebootSkipped > 0
+												? `Reboot ${selectedRebootCandidates.length} host${selectedRebootCandidates.length !== 1 ? "s" : ""} that need it (${selectedRebootSkipped} skipped — not flagged)`
+												: `Reboot ${selectedRebootCandidates.length} host${selectedRebootCandidates.length !== 1 ? "s" : ""} that need it`
+									}
+								>
+									<Power className="h-4 w-4 flex-shrink-0" />
+									<span className="hidden sm:inline">
+										Reboot
+										{selectedRebootCandidates.length > 0
+											? ` (${selectedRebootCandidates.length})`
+											: ""}
+									</span>
+									<span className="sm:hidden">Reboot</span>
+								</button>
+								<button
+									type="button"
 									onClick={() => setShowBulkAssignModal(true)}
 									className="btn-outline flex items-center gap-1.5 sm:gap-2 px-3 sm:px-4 py-2 min-h-[44px] text-xs sm:text-sm"
 								>
@@ -2729,6 +2794,70 @@ const Hosts = () => {
 					onDelete={handleBulkDelete}
 					isLoading={bulkDeleteMutation.isPending}
 				/>
+			)}
+
+			{/* Bulk Reboot Confirm Modal */}
+			{showBulkRebootModal && (
+				<div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+					<div className="bg-white dark:bg-secondary-800 rounded-lg shadow-xl max-w-md w-full mx-4 overflow-hidden">
+						<div className="p-6">
+							<div className="flex items-start gap-4">
+								<div className="flex-shrink-0 w-10 h-10 rounded-full bg-orange-100 dark:bg-orange-900/30 flex items-center justify-center">
+									<Power className="h-5 w-5 text-orange-600 dark:text-orange-400" />
+								</div>
+								<div className="flex-1">
+									<h3 className="text-lg font-semibold text-secondary-900 dark:text-white mb-2">
+										Reboot {selectedRebootCandidates.length} host
+										{selectedRebootCandidates.length !== 1 ? "s" : ""}?
+									</h3>
+									<p className="text-sm text-secondary-600 dark:text-white/80 mb-3">
+										Each agent will run <code>shutdown -r +1</code> (one minute
+										warning). The hosts will be unreachable for a few minutes.
+										Only hosts flagged as needing a reboot are included.
+									</p>
+									{selectedRebootSkipped > 0 && (
+										<p className="text-xs text-amber-600 dark:text-amber-400 mb-3">
+											{selectedRebootSkipped} selected host
+											{selectedRebootSkipped !== 1 ? "s" : ""} not flagged as
+											needing reboot, will be skipped.
+										</p>
+									)}
+									<div className="max-h-40 overflow-y-auto text-xs font-mono text-secondary-700 dark:text-white/70 border border-secondary-200 dark:border-secondary-600 rounded p-2 mb-4">
+										{selectedRebootCandidates.map((h) => (
+											<div key={h.id}>
+												{h.friendly_name || h.hostname || h.id}
+											</div>
+										))}
+									</div>
+								</div>
+							</div>
+							<div className="flex justify-end gap-2">
+								<button
+									type="button"
+									onClick={() => setShowBulkRebootModal(false)}
+									disabled={bulkRebootMutation.isPending}
+									className="btn-outline px-4 py-2"
+								>
+									Cancel
+								</button>
+								<button
+									type="button"
+									onClick={() =>
+										bulkRebootMutation.mutate(
+											selectedRebootCandidates.map((h) => h.id),
+										)
+									}
+									disabled={bulkRebootMutation.isPending}
+									className="btn-danger px-4 py-2"
+								>
+									{bulkRebootMutation.isPending
+										? "Queueing..."
+										: `Reboot ${selectedRebootCandidates.length}`}
+								</button>
+							</div>
+						</div>
+					</div>
+				</div>
 			)}
 
 			{/* Column Settings Modal */}

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -193,6 +193,17 @@ export const adminHostsAPI = {
 			host_down_alerts_enabled: enabled,
 		}),
 	forceAgentUpdate: (hostId) => api.post(`/hosts/${hostId}/force-agent-update`),
+	rebootHost: (hostId, opts = {}) =>
+		api.post(`/hosts/${hostId}/reboot`, {
+			delay_minutes: opts.delayMinutes,
+			reason: opts.reason,
+		}),
+	bulkRebootHosts: (hostIds, opts = {}) =>
+		api.post("/hosts/bulk/reboot", {
+			hostIds,
+			delay_minutes: opts.delayMinutes,
+			reason: opts.reason,
+		}),
 	refreshIntegrationStatus: (hostId) =>
 		api.post(`/hosts/${hostId}/refresh-integration-status`),
 	fetchReport: (hostId) => api.post(`/hosts/${hostId}/fetch-report`),

--- a/server-source-code/internal/handler/hosts.go
+++ b/server-source-code/internal/handler/hosts.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/PatchMon/PatchMon/server-source-code/internal/agentregistry"
@@ -670,6 +671,124 @@ func (h *HostsHandler) RefreshDocker(w http.ResponseWriter, r *http.Request) {
 			"friendlyName": host.FriendlyName,
 			"apiId":        host.ApiID,
 		},
+	})
+}
+
+// RebootHost handles POST /hosts/:hostId/reboot.
+// Body: { delay_minutes?: int (default 1), reason?: string }
+func (h *HostsHandler) RebootHost(w http.ResponseWriter, r *http.Request) {
+	if h.queueClient == nil {
+		Error(w, http.StatusServiceUnavailable, "Queue service unavailable")
+		return
+	}
+	hostID := chi.URLParam(r, "hostId")
+	var body struct {
+		DelayMinutes *int   `json:"delay_minutes"`
+		Reason       string `json:"reason"`
+	}
+	_ = decodeJSON(r, &body) // body is optional
+	delay := 1
+	if body.DelayMinutes != nil {
+		delay = *body.DelayMinutes
+	}
+	if delay < 0 {
+		delay = 0
+	}
+	if delay > 60 {
+		delay = 60
+	}
+	reason := body.Reason
+	if reason == "" {
+		reason = "Triggered by PatchMon operator"
+	}
+	host, err := h.hosts.GetByID(r.Context(), hostID)
+	if err != nil || host == nil {
+		Error(w, http.StatusNotFound, "Host not found")
+		return
+	}
+	task, err := queue.NewRebootHostTask(host.ApiID, hostFromRequest(r), delay, reason)
+	if err != nil {
+		Error(w, http.StatusInternalServerError, "Failed to create reboot task")
+		return
+	}
+	info, err := h.queueClient.Enqueue(task)
+	if err != nil {
+		Error(w, http.StatusInternalServerError, "Failed to queue reboot")
+		return
+	}
+	JSON(w, http.StatusOK, map[string]interface{}{
+		"success":      true,
+		"message":      "Reboot queued",
+		"jobId":        info.ID,
+		"delayMinutes": delay,
+		"host": map[string]interface{}{
+			"id":           host.ID,
+			"friendlyName": host.FriendlyName,
+			"apiId":        host.ApiID,
+		},
+	})
+}
+
+// BulkRebootHosts handles POST /hosts/bulk/reboot.
+// Body: { hostIds: [...], delay_minutes?: int, reason?: string }
+func (h *HostsHandler) BulkRebootHosts(w http.ResponseWriter, r *http.Request) {
+	if h.queueClient == nil {
+		Error(w, http.StatusServiceUnavailable, "Queue service unavailable")
+		return
+	}
+	var body struct {
+		HostIds      []string `json:"hostIds"`
+		DelayMinutes *int     `json:"delay_minutes"`
+		Reason       string   `json:"reason"`
+	}
+	if err := decodeJSON(r, &body); err != nil {
+		Error(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+	if len(body.HostIds) == 0 {
+		Error(w, http.StatusBadRequest, "At least one host ID is required")
+		return
+	}
+	delay := 1
+	if body.DelayMinutes != nil {
+		delay = *body.DelayMinutes
+	}
+	if delay < 0 {
+		delay = 0
+	}
+	if delay > 60 {
+		delay = 60
+	}
+	reason := body.Reason
+	if reason == "" {
+		reason = "Triggered by PatchMon operator (bulk)"
+	}
+
+	hostHeader := hostFromRequest(r)
+	queued := 0
+	failures := []map[string]string{}
+	for _, id := range body.HostIds {
+		host, err := h.hosts.GetByID(r.Context(), id)
+		if err != nil || host == nil {
+			failures = append(failures, map[string]string{"hostId": id, "reason": "not_found"})
+			continue
+		}
+		task, err := queue.NewRebootHostTask(host.ApiID, hostHeader, delay, reason)
+		if err != nil {
+			failures = append(failures, map[string]string{"hostId": id, "reason": "task_create_failed"})
+			continue
+		}
+		if _, err := h.queueClient.Enqueue(task); err != nil {
+			failures = append(failures, map[string]string{"hostId": id, "reason": "enqueue_failed"})
+			continue
+		}
+		queued++
+	}
+	JSON(w, http.StatusOK, map[string]interface{}{
+		"message":      "Reboot queued for " + strconv.Itoa(queued) + " of " + strconv.Itoa(len(body.HostIds)) + " host(s)",
+		"queued":       queued,
+		"delayMinutes": delay,
+		"failures":     failures,
 	})
 }
 

--- a/server-source-code/internal/migrate/migrations/000042_v2-0-3_patch_policies_auto_reboot.down.sql
+++ b/server-source-code/internal/migrate/migrations/000042_v2-0-3_patch_policies_auto_reboot.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE patch_policies DROP COLUMN IF EXISTS auto_reboot;

--- a/server-source-code/internal/migrate/migrations/000042_v2-0-3_patch_policies_auto_reboot.up.sql
+++ b/server-source-code/internal/migrate/migrations/000042_v2-0-3_patch_policies_auto_reboot.up.sql
@@ -1,0 +1,12 @@
+-- 000042: reserved column for future policy-level auto_reboot toggle.
+--
+-- The column is added now so the schema is forward-compatible with the
+-- planned policy-driven reboot flow, even though this release ships the
+-- simpler on-demand reboot path (POST /hosts/:id/reboot,
+-- POST /hosts/bulk/reboot) that doesn't read this flag yet.
+--
+-- Keeping the migration in tree means a deploy that already applied this
+-- column (during the on-demand reboot feature development) doesn't end up
+-- with a schema version ahead of the migration set on subsequent rebuilds.
+
+ALTER TABLE patch_policies ADD COLUMN IF NOT EXISTS auto_reboot BOOLEAN NOT NULL DEFAULT false;

--- a/server-source-code/internal/queue/jobs.go
+++ b/server-source-code/internal/queue/jobs.go
@@ -22,6 +22,7 @@ const (
 	TypeRefreshIntegrationStatus = "refresh_integration_status"
 	TypeDockerInventoryRefresh   = "docker_inventory_refresh"
 	TypeUpdateAgent              = "update_agent"
+	TypeRebootHost               = "reboot_host"
 	TypeSessionCleanup           = "session-cleanup"
 	TypeOrphanedRepoCleanup      = "orphaned-repo-cleanup"
 	TypeOrphanedPkgCleanup       = "orphaned-package-cleanup"
@@ -253,6 +254,30 @@ func NewUpdateAgentTask(apiID, host string, bypassSettings bool) (*asynq.Task, e
 		return nil, err
 	}
 	return asynq.NewTask(TypeUpdateAgent, payload, asynq.Queue(QueueAgentCommands), asynq.MaxRetry(3)), nil
+}
+
+// RebootHostPayload is the payload for the reboot_host job.
+type RebootHostPayload struct {
+	ApiID        string `json:"api_id"`
+	Host         string `json:"host,omitempty"`
+	DelayMinutes int    `json:"delay_minutes"`
+	Reason       string `json:"reason,omitempty"`
+}
+
+// NewRebootHostTask creates a reboot_host task. MaxRetry is intentionally
+// low: rebooting a host that has come back online from a stale queued task
+// would be a nasty surprise, so we'd rather drop than retry.
+func NewRebootHostTask(apiID, host string, delayMinutes int, reason string) (*asynq.Task, error) {
+	payload, err := json.Marshal(RebootHostPayload{
+		ApiID:        apiID,
+		Host:         host,
+		DelayMinutes: delayMinutes,
+		Reason:       reason,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return asynq.NewTask(TypeRebootHost, payload, asynq.Queue(QueueAgentCommands), asynq.MaxRetry(1)), nil
 }
 
 // AutomationRetention keeps completed automation tasks in Redis for 7 days for dashboard visibility.
@@ -649,6 +674,82 @@ func (h *UpdateAgentHandler) ProcessTask(ctx context.Context, t *asynq.Task) err
 		_ = d.Queries.UpdateJobHistoryCompleted(ctx, taskID)
 	}
 	h.log.Info("update_agent sent", "api_id", p.ApiID)
+	return nil
+}
+
+// RebootHostHandler handles reboot_host jobs.
+type RebootHostHandler struct {
+	registry *agentregistry.Registry
+	db       *database.DB
+	log      *slog.Logger
+}
+
+// NewRebootHostHandler creates a reboot_host handler.
+func NewRebootHostHandler(registry *agentregistry.Registry, db *database.DB, log *slog.Logger) *RebootHostHandler {
+	return &RebootHostHandler{registry: registry, db: db, log: log}
+}
+
+// ProcessTask implements asynq.Handler.
+func (h *RebootHostHandler) ProcessTask(ctx context.Context, t *asynq.Task) error {
+	var p RebootHostPayload
+	if err := json.Unmarshal(t.Payload(), &p); err != nil {
+		return err
+	}
+
+	taskID, _ := asynq.GetTaskID(ctx)
+	retryCount, _ := asynq.GetRetryCount(ctx)
+	attempt := int32(retryCount + 1)
+
+	if h.db != nil && taskID != "" && retryCount == 0 {
+		host, err := h.db.Queries.GetHostByApiID(ctx, p.ApiID)
+		var hostID *string
+		if err == nil {
+			hostID = &host.ID
+		}
+		apiIDPtr := &p.ApiID
+		_ = h.db.Queries.InsertJobHistory(ctx, db.InsertJobHistoryParams{
+			ID:            uuid.New().String(),
+			JobID:         taskID,
+			QueueName:     QueueAgentCommands,
+			JobName:       TypeRebootHost,
+			HostID:        hostID,
+			ApiID:         apiIDPtr,
+			Status:        "active",
+			AttemptNumber: attempt,
+		})
+	}
+
+	if !h.registry.IsConnected(p.ApiID) {
+		h.log.Warn("reboot_host: agent not connected", "api_id", p.ApiID)
+		if taskID != "" && h.db != nil {
+			msg := "Agent not connected"
+			_ = h.db.Queries.UpdateJobHistoryFailed(ctx, db.UpdateJobHistoryFailedParams{JobID: taskID, ErrorMessage: &msg})
+		}
+		// Drop (don't retry): a queued reboot that fires later on a fresh
+		// session would be unexpected.
+		return nil
+	}
+
+	wsMsg := map[string]interface{}{
+		"type":                 "reboot_host",
+		"reboot_delay_minutes": p.DelayMinutes,
+	}
+	if p.Reason != "" {
+		wsMsg["reboot_reason"] = p.Reason
+	}
+	msg, err := json.Marshal(wsMsg)
+	if err != nil {
+		return err
+	}
+	if err := h.registry.SendMessage(p.ApiID, websocket.TextMessage, msg); err != nil {
+		h.log.Warn("reboot_host: write failed", "api_id", p.ApiID, "error", err)
+		return err
+	}
+
+	if taskID != "" && h.db != nil {
+		_ = h.db.Queries.UpdateJobHistoryCompleted(ctx, taskID)
+	}
+	h.log.Info("reboot_host sent", "api_id", p.ApiID, "delay_minutes", p.DelayMinutes)
 	return nil
 }
 

--- a/server-source-code/internal/queue/server.go
+++ b/server-source-code/internal/queue/server.go
@@ -112,6 +112,7 @@ func Mux(opts MuxOpts) *asynq.ServeMux {
 	mux.Handle(TypeRefreshIntegrationStatus, wrap(TypeRefreshIntegrationStatus, NewRefreshIntegrationStatusHandler(registry, db, opts.PoolCache, log)))
 	mux.Handle(TypeDockerInventoryRefresh, wrap(TypeDockerInventoryRefresh, NewDockerInventoryRefreshHandler(registry, db, opts.PoolCache, log)))
 	mux.Handle(TypeUpdateAgent, wrap(TypeUpdateAgent, NewUpdateAgentHandler(registry, db, opts.PoolCache, log)))
+	mux.Handle(TypeRebootHost, wrap(TypeRebootHost, NewRebootHostHandler(registry, db, log)))
 	dbResolver := &hostctx.DBResolver{Default: db}
 	mux.Handle(TypeHostStatusMonitor, wrap(TypeHostStatusMonitor, NewHostStatusMonitorHandler(db, opts.PoolCache, registry, opts.Emit, log)))
 	mux.Handle(TypeUpdateThresholdMonitor, wrap(TypeUpdateThresholdMonitor, NewUpdateThresholdMonitorHandler(db, opts.PoolCache, opts.Emit, log)))

--- a/server-source-code/internal/server/router.go
+++ b/server-source-code/internal/server/router.go
@@ -556,6 +556,8 @@ func NewRouter(ctx context.Context, cfg *config.Config, db *database.DB, rdb *re
 			r.With(middleware.RequirePermission("can_manage_hosts", permissionsStore)).Post("/hosts/{hostId}/refresh-integration-status", hostsHandler.RefreshIntegrationStatus)
 			r.With(middleware.RequirePermission("can_manage_hosts", permissionsStore)).Post("/hosts/{hostId}/refresh-docker", hostsHandler.RefreshDocker)
 			r.With(middleware.RequirePermission("can_manage_hosts", permissionsStore)).Post("/hosts/{hostId}/force-agent-update", hostsHandler.ForceAgentUpdate)
+			r.With(middleware.RequirePermission("can_manage_hosts", permissionsStore)).Post("/hosts/{hostId}/reboot", hostsHandler.RebootHost)
+			r.With(middleware.RequirePermission("can_manage_hosts", permissionsStore)).Post("/hosts/bulk/reboot", hostsHandler.BulkRebootHosts)
 			r.With(middleware.RequirePermission("can_manage_hosts", permissionsStore)).Delete("/hosts/{hostId}", hostsHandler.Delete)
 			r.With(middleware.RequirePermission("can_manage_hosts", permissionsStore)).Delete("/hosts/bulk", hostsHandler.BulkDelete)
 			r.With(middleware.RequirePermission("can_view_packages", permissionsStore)).Get("/packages/categories/list", packagesHandler.GetCategories)


### PR DESCRIPTION
Closes #828
Addresses part of #838

## What

Adds a way to reboot hosts on demand from the PatchMon UI — the recurring "how do I reboot remotely?" request. Primary use case: a batch of VMs was patched and is sitting with `needs-restarting -r` / `/var/run/reboot-required` set, but nobody has gone around rebooting them.

## Surfaces

- `POST /hosts/:id/reboot` — `{ delay_minutes?: int (default 1), reason?: string }`
- `POST /hosts/bulk/reboot` — `{ hostIds: [], delay_minutes?, reason? }`
- **Hosts page** bulk action bar: a **Reboot (N)** button. It only counts hosts the agent flagged `needs_reboot=true`, and the confirm modal lists them by name so the operator can sanity-check. A bulk action that silently included hosts that hadn't asked for a reboot would be too easy to fire by accident.

## Mechanics

`delay_minutes` is clamped to `[0, 60]` on both the server (handler) and agent (`system.ExecuteReboot`). Default 1 minute so logged-in tty users get the `shutdown -r +1` broadcast wall before the box goes down. Agent gains a `reboot_host` WebSocket message; the asynq task uses `MaxRetry(1)` deliberately — re-running a queued reboot on a host that just came back online would be a nasty surprise.

`shutdown -r +N` on Linux/BSD, `shutdown /r /t` on Windows.

No DB migration — pure queue + WS message flow.

> Note: depends on the agent self-update fix (#852) to be reliable in practice — without it the agent can restart mid-flow before the reboot is scheduled.