### PR TITLE
fix(compliance): reject scans when scanner is unavailable

### DIFF
--- a/server-source-code/internal/handler/compliance.go
+++ b/server-source-code/internal/handler/compliance.go
@@ -966,6 +966,10 @@ func (h *ComplianceHandler) TriggerScan(w http.ResponseWriter, r *http.Request) 
 	if req.ProfileType != "" {
 		profileType = req.ProfileType
 	}
+	if err := queue.ValidateComplianceScanReadiness([]byte(host.ComplianceScannerStatus), profileType, req.ProfileID, host.ComplianceOpenscapEnabled, host.ComplianceDockerBenchEnabled); err != nil {
+		Error(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	if h.integrationStatus != nil {
 		_ = h.integrationStatus.ClearComplianceScanCancel(r.Context(), hostID)
 	}
@@ -1014,33 +1018,60 @@ func (h *ComplianceHandler) TriggerBulkScan(w http.ResponseWriter, r *http.Reque
 		hostByID[hosts[i].ID] = &hosts[i]
 	}
 	enqueued := 0
+	skipped := 0
+	skipErrors := make([]map[string]string, 0)
 	for _, hostID := range req.HostIDs {
 		host := hostByID[hostID]
 		if host == nil {
+			skipped++
+			continue
+		}
+		if !host.ComplianceEnabled {
+			skipped++
+			skipErrors = append(skipErrors, map[string]string{
+				"hostId": hostID,
+				"error":  "Compliance scanning is disabled for this host",
+			})
+			continue
+		}
+		if err := queue.ValidateComplianceScanReadiness([]byte(host.ComplianceScannerStatus), "all", nil, host.ComplianceOpenscapEnabled, host.ComplianceDockerBenchEnabled); err != nil {
+			skipped++
+			skipErrors = append(skipErrors, map[string]string{
+				"hostId": hostID,
+				"error":  err.Error(),
+			})
 			continue
 		}
 		if h.integrationStatus != nil {
 			_ = h.integrationStatus.ClearComplianceScanCancel(r.Context(), hostID)
 		}
 		if h.queueClient == nil {
+			skipped++
 			continue
 		}
 		task, err := queue.NewRunScanTask(queue.RunScanPayload{
 			HostID: hostID, ApiID: host.ApiID, Host: hostFromRequest(r), ProfileType: "all",
 		})
 		if err != nil {
+			skipped++
 			continue
 		}
 		if _, err := h.queueClient.Enqueue(task); err != nil {
+			skipped++
 			continue
 		}
 		enqueued++
 	}
-	JSON(w, http.StatusOK, map[string]interface{}{
+	resp := map[string]interface{}{
 		"success":  true,
 		"message":  "Bulk scan triggered",
 		"enqueued": enqueued,
-	})
+		"skipped":  skipped,
+	}
+	if len(skipErrors) > 0 {
+		resp["errors"] = skipErrors
+	}
+	JSON(w, http.StatusOK, resp)
 }
 
 // CancelScan handles POST /compliance/cancel/:hostId.

--- a/server-source-code/internal/queue/compliance_readiness_test.go
+++ b/server-source-code/internal/queue/compliance_readiness_test.go
@@ -1,0 +1,71 @@
+package queue
+
+import "testing"
+
+func TestValidateComplianceScanReadinessBlocksFailedOpenSCAP(t *testing.T) {
+	status := []byte(`{"components":{"openscap":"failed","docker-bench":"ready"}}`)
+
+	err := ValidateComplianceScanReadiness(status, "openscap", nil, true, true)
+
+	if err == nil {
+		t.Fatal("expected failed OpenSCAP scanner to block the scan")
+	}
+	if err.Error() != "OpenSCAP scanner is failed" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateComplianceScanReadinessAllowsReadyDockerBenchWhenOpenSCAPFailed(t *testing.T) {
+	status := []byte(`{"components":{"openscap":"failed","docker-bench":"ready"}}`)
+
+	err := ValidateComplianceScanReadiness(status, "docker-bench", nil, true, true)
+
+	if err != nil {
+		t.Fatalf("expected Docker Bench scan to be allowed: %v", err)
+	}
+}
+
+func TestValidateComplianceScanReadinessBlocksDefaultScanWhenEnabledScannerFailed(t *testing.T) {
+	status := []byte(`{"components":{"openscap":"failed","docker-bench":"unavailable"}}`)
+
+	err := ValidateComplianceScanReadiness(status, "all", nil, true, false)
+
+	if err == nil {
+		t.Fatal("expected failed enabled scanner to block default scan")
+	}
+	if err.Error() != "OpenSCAP scanner is failed" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateComplianceScanReadinessAllowsUnknownStatusForOlderAgents(t *testing.T) {
+	err := ValidateComplianceScanReadiness(nil, "openscap", nil, true, false)
+
+	if err != nil {
+		t.Fatalf("expected missing scanner status to be allowed: %v", err)
+	}
+}
+
+func TestValidateComplianceScanReadinessBlocksDisabledExplicitScanner(t *testing.T) {
+	err := ValidateComplianceScanReadiness(nil, "docker-bench", nil, true, false)
+
+	if err == nil {
+		t.Fatal("expected disabled Docker Bench scanner to block explicit scan")
+	}
+	if err.Error() != "docker-bench scanner is disabled for this host" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateComplianceScanReadinessUsesScannerInfoWhenComponentsMissing(t *testing.T) {
+	status := []byte(`{"scanner_info":{"openscap_available":false}}`)
+
+	err := ValidateComplianceScanReadiness(status, "openscap", nil, true, false)
+
+	if err == nil {
+		t.Fatal("expected unavailable OpenSCAP scanner to block the scan")
+	}
+	if err.Error() != "OpenSCAP scanner is unavailable" {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/server-source-code/internal/queue/compliance_workers.go
+++ b/server-source-code/internal/queue/compliance_workers.go
@@ -3,7 +3,9 @@ package queue
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/PatchMon/PatchMon/server-source-code/internal/agentregistry"
@@ -27,6 +29,118 @@ const (
 	// decommissioned or permanently unreachable agents.
 	maxScanRequeueAttempts = 30 // ~30 minutes at 1-minute intervals
 )
+
+type complianceScannerStatusPayload struct {
+	Components  map[string]string `json:"components"`
+	ScannerInfo struct {
+		OpenSCAPAvailable    *bool `json:"openscap_available"`
+		DockerBenchAvailable *bool `json:"docker_bench_available"`
+	} `json:"scanner_info"`
+}
+
+// ValidateComplianceScanReadiness checks scanner state the agent has already reported.
+// Unknown or absent scanner status is allowed so older agents are not blocked.
+func ValidateComplianceScanReadiness(scannerStatus []byte, profileType string, profileID *string, openscapEnabled, dockerBenchEnabled bool) error {
+	requested := requestedComplianceScanners(profileType, profileID)
+	if len(requested) == 0 {
+		if openscapEnabled {
+			requested = append(requested, "openscap")
+		}
+		if dockerBenchEnabled {
+			requested = append(requested, "docker-bench")
+		}
+		if len(requested) == 0 {
+			return fmt.Errorf("no compliance scanners are enabled for this host")
+		}
+	}
+
+	for _, scanner := range requested {
+		switch scanner {
+		case "openscap":
+			if !openscapEnabled {
+				return fmt.Errorf("OpenSCAP scanner is disabled for this host")
+			}
+		case "docker-bench":
+			if !dockerBenchEnabled {
+				return fmt.Errorf("docker-bench scanner is disabled for this host")
+			}
+		}
+	}
+
+	status, ok := parseComplianceScannerStatus(scannerStatus)
+	if !ok {
+		return nil
+	}
+	for _, scanner := range requested {
+		if componentStatus, blocked := blockedScannerStatus(status, scanner); blocked {
+			return fmt.Errorf("%s scanner is %s", scannerDisplayName(scanner), componentStatus)
+		}
+	}
+	return nil
+}
+
+func requestedComplianceScanners(profileType string, profileID *string) []string {
+	if profileID != nil && strings.TrimSpace(*profileID) == "docker-bench" {
+		return []string{"docker-bench"}
+	}
+
+	switch strings.TrimSpace(profileType) {
+	case "openscap":
+		return []string{"openscap"}
+	case "docker-bench":
+		return []string{"docker-bench"}
+	case "", "all":
+		return nil
+	default:
+		return []string{"openscap"}
+	}
+}
+
+func parseComplianceScannerStatus(raw []byte) (complianceScannerStatusPayload, bool) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return complianceScannerStatusPayload{}, false
+	}
+	var status complianceScannerStatusPayload
+	if err := json.Unmarshal(raw, &status); err != nil {
+		return complianceScannerStatusPayload{}, false
+	}
+	return status, true
+}
+
+func blockedScannerStatus(status complianceScannerStatusPayload, scanner string) (string, bool) {
+	if status.Components != nil {
+		if value, ok := status.Components[scanner]; ok {
+			normalized := strings.ToLower(strings.TrimSpace(value))
+			if normalized != "" && normalized != "ready" {
+				return normalized, true
+			}
+			return "", false
+		}
+	}
+
+	switch scanner {
+	case "openscap":
+		if status.ScannerInfo.OpenSCAPAvailable != nil && !*status.ScannerInfo.OpenSCAPAvailable {
+			return "unavailable", true
+		}
+	case "docker-bench":
+		if status.ScannerInfo.DockerBenchAvailable != nil && !*status.ScannerInfo.DockerBenchAvailable {
+			return "unavailable", true
+		}
+	}
+	return "", false
+}
+
+func scannerDisplayName(scanner string) string {
+	switch scanner {
+	case "openscap":
+		return "OpenSCAP"
+	case "docker-bench":
+		return "Docker Bench"
+	default:
+		return scanner
+	}
+}
 
 // RunScanHandler handles run_scan jobs.
 type RunScanHandler struct {
@@ -154,6 +268,19 @@ func (h *RunScanHandler) ProcessTask(ctx context.Context, t *asynq.Task) error {
 			return nil
 		} else {
 			effectiveProfileType = "all"
+		}
+	}
+
+	if err == nil {
+		if readinessErr := ValidateComplianceScanReadiness(host.ComplianceScannerStatus, effectiveProfileType, p.ProfileID, openscapEnabled, dockerBenchEnabled); readinessErr != nil {
+			h.log.Warn("run_scan: scanner not ready", "host_id", p.HostID, "error", readinessErr)
+			if taskID != "" && d != nil {
+				msg := readinessErr.Error()
+				_ = d.Queries.UpdateJobHistoryFailed(ctx, db.UpdateJobHistoryFailedParams{
+					JobID: taskID, ErrorMessage: &msg,
+				})
+			}
+			return nil
 		}
 	}
 


### PR DESCRIPTION
## What changed

This adds a server-side readiness check before compliance scans are queued or sent to an agent.

The check uses the agent-reported `compliance_scanner_status` payload when present. It blocks scans when the requested scanner is explicitly disabled, failed, or unavailable, while still allowing older agents that do not report scanner status yet.

The bulk scan path now skips hosts that are not ready and returns those skips in the response instead of enqueueing work that is likely to sit in a misleading running state.

Related to #688.
Related to #686.

## Why

When OpenSCAP or Docker Bench is not actually available on an agent, the server can currently accept the scan request anyway. That makes the UI look like the scan started, even though the host cannot run it.

This keeps the failure closer to the request and gives the caller a clear error instead of creating confusing scan state.

I am marking this as related rather than closing those issues directly because the reports may also involve agent-side install or result-collection behavior. This patch fixes the server accepting work when the scanner is already known to be unavailable.

## Validation

Ran from `server-source-code`:

```bash
go test ./internal/queue -run 'TestValidateComplianceScanReadiness' -count=1
go test ./internal/handler ./internal/queue
make check
```

`make check` covered format check, vet, golangci-lint, and tests.
