### PR TITLE
feat(agent+server): add live patching support for Alpine Linux via APK

### DIFF
--- a/agent-source-code/cmd/patchmon-agent/commands/serve.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/serve.go
@@ -2213,8 +2213,8 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 		return runPatchWindows(ctx, httpClient, patchRunID, patchType, packageNames, dryRun)
 	}
 
-	if pkgManager != "apt" && pkgManager != "dnf" && pkgManager != "yum" && pkgManager != "pkg" && pkgManager != "pacman" {
-		errMsg := fmt.Sprintf("package manager %q not supported for patching (apt, dnf, yum, pkg, pacman required)", pkgManager)
+	if pkgManager != "apt" && pkgManager != "dnf" && pkgManager != "yum" && pkgManager != "pkg" && pkgManager != "pacman" && pkgManager != "apk" {
+		errMsg := fmt.Sprintf("package manager %q not supported for patching (apt, dnf, yum, pkg, pacman, apk required)", pkgManager)
 		_ = httpClient.SendPatchOutput(ctx, patchRunID, "failed", "", errMsg)
 		return fmt.Errorf("%s", errMsg)
 	}
@@ -2244,6 +2244,12 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 				return fmt.Errorf("freebsd-update not found: %w", err)
 			}
 		}
+	case "apk":
+		if _, err := exec.LookPath("apk"); err != nil {
+			_ = httpClient.SendPatchOutput(ctx, patchRunID, "failed", "", "apk not found: Alpine Linux package manager not installed")
+			return fmt.Errorf("apk not found: %w", err)
+		}
+		upgradeBin = "apk"
 	case "pacman":
 		if _, err := exec.LookPath("pacman"); err != nil {
 			_ = httpClient.SendPatchOutput(ctx, patchRunID, "failed", "", "pacman not found: Arch Linux package manager not installed")
@@ -2316,6 +2322,10 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 			if err, abort := runStep(false, "pkg update", "pkg update failed: %w", upgradeBin, "update"); abort {
 				stepErr = err
 			}
+		case "apk":
+			if err, abort := runStep(false, "apk update", "apk update failed: %w", "apk", "update"); abort {
+				stepErr = err
+			}
 		case "pacman":
 			if err, abort := runStep(false, "pacman refresh", "pacman -Sy failed: %w", "pacman", "-Sy", "--noconfirm"); abort {
 				stepErr = err
@@ -2347,6 +2357,16 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 					}
 				} else {
 					if err, abort := runStep(false, "pkg upgrade", "pkg upgrade failed: %w", upgradeBin, "upgrade", "-y"); abort {
+						stepErr = err
+					}
+				}
+			case "apk":
+				if dryRun {
+					if err, abort := runStep(false, "apk upgrade --simulate", "apk upgrade --simulate failed: %w", "apk", "upgrade", "--simulate"); abort {
+						stepErr = err
+					}
+				} else {
+					if err, abort := runStep(false, "apk upgrade", "apk upgrade failed: %w", "apk", "upgrade"); abort {
 						stepErr = err
 					}
 				}
@@ -2402,6 +2422,18 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 						if err, abort := runStep(false, "pkg install", "pkg install failed: %w", upgradeBin, args...); abort {
 							stepErr = err
 						}
+					}
+				}
+			case "apk":
+				if dryRun {
+					args := append([]string{"upgrade", "--simulate"}, packageNames...)
+					if err, abort := runStep(false, "apk upgrade --simulate", "apk upgrade --simulate failed: %w", "apk", args...); abort {
+						stepErr = err
+					}
+				} else {
+					args := append([]string{"upgrade"}, packageNames...)
+					if err, abort := runStep(false, "apk upgrade", "apk upgrade failed: %w", "apk", args...); abort {
+						stepErr = err
 					}
 				}
 			case "pacman":

--- a/server-source-code/internal/store/patching.go
+++ b/server-source-code/internal/store/patching.go
@@ -21,6 +21,7 @@ const freeBSDBasePackageName = "freebsd-base"
 
 var freeBSDPkgSummaryLinePattern = regexp.MustCompile(`^\s+(\S+):\s+`)
 var freeBSDPkgActionLinePattern = regexp.MustCompile(`^\[\d+/\d+\]\s+(?:Installing|Upgrading|Reinstalling)\s+(\S+)`)
+var apkActionLinePattern = regexp.MustCompile(`^\(\d+/\d+\)\s+(?:Installing|Upgrading|Reinstalling)\s+(\S+)`)
 
 // isFreeBSD reports whether the host OS type represents FreeBSD. The synthetic
 // "freebsd-base" package must only be emitted for FreeBSD hosts; otherwise
@@ -56,6 +57,12 @@ func parsePackagesAffectedFromDryRunOutput(osType, output string) []string {
 			if len(fields) >= 2 {
 				addPkg(fields[1])
 			}
+			continue
+		}
+
+		// apk (--simulate and real): "(1/3) Upgrading pkgname (oldver -> newver)"
+		if matches := apkActionLinePattern.FindStringSubmatch(trimmed); len(matches) == 2 {
+			addPkg(matches[1])
 			continue
 		}
 
