### PR TITLE
fix(notifications): wrap SMTP email bodies

### DIFF
--- a/server-source-code/internal/queue/email_message_test.go
+++ b/server-source-code/internal/queue/email_message_test.go
@@ -1,0 +1,51 @@
+package queue
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildEmailMessageWrapsLongHTMLLines(t *testing.T) {
+	html := "<html><body><p>" + strings.Repeat("a", 2500) + "</p></body></html>"
+
+	msg := string(buildEmailMessage(
+		"patchmon@example.com",
+		"ops@example.com",
+		"Compliance scan completed",
+		html,
+	))
+
+	if !strings.Contains(msg, "Content-Transfer-Encoding: quoted-printable\r\n") {
+		t.Fatal("expected quoted-printable transfer encoding")
+	}
+	if !strings.Contains(msg, "=\r\n") {
+		t.Fatal("expected quoted-printable soft line breaks")
+	}
+	assertSMTPLineLengths(t, msg)
+}
+
+func TestBuildEmailMessageFoldsAndSanitizesSubject(t *testing.T) {
+	msg := string(buildEmailMessage(
+		"patchmon@example.com",
+		"ops@example.com",
+		"[ERROR] "+strings.Repeat("very-long-hostname ", 20)+"\r\nBcc: injected@example.com",
+		"<html><body>short body</body></html>",
+	))
+
+	if strings.Contains(msg, "\r\nBcc:") {
+		t.Fatal("subject newline created an injected Bcc header")
+	}
+	if strings.Count(msg, "\r\n\t") == 0 {
+		t.Fatal("expected long subject to be folded onto continuation lines")
+	}
+	assertSMTPLineLengths(t, msg)
+}
+
+func assertSMTPLineLengths(t *testing.T, msg string) {
+	t.Helper()
+	for i, line := range strings.Split(msg, "\r\n") {
+		if len(line) > 998 {
+			t.Fatalf("SMTP line %d is %d octets, want <= 998", i+1, len(line))
+		}
+	}
+}

--- a/server-source-code/internal/queue/notification_worker.go
+++ b/server-source-code/internal/queue/notification_worker.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"mime/quotedprintable"
 	"net"
 	"net/http"
 	"net/smtp"
@@ -605,6 +606,106 @@ type emailConfig struct {
 	UseTLS   bool   `json:"use_tls"`
 }
 