@@ -135,6 +142,11 @@ func parsePackagesAffectedFromRealOutput(osType, output string) []string {
 			if len(fields) >= 3 {
 				addPkg(fields[2])
 			}
+			continue
+		}
+		// apk (--simulate and real): "(1/3) Upgrading pkgname (oldver -> newver)"
+		if matches := apkActionLinePattern.FindStringSubmatch(trimmed); len(matches) == 2 {
+			addPkg(matches[1])
 			continue
 		}
 		// dnf/yum real: "  Upgrading   : pkgname-version.arch" / "  Installing  : pkgname-version.arch"

--- a/server-source-code/internal/store/patching_test.go
+++ b/server-source-code/internal/store/patching_test.go
@@ -102,6 +102,26 @@ Conf libcap2-bin (1:2.66-5ubuntu2.4 Ubuntu:24.04/noble-updates, Ubuntu:24.04/nob
 		}
 	})
 
+	t.Run("parses apk simulate output", func(t *testing.T) {
+		output := `$ apk update
+v3.22.4-151-g9faf79747cd [http://dl-cdn.alpinelinux.org/alpine/v3.22/main]
+v3.22.4-142-g851e02b940b [http://dl-cdn.alpinelinux.org/alpine/v3.22/community]
+OK: 26353 distinct packages available
+$ apk upgrade --simulate libssl3
+(1/2) Upgrading libcrypto3 (3.5.4-r0 -> 3.5.7-r0)
+(2/2) Upgrading libssl3 (3.5.4-r0 -> 3.5.7-r0)
+OK: 80 MiB in 76 packages
+
+--- Dry run completed at 2026-06-20T15:55:42Z ---`
+
+		got := parsePackagesAffectedFromDryRunOutput("alpine", output)
+		want := []string{"libcrypto3", "libssl3"}
+
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("parsePackagesAffectedFromDryRunOutput() = %v, want %v", got, want)
+		}
+	})
+
 	t.Run("apt bulk dry run does not emit freebsd-base on linux", func(t *testing.T) {
 		output := `$ apt-get update -qq
 $ apt-get -s install libcap2 libcap2-bin libntfs-3g89t64 libpam-cap libpython3.12-minimal libpython3.12-stdlib libpython3.12t64 ntfs-3g python3.12 python3.12-minimal
@@ -167,6 +187,26 @@ Number of packages to be installed: 1
 
 		got := parsePackagesAffectedFromRealOutput("freebsd", output)
 		want := []string{freeBSDBasePackageName, "curl", "ca_root_nss"}
+
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("parsePackagesAffectedFromRealOutput() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("parses apk real output", func(t *testing.T) {
+		output := `$ apk update
+v3.22.4-151-g9faf79747cd [http://dl-cdn.alpinelinux.org/alpine/v3.22/main]
+v3.22.4-142-g851e02b940b [http://dl-cdn.alpinelinux.org/alpine/v3.22/community]
+OK: 26353 distinct packages available
+$ apk upgrade libssl3
+(1/2) Upgrading libcrypto3 (3.5.4-r0 -> 3.5.7-r0)
+(2/2) Upgrading libssl3 (3.5.4-r0 -> 3.5.7-r0)
+OK: 80 MiB in 76 packages
+
+--- Patch run completed at 2026-06-20T16:00:55Z ---`
+
+		got := parsePackagesAffectedFromRealOutput("alpine", output)
+		want := []string{"libcrypto3", "libssl3"}
 
 		if !reflect.DeepEqual(got, want) {
 			t.Fatalf("parsePackagesAffectedFromRealOutput() = %v, want %v", got, want)


### PR DESCRIPTION
## AI Disclosure

- **Used AI:** yes
- **Model(s):** Claude Sonnet 4.6
- **Harness / tool:** Claude Code CLI
- **Scope:** code analysis, commit message, helps with building the binary, tests and PR-Description.
- **Human review completed:** yes - reviewed code and tested on multiple alpine hosts to confirm changes.

## Agent
Adds apk to the supported patching path in runPatch(). Previously the agent would reject any patch attempt on Alpine with "package manager \"apk\" not supported for patching", despite APK being listed as supported in the README.

Changes in serve.go:
- Remove apk from the unsupported-manager guard
- Add apk binary/env setup case (apk upgrade as upgradeBin)
- Add apk cache update step (apk update)
- Add apk patch_all: apk upgrade / apk upgrade --simulate (dry-run)
- Add apk patch_package: apk upgrade <pkg> / apk upgrade --simulate <pkg>

Tested on Alpine 3.22 (amd64): dry-run and live patch of libssl3 both streamed correct output including transitive dependency upgrades.

## Server
Adds an apkActionLinePattern regex to patching.go and wires it into
both parsePackagesAffectedFromDryRunOutput and
parsePackagesAffectedFromRealOutput.

APK outputs lines of the form "(1/2) Upgrading pkgname (oldver -> newver)"
for both --simulate and real runs. Without this, the packages_affected
field stayed empty after APK patch runs, so the UI showed no package
list and users had to open the full shell output to see what changed.

Both parsers now extract package names from these lines, consistent
with the existing apt, dnf/yum, and FreeBSD pkg handling.

Tests added for apk simulate and real output in both parser test suites.

fixes https://github.com/PatchMon/PatchMon/issues/778