+const emailRecommendedLineLength = 78
+
+func buildEmailMessage(from, to, subject, html string) []byte {
+	var msg strings.Builder
+	writeEmailHeader(&msg, "From", from)
+	writeEmailHeader(&msg, "To", to)
+	msg.WriteString(foldEmailHeader("Subject", subject))
+	msg.WriteString("MIME-Version: 1.0\r\n")
+	msg.WriteString("Content-Type: text/html; charset=utf-8\r\n")
+	msg.WriteString("Content-Transfer-Encoding: quoted-printable\r\n")
+	msg.WriteString("\r\n")
+
+	qp := quotedprintable.NewWriter(&msg)
+	_, _ = qp.Write([]byte(html))
+	_ = qp.Close()
+
+	return []byte(msg.String())
+}
+
+func writeEmailHeader(msg *strings.Builder, name, value string) {
+	msg.WriteString(name)
+	msg.WriteString(": ")
+	msg.WriteString(sanitizeEmailHeaderValue(value))
+	msg.WriteString("\r\n")
+}
+
+func foldEmailHeader(name, value string) string {
+	value = sanitizeEmailHeaderValue(value)
+	prefix := name + ": "
+	if value == "" {
+		return prefix + "\r\n"
+	}
+
+	var out strings.Builder
+	remaining := value
+	for linePrefix := prefix; remaining != ""; linePrefix = "\t" {
+		maxValueLength := emailRecommendedLineLength - len(linePrefix)
+		if maxValueLength < 1 {
+			maxValueLength = 1
+		}
+		if len(linePrefix)+len(remaining) <= emailRecommendedLineLength {
+			out.WriteString(linePrefix)
+			out.WriteString(remaining)
+			out.WriteString("\r\n")
+			break
+		}
+
+		cut := headerFoldIndex(remaining, maxValueLength)
+		out.WriteString(linePrefix)
+		out.WriteString(strings.TrimRight(remaining[:cut], " \t"))
+		out.WriteString("\r\n")
+		remaining = strings.TrimLeft(remaining[cut:], " \t")
+	}
+
+	return out.String()
+}
+
+func sanitizeEmailHeaderValue(value string) string {
+	value = strings.NewReplacer("\r", " ", "\n", " ").Replace(value)
+	return strings.Join(strings.Fields(value), " ")
+}
+
+func headerFoldIndex(value string, maxBytes int) int {
+	if len(value) <= maxBytes {
+		return len(value)
+	}
+	bestSpace := -1
+	for i, r := range value {
+		if i > maxBytes {
+			break
+		}
+		if r == ' ' || r == '\t' {
+			bestSpace = i
+		}
+	}
+	if bestSpace > 0 {
+		return bestSpace
+	}
+	return utf8SafeCut(value, maxBytes)
+}
+
+func utf8SafeCut(value string, maxBytes int) int {
+	if maxBytes <= 0 {
+		_, size := utf8.DecodeRuneInString(value)
+		return size
+	}
+	cut := 0
+	for i := range value {
+		if i > maxBytes {
+			break
+		}
+		cut = i
+	}
+	if cut > 0 {
+		return cut
+	}
+	_, size := utf8.DecodeRuneInString(value)
+	return size
+}
+
 func (h *NotificationDeliverHandler) sendWebhook(ctx context.Context, plain string, p notifications.NotificationDeliverPayload) error {
 	var cfg webhookConfig
 	if err := json.Unmarshal([]byte(plain), &cfg); err != nil {
@@ -756,11 +857,8 @@ func (h *NotificationDeliverHandler) sendEmail(ctx context.Context, plain string
 		cfg.SMTPPort = 587
 	}
 	subject := fmt.Sprintf("[%s] %s", strings.ToUpper(p.Severity), p.Title)
-	// Sanitize subject to prevent SMTP header injection via \r\n in host names / alert titles.
-	subject = strings.NewReplacer("\r", "", "\n", "").Replace(subject)
 	html := buildEmailHTML(p)
-	msg := []byte(fmt.Sprintf("From: %s\r\nTo: %s\r\nSubject: %s\r\nMIME-Version: 1.0\r\nContent-Type: text/html; charset=utf-8\r\n\r\n%s",
-		cfg.From, cfg.To, subject, html))
+	msg := buildEmailMessage(cfg.From, cfg.To, subject, html)
 	addr := cfg.SMTPHost + ":" + strconv.Itoa(cfg.SMTPPort)
 	var auth smtp.Auth
 	if cfg.Username != "" {

--- a/server-source-code/internal/queue/scheduled_report_worker.go
+++ b/server-source-code/internal/queue/scheduled_report_worker.go
@@ -374,10 +374,7 @@ func sendScheduledEmail(plain, subject, html, csv string) error {
 	if cfg.SMTPPort == 0 {
 		cfg.SMTPPort = 587
 	}
-	// Sanitize subject to prevent SMTP header injection.
-	subject = strings.NewReplacer("\r", "", "\n", "").Replace(subject)
-	msg := []byte(fmt.Sprintf("From: %s\r\nTo: %s\r\nSubject: %s\r\nMIME-Version: 1.0\r\nContent-Type: text/html; charset=utf-8\r\n\r\n%s",
-		cfg.From, cfg.To, subject, html))
+	msg := buildEmailMessage(cfg.From, cfg.To, subject, html)
 	addr := cfg.SMTPHost + ":" + strconv.Itoa(cfg.SMTPPort)
 	var auth smtp.Auth
 	if cfg.Username != "" {


### PR DESCRIPTION
## What changed

This fixes long SMTP message lines in notification emails by encoding HTML bodies as quoted-printable before sending.

The notification worker and scheduled report worker now use a shared message builder that:

- emits quoted-printable HTML bodies
- folds long Subject headers
- strips CR/LF from address headers
- keeps email line lengths inside SMTP limits

Fixes #845.

## Why

Some generated HTML notifications can produce lines longer than SMTP allows. A few mail providers tolerate that, but others reject or mangle the message. Quoted-printable is a standard way to keep the rendered HTML intact while making the wire format safe for SMTP.

## Validation

Ran from `server-source-code`:

```bash
go test ./internal/queue
make check
```

`make check` covered format check, vet, golangci-lint, and tests.
