### PR TITLE
feat: add Univention Corporate Server (UCS) support

### DIFF
--- a/agent-source-code/cmd/patchmon-agent/commands/serve.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/serve.go
@@ -2213,7 +2213,7 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 		return runPatchWindows(ctx, httpClient, patchRunID, patchType, packageNames, dryRun)
 	}
 
-	if pkgManager != "apt" && pkgManager != "dnf" && pkgManager != "yum" && pkgManager != "pkg" && pkgManager != "pacman" {
+	if pkgManager != "apt" && pkgManager != "ucs" && pkgManager != "dnf" && pkgManager != "yum" && pkgManager != "pkg" && pkgManager != "pacman" {
 		errMsg := fmt.Sprintf("package manager %q not supported for patching (apt, dnf, yum, pkg, pacman required)", pkgManager)
 		_ = httpClient.SendPatchOutput(ctx, patchRunID, "failed", "", errMsg)
 		return fmt.Errorf("%s", errMsg)
@@ -2225,6 +2225,13 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 	freeBSDPkgTargets := packageNames
 	includeFreeBSDBase := pkgManager == "pkg" && patchType == "patch_all"
 	switch pkgManager {
+	case "ucs":
+		if _, err := exec.LookPath("univention-upgrade"); err != nil {
+			_ = httpClient.SendPatchOutput(ctx, patchRunID, "failed", "", "univention-upgrade not found: not a Univention Corporate Server system")
+			return fmt.Errorf("univention-upgrade not found: %w", err)
+		}
+		env = append(os.Environ(), "DEBIAN_FRONTEND=noninteractive")
+		upgradeBin = "univention-upgrade"
 	case "apt":
 		if _, err := exec.LookPath("apt-get"); err != nil {
 			_ = httpClient.SendPatchOutput(ctx, patchRunID, "failed", "", "apt-get not found: not a Debian/Ubuntu system or apt not installed")
@@ -2308,7 +2315,7 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 	if stepErr == nil && needsPkgTransaction {
 		// Update package cache
 		switch pkgManager {
-		case "apt":
+		case "ucs", "apt":
 			if err, abort := runStep(false, "apt-get update", "apt-get update failed: %w", "apt-get", "update", "-qq"); abort {
 				stepErr = err
 			}
@@ -2330,6 +2337,16 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 	if stepErr == nil {
 		if patchType == "patch_all" {
 			switch pkgManager {
+			case "ucs":
+				if dryRun {
+					if err, abort := runStep(false, "apt-get -s upgrade", "apt-get -s upgrade failed: %w", "apt-get", "-s", "upgrade"); abort {
+						stepErr = err
+					}
+				} else {
+					if err, abort := runStep(false, "univention-upgrade", "univention-upgrade failed: %w", "univention-upgrade", "--noninteractive"); abort {
+						stepErr = err
+					}
+				}
 			case "apt":
 				if dryRun {
 					if err, abort := runStep(false, "apt-get -s upgrade", "apt-get -s upgrade failed: %w", "apt-get", "-s", "upgrade"); abort {
@@ -2378,6 +2395,18 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 				return fmt.Errorf("package_names required for patch_package")
 			}
 			switch pkgManager {
+			case "ucs":
+				if dryRun {
+					args := append([]string{"-s", "install"}, packageNames...)
+					if err, abort := runStep(false, "apt-get -s install", "apt-get -s install failed: %w", "apt-get", args...); abort {
+						stepErr = err
+					}
+				} else {
+					args := append([]string{"-y"}, packageNames...)
+					if err, abort := runStep(false, "univention-install", "univention-install failed: %w", "univention-install", args...); abort {
+						stepErr = err
+					}
+				}
 			case "apt":
 				if dryRun {
 					args := append([]string{"-s", "install"}, packageNames...)

--- a/agent-source-code/cmd/patchmon-agent/commands/serve.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/serve.go
@@ -2251,7 +2251,7 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 		return runPatchWindows(ctx, httpClient, patchRunID, patchType, packageNames, dryRun)
 	}
 
-	if pkgManager != "apt" && pkgManager != "dnf" && pkgManager != "yum" && pkgManager != "pkg" && pkgManager != "pacman" {
+	if pkgManager != "apt" && pkgManager != "ucs" && pkgManager != "dnf" && pkgManager != "yum" && pkgManager != "pkg" && pkgManager != "pacman" {
 		errMsg := fmt.Sprintf("package manager %q not supported for patching (apt, dnf, yum, pkg, pacman required)", pkgManager)
 		_ = httpClient.SendPatchOutput(ctx, patchRunID, "failed", "", errMsg)
 		return fmt.Errorf("%s", errMsg)
@@ -2263,6 +2263,13 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 	freeBSDPkgTargets := packageNames
 	includeFreeBSDBase := pkgManager == "pkg" && patchType == "patch_all"
 	switch pkgManager {
+	case "ucs":
+		if _, err := exec.LookPath("univention-upgrade"); err != nil {
+			_ = httpClient.SendPatchOutput(ctx, patchRunID, "failed", "", "univention-upgrade not found: not a Univention Corporate Server system")
+			return fmt.Errorf("univention-upgrade not found: %w", err)
+		}
+		env = append(os.Environ(), "DEBIAN_FRONTEND=noninteractive")
+		upgradeBin = "univention-upgrade"
 	case "apt":
 		if _, err := exec.LookPath("apt-get"); err != nil {
 			_ = httpClient.SendPatchOutput(ctx, patchRunID, "failed", "", "apt-get not found: not a Debian/Ubuntu system or apt not installed")
@@ -2346,7 +2353,7 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 	if stepErr == nil && needsPkgTransaction {
 		// Update package cache
 		switch pkgManager {
-		case "apt":
+		case "ucs", "apt":
 			if err, abort := runStep(false, "apt-get update", "apt-get update failed: %w", "apt-get", "update", "-qq"); abort {
 				stepErr = err
 			}
@@ -2371,6 +2378,16 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 	if stepErr == nil {
 		if patchType == "patch_all" {
 			switch pkgManager {
+			case "ucs":
+				if dryRun {
+					if err, abort := runStep(false, "apt-get -s upgrade", "apt-get -s upgrade failed: %w", "apt-get", "-s", "upgrade"); abort {
+						stepErr = err
+					}
+				} else {
+					if err, abort := runStep(false, "univention-upgrade", "univention-upgrade failed: %w", "univention-upgrade", "--noninteractive"); abort {
+						stepErr = err
+					}
+				}
 			case "apt":
 				// --with-new-pkgs makes apt-get match what the collector
 				// measures. Collection runs /usr/bin/apt (see
@@ -2427,6 +2444,18 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 				return fmt.Errorf("package_names required for patch_package")
 			}
 			switch pkgManager {
+			case "ucs":
+				if dryRun {
+					args := append([]string{"-s", "install"}, packageNames...)
+					if err, abort := runStep(false, "apt-get -s install", "apt-get -s install failed: %w", "apt-get", args...); abort {
+						stepErr = err
+					}
+				} else {
+					args := append([]string{"-y"}, packageNames...)
+					if err, abort := runStep(false, "univention-install", "univention-install failed: %w", "univention-install", args...); abort {
+						stepErr = err
+					}
+				}
 			case "apt":
 				if dryRun {
 					args := append([]string{"-s", "--only-upgrade", "install"}, packageNames...)

--- a/agent-source-code/internal/packages/packages.go
+++ b/agent-source-code/internal/packages/packages.go
@@ -27,6 +27,7 @@ type Manager struct {
 	pacmanManager  *PacmanManager
 	freebsdManager *FreeBSDManager
 	winManager     *WindowsManager
+	ucsManager     *UCSManager
 }
 
 // New creates a new package manager
@@ -37,6 +38,7 @@ func New(logger *logrus.Logger, cacheRefresh CacheRefreshConfig) *Manager {
 	pacmanManager := NewPacmanManager(logger)
 	freebsdManager := NewFreeBSDManager(logger)
 	winManager := NewWindowsManager(logger)
+	ucsManager := NewUCSManager(logger, cacheRefresh)
 
 	return &Manager{
 		logger:         logger,
@@ -46,6 +48,7 @@ func New(logger *logrus.Logger, cacheRefresh CacheRefreshConfig) *Manager {
 		pacmanManager:  pacmanManager,
 		freebsdManager: freebsdManager,
 		winManager:     winManager,
+		ucsManager:     ucsManager,
 	}
 }
 
@@ -58,6 +61,8 @@ func (m *Manager) GetPackages() ([]models.Package, error) {
 	switch packageManager {
 	case "windows":
 		return m.winManager.GetPackages(), nil
+	case "ucs":
+		return m.ucsManager.GetPackages(), nil
 	case "apt":
 		return m.aptManager.GetPackages()
 	case "dnf", "yum":
@@ -101,6 +106,11 @@ func (m *Manager) DetectPackageManager() string {
 	// Check for APK (Alpine Linux)
 	if _, err := exec.LookPath("apk"); err == nil {
 		return "apk"
+	}
+
+	// Check for UCS before generic APT — UCS has apt, but uses univention-upgrade for patching
+	if IsUCS() {
+		return "ucs"
 	}
 
 	// Check for APT

--- a/agent-source-code/internal/packages/packages.go
+++ b/agent-source-code/internal/packages/packages.go
@@ -27,6 +27,7 @@ type Manager struct {
 	pacmanManager  *PacmanManager
 	freebsdManager *FreeBSDManager
 	winManager     *WindowsManager
+	ucsManager     *UCSManager
 }
 
 // New creates a new package manager
@@ -37,6 +38,7 @@ func New(logger *logrus.Logger, cacheRefresh CacheRefreshConfig) *Manager {
 	pacmanManager := NewPacmanManager(logger)
 	freebsdManager := NewFreeBSDManager(logger)
 	winManager := NewWindowsManager(logger)
+	ucsManager := NewUCSManager(logger, cacheRefresh)
 
 	return &Manager{
 		logger:         logger,
@@ -46,6 +48,7 @@ func New(logger *logrus.Logger, cacheRefresh CacheRefreshConfig) *Manager {
 		pacmanManager:  pacmanManager,
 		freebsdManager: freebsdManager,
 		winManager:     winManager,
+		ucsManager:     ucsManager,
 	}
 }
 
@@ -58,6 +61,8 @@ func (m *Manager) GetPackages() ([]models.Package, error) {
 	switch packageManager {
 	case "windows":
 		return m.winManager.GetPackages(), nil
+	case "ucs":
+		return m.ucsManager.GetPackages(), nil
 	case "apt":
 		return m.aptManager.GetPackages(), nil
 	case "dnf", "yum":
@@ -101,6 +106,11 @@ func (m *Manager) DetectPackageManager() string {
 	// Check for APK (Alpine Linux)
 	if _, err := exec.LookPath("apk"); err == nil {
 		return "apk"
+	}
+
+	// Check for UCS before generic APT — UCS has apt, but uses univention-upgrade for patching
+	if IsUCS() {
+		return "ucs"
 	}
 
 	// Check for APT

--- a/agent-source-code/internal/packages/ucs.go
+++ b/agent-source-code/internal/packages/ucs.go
@@ -1,0 +1,42 @@
+package packages
+
+import (
+	"os"
+	"os/exec"
+
+	"patchmon-agent/pkg/models"
+
+	"github.com/sirupsen/logrus"
+)
+
+// UCSManager handles package information collection on Univention Corporate Server.
+// UCS is Debian-based; package listing delegates to APTManager.
+type UCSManager struct {
+	logger     *logrus.Logger
+	aptManager *APTManager
+}
+
+// NewUCSManager creates a new UCS package manager.
+func NewUCSManager(logger *logrus.Logger, cacheRefresh CacheRefreshConfig) *UCSManager {
+	return &UCSManager{
+		logger:     logger,
+		aptManager: NewAPTManager(logger, cacheRefresh),
+	}
+}
+
+// GetPackages returns installed packages on a UCS host via the underlying apt layer.
+func (m *UCSManager) GetPackages() []models.Package {
+	return m.aptManager.GetPackages()
+}
+
+// IsUCS returns true when running on Univention Corporate Server.
+// The /etc/univention/ directory is the canonical marker for a UCS installation.
+func IsUCS() bool {
+	if info, err := os.Stat("/etc/univention"); err == nil && info.IsDir() {
+		return true
+	}
+	if _, err := exec.LookPath("ucr"); err == nil {
+		return true
+	}
+	return false
+}

--- a/frontend/src/components/AddHostWizard.jsx
+++ b/frontend/src/components/AddHostWizard.jsx
@@ -3,6 +3,7 @@ import { CheckCircle, Copy, Download, RefreshCw, Wifi, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { DiWindows } from "react-icons/di";
 import { SiFreebsd, SiLinux } from "react-icons/si";
+import { UCSLogoIcon } from "../utils/osIcons";
 import { useNavigate } from "react-router-dom";
 import {
 	adminHostsAPI,
@@ -37,7 +38,7 @@ const hasInitialReport = (hostData) => {
 
 const AddHostWizard = ({ isOpen, onClose, onSuccess }) => {
 	const [step, setStep] = useState(1);
-	const [platform, setPlatform] = useState("linux"); // linux | freebsd | windows
+	const [platform, setPlatform] = useState("linux"); // linux | freebsd | windows | ucs
 	const [formData, setFormData] = useState({
 		friendly_name: "",
 		hostGroupIds: [],
@@ -93,6 +94,7 @@ const AddHostWizard = ({ isOpen, onClose, onSuccess }) => {
 		const params = new URLSearchParams();
 		if (platform === "freebsd") params.set("os", "freebsd");
 		if (platform === "windows") params.set("os", "windows");
+		if (platform === "ucs") params.set("os", "ucs");
 		if (force && platform !== "windows") params.set("force", "true");
 		const qs = params.toString();
 		return qs ? `${base}?${qs}` : base;
@@ -342,7 +344,7 @@ const AddHostWizard = ({ isOpen, onClose, onSuccess }) => {
 							Select the operating system of the host you want to add. The
 							install command will match this choice.
 						</p>
-						<div className="grid grid-cols-3 gap-4">
+						<div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
 							<button
 								type="button"
 								onClick={() => setPlatform("linux")}
@@ -378,6 +380,18 @@ const AddHostWizard = ({ isOpen, onClose, onSuccess }) => {
 							>
 								<DiWindows className="h-12 w-12 text-secondary-700 dark:text-secondary-200 mb-2" />
 								<span className="text-sm font-medium">Windows</span>
+							</button>
+							<button
+								type="button"
+								onClick={() => setPlatform("ucs")}
+								className={`flex flex-col items-center justify-center p-6 rounded-lg border-2 transition-all ${
+									platform === "ucs"
+										? "border-primary-500 bg-primary-50 dark:bg-primary-900/30"
+										: "border-secondary-300 dark:border-secondary-600 hover:border-primary-400"
+								}`}
+							>
+								<UCSLogoIcon className="h-12 w-12 mb-2" />
+								<span className="text-sm font-medium text-center">Univention UCS</span>
 							</button>
 						</div>
 						<div className="flex justify-end pt-2">
@@ -557,7 +571,9 @@ const AddHostWizard = ({ isOpen, onClose, onSuccess }) => {
 								? "Windows"
 								: platform === "freebsd"
 									? "FreeBSD"
-									: "Linux"}{" "}
+									: platform === "ucs"
+										? "Univention UCS"
+										: "Linux"}{" "}
 							host to install the agent
 							{platform === "windows"
 								? " (run PowerShell as Administrator)"

--- a/frontend/src/components/AddHostWizard.jsx
+++ b/frontend/src/components/AddHostWizard.jsx
@@ -3,6 +3,7 @@ import { CheckCircle, Copy, Download, RefreshCw, Wifi, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { DiWindows } from "react-icons/di";
 import { SiFreebsd, SiLinux } from "react-icons/si";
+import { UCSLogoIcon } from "../utils/osIcons";
 import { useNavigate } from "react-router-dom";
 import {
 	adminHostsAPI,
@@ -37,7 +38,7 @@ const hasInitialReport = (hostData) => {
 
 const AddHostWizard = ({ isOpen, onClose, onSuccess }) => {
 	const [step, setStep] = useState(1);
-	const [platform, setPlatform] = useState("linux"); // linux | freebsd | windows
+	const [platform, setPlatform] = useState("linux"); // linux | freebsd | windows | ucs
 	const [formData, setFormData] = useState({
 		friendly_name: "",
 		hostGroupIds: [],
@@ -93,6 +94,7 @@ const AddHostWizard = ({ isOpen, onClose, onSuccess }) => {
 		const params = new URLSearchParams();
 		if (platform === "freebsd") params.set("os", "freebsd");
 		if (platform === "windows") params.set("os", "windows");
+		if (platform === "ucs") params.set("os", "ucs");
 		if (force && platform !== "windows") params.set("force", "true");
 		const qs = params.toString();
 		return qs ? `${base}?${qs}` : base;
@@ -341,7 +343,7 @@ const AddHostWizard = ({ isOpen, onClose, onSuccess }) => {
 							Select the operating system of the host you want to add. The
 							install command will match this choice.
 						</p>
-						<div className="grid grid-cols-3 gap-4">
+						<div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
 							<button
 								type="button"
 								onClick={() => setPlatform("linux")}
@@ -377,6 +379,18 @@ const AddHostWizard = ({ isOpen, onClose, onSuccess }) => {
 							>
 								<DiWindows className="h-12 w-12 text-secondary-700 dark:text-secondary-200 mb-2" />
 								<span className="text-sm font-medium">Windows</span>
+							</button>
+							<button
+								type="button"
+								onClick={() => setPlatform("ucs")}
+								className={`flex flex-col items-center justify-center p-6 rounded-lg border-2 transition-all ${
+									platform === "ucs"
+										? "border-primary-500 bg-primary-50 dark:bg-primary-900/30"
+										: "border-secondary-300 dark:border-secondary-600 hover:border-primary-400"
+								}`}
+							>
+								<UCSLogoIcon className="h-12 w-12 mb-2" />
+								<span className="text-sm font-medium text-center">Univention UCS</span>
 							</button>
 						</div>
 						<div className="flex justify-end pt-2">
@@ -556,7 +570,9 @@ const AddHostWizard = ({ isOpen, onClose, onSuccess }) => {
 								? "Windows"
 								: platform === "freebsd"
 									? "FreeBSD"
-									: "Linux"}{" "}
+									: platform === "ucs"
+										? "Univention UCS"
+										: "Linux"}{" "}
 							host to install the agent
 							{platform === "windows"
 								? " (run PowerShell as Administrator)"

--- a/frontend/src/utils/osIcons.jsx
+++ b/frontend/src/utils/osIcons.jsx
@@ -1,5 +1,20 @@
 import { Monitor } from "lucide-react";
 import { DiWindows } from "react-icons/di";
+
+const UCSLogoIcon = ({ className, title }) => (
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 20 20"
+		className={className}
+		fill="#DD042D"
+		aria-label={title}
+	>
+		<path d="M15.989.38h-9.59A3.198 3.198 0 0 0 3.2 3.58h2.877v9.291c.06.709 1.093 1.486 3.23 1.622 1.75.109 3.397-.545 3.812-1.526V3.588c.366.034 2.418.565 2.803 2.554.027.115.045.232.055.35v.006c.008.09.012.181.012.28v9.593h-2.877v-1.394a3.638 3.638 0 0 1-1.997 1.394h-4.72a3.159 3.159 0 0 1-3.199-3.199V3.58A3.198 3.198 0 0 0 0 6.777v9.594a3.198 3.198 0 0 0 3.198 3.199h9.593a3.199 3.199 0 0 0 3.198-3.2 3.196 3.196 0 0 0 3.198-3.197V3.579A3.198 3.198 0 0 0 15.989.38Z" />
+	</svg>
+);
+
+export { UCSLogoIcon };
+
 // Import OS icons from react-icons Simple Icons - using only confirmed available icons
 import {
 	SiAlmalinux,
@@ -55,6 +70,9 @@ export const getOSIcon = (osType) => {
 
 	// Elementary OS
 	if (os.includes("elementary")) return SiElementary;
+
+	// Univention Corporate Server
+	if (os.includes("univention") || os === "ucs") return UCSLogoIcon;
 
 	// Debian
 	if (os.includes("debian")) return SiDebian;
@@ -166,6 +184,9 @@ export const getOSDisplayName = (osType) => {
 
 	// Elementary OS
 	if (os.includes("elementary")) return "Elementary OS";
+
+	// Univention Corporate Server
+	if (os.includes("univention") || os === "ucs") return "Univention Corporate Server";
 
 	// Debian
 	if (os.includes("debian")) return "Debian";

--- a/server-source-code/internal/handler/install.go
+++ b/server-source-code/internal/handler/install.go
@@ -142,7 +142,11 @@ func (h *InstallHandler) ServeInstall(w http.ResponseWriter, r *http.Request) {
 		architecture = ""
 	}
 	osParam := r.URL.Query().Get("os")
-	if osParam != "linux" && osParam != "freebsd" && osParam != "windows" {
+	if osParam != "linux" && osParam != "freebsd" && osParam != "windows" && osParam != "ucs" {
+		osParam = "linux"
+	}
+	// UCS uses the Linux agent binary and install script
+	if osParam == "ucs" {
 		osParam = "linux"
 	}
 
@@ -537,6 +541,8 @@ func (h *InstallHandler) ServeAgentVersion(w http.ResponseWriter, r *http.Reques
 			osParam = "windows"
 		} else if strings.Contains(ep, "freebsd") || strings.Contains(ep, "pfsense") {
 			osParam = "freebsd"
+		} else if ep == "ucs" || strings.Contains(ep, "univention") {
+			osParam = "ucs"
 		} else {
 			osParam = "linux"
 		}
@@ -547,6 +553,8 @@ func (h *InstallHandler) ServeAgentVersion(w http.ResponseWriter, r *http.Reques
 			osParam = "windows"
 		} else if strings.Contains(reported, "freebsd") || strings.Contains(reported, "pfsense") {
 			osParam = "freebsd"
+		} else if strings.Contains(reported, "univention") {
+			osParam = "ucs"
 		} else {
 			osParam = "linux"
 		}
@@ -555,10 +563,14 @@ func (h *InstallHandler) ServeAgentVersion(w http.ResponseWriter, r *http.Reques
 		osParam = "linux"
 	}
 
-	validOss := map[string]bool{"linux": true, "freebsd": true, "windows": true}
+	validOss := map[string]bool{"linux": true, "freebsd": true, "windows": true, "ucs": true}
 	if !validOss[osParam] {
-		JSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid os. Must be one of: linux, freebsd, windows"})
+		JSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid os. Must be one of: linux, freebsd, windows, ucs"})
 		return
+	}
+	// UCS uses the Linux agent binary
+	if osParam == "ucs" {
+		osParam = "linux"
 	}
 
 	validArchLinux := map[string]bool{"amd64": true, "386": true, "arm64": true, "arm": true}
@@ -721,6 +733,8 @@ func (h *InstallHandler) ServeAgentDownload(w http.ResponseWriter, r *http.Reque
 			osParam = "windows"
 		} else if strings.Contains(ep, "freebsd") || strings.Contains(ep, "pfsense") {
 			osParam = "freebsd"
+		} else if ep == "ucs" || strings.Contains(ep, "univention") {
+			osParam = "ucs"
 		} else {
 			osParam = "linux"
 		}
@@ -731,6 +745,8 @@ func (h *InstallHandler) ServeAgentDownload(w http.ResponseWriter, r *http.Reque
 			osParam = "windows"
 		} else if strings.Contains(reported, "freebsd") || strings.Contains(reported, "pfsense") {
 			osParam = "freebsd"
+		} else if strings.Contains(reported, "univention") {
+			osParam = "ucs"
 		} else {
 			osParam = "linux"
 		}
@@ -739,10 +755,14 @@ func (h *InstallHandler) ServeAgentDownload(w http.ResponseWriter, r *http.Reque
 		osParam = "linux"
 	}
 
-	validOss := map[string]bool{"linux": true, "freebsd": true, "windows": true}
+	validOss := map[string]bool{"linux": true, "freebsd": true, "windows": true, "ucs": true}
 	if !validOss[osParam] {
-		JSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid os. Must be one of: linux, freebsd, windows"})
+		JSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid os. Must be one of: linux, freebsd, windows, ucs"})
 		return
+	}
+	// UCS uses the Linux agent binary
+	if osParam == "ucs" {
+		osParam = "linux"
 	}
 
 	validArchLinux := map[string]bool{"amd64": true, "386": true, "arm64": true, "arm": true}

--- a/server-source-code/internal/handler/install.go
+++ b/server-source-code/internal/handler/install.go
@@ -144,7 +144,11 @@ func (h *InstallHandler) ServeInstall(w http.ResponseWriter, r *http.Request) {
 		architecture = ""
 	}
 	osParam := r.URL.Query().Get("os")
-	if osParam != "linux" && osParam != "freebsd" && osParam != "windows" {
+	if osParam != "linux" && osParam != "freebsd" && osParam != "windows" && osParam != "ucs" {
+		osParam = "linux"
+	}
+	// UCS uses the Linux agent binary and install script
+	if osParam == "ucs" {
 		osParam = "linux"
 	}
 
@@ -921,6 +925,8 @@ func (h *InstallHandler) ServeAgentVersion(w http.ResponseWriter, r *http.Reques
 			osParam = "windows"
 		} else if strings.Contains(ep, "freebsd") || strings.Contains(ep, "pfsense") {
 			osParam = "freebsd"
+		} else if ep == "ucs" || strings.Contains(ep, "univention") {
+			osParam = "ucs"
 		} else {
 			osParam = "linux"
 		}
@@ -931,6 +937,8 @@ func (h *InstallHandler) ServeAgentVersion(w http.ResponseWriter, r *http.Reques
 			osParam = "windows"
 		} else if strings.Contains(reported, "freebsd") || strings.Contains(reported, "pfsense") {
 			osParam = "freebsd"
+		} else if strings.Contains(reported, "univention") {
+			osParam = "ucs"
 		} else {
 			osParam = "linux"
 		}
@@ -939,10 +947,14 @@ func (h *InstallHandler) ServeAgentVersion(w http.ResponseWriter, r *http.Reques
 		osParam = "linux"
 	}
 
-	validOss := map[string]bool{"linux": true, "freebsd": true, "windows": true}
+	validOss := map[string]bool{"linux": true, "freebsd": true, "windows": true, "ucs": true}
 	if !validOss[osParam] {
-		JSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid os. Must be one of: linux, freebsd, windows"})
+		JSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid os. Must be one of: linux, freebsd, windows, ucs"})
 		return
+	}
+	// UCS uses the Linux agent binary
+	if osParam == "ucs" {
+		osParam = "linux"
 	}
 
 	binaryName, supported := util.AgentBinaryName(osParam, architecture)
@@ -1085,6 +1097,8 @@ func (h *InstallHandler) ServeAgentDownload(w http.ResponseWriter, r *http.Reque
 			osParam = "windows"
 		} else if strings.Contains(ep, "freebsd") || strings.Contains(ep, "pfsense") {
 			osParam = "freebsd"
+		} else if ep == "ucs" || strings.Contains(ep, "univention") {
+			osParam = "ucs"
 		} else {
 			osParam = "linux"
 		}
@@ -1095,6 +1109,8 @@ func (h *InstallHandler) ServeAgentDownload(w http.ResponseWriter, r *http.Reque
 			osParam = "windows"
 		} else if strings.Contains(reported, "freebsd") || strings.Contains(reported, "pfsense") {
 			osParam = "freebsd"
+		} else if strings.Contains(reported, "univention") {
+			osParam = "ucs"
 		} else {
 			osParam = "linux"
 		}
@@ -1103,10 +1119,14 @@ func (h *InstallHandler) ServeAgentDownload(w http.ResponseWriter, r *http.Reque
 		osParam = "linux"
 	}
 
-	validOss := map[string]bool{"linux": true, "freebsd": true, "windows": true}
+	validOss := map[string]bool{"linux": true, "freebsd": true, "windows": true, "ucs": true}
 	if !validOss[osParam] {
-		JSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid os. Must be one of: linux, freebsd, windows"})
+		JSON(w, http.StatusBadRequest, map[string]string{"error": "Invalid os. Must be one of: linux, freebsd, windows, ucs"})
 		return
+	}
+	// UCS uses the Linux agent binary
+	if osParam == "ucs" {
+		osParam = "linux"
 	}
 
 	binaryName, supported := util.AgentBinaryName(osParam, architecture)


### PR DESCRIPTION
## Summary

Adds full support for Univention Corporate Server (UCS) as a managed
host type in PatchMon, alongside the existing Linux, FreeBSD, and
Windows support.

**Agent:**
- Detects UCS via `/etc/univention/` directory or `ucr` binary (checked
  before the generic APT fallback, since UCS ships apt but uses its own
  upgrade tooling)
- Uses `univention-upgrade --noninteractive` for `patch_all` and
  `univention-install -y` for `patch_package`
- Dry-run falls back to `apt-get -s` (univention-upgrade has no
  simulate mode)
- Package inventory reuses APTManager (UCS is Debian-based)

**Server:**
- `"ucs"` accepted as a valid `?os=` parameter in the install script
  and binary download endpoints
- Maps to the Linux agent binary (no separate build needed)
- Auto-detects UCS from `expected_platform` or reported `os_type`
  containing "univention"

**Frontend:**
- New "Univention UCS" button in the AddHostWizard OS selector
  (4-column grid)
- Official Univention icon mark (SVG, red #DD042D) as a reusable
  `UCSLogoIcon` component
- `getOSIcon()` / `getOSDisplayName()` handle "univention"/"ucs" OS
  strings across the UI

## Test plan

- [x] `make check` passes in `agent-source-code/` and `server-source-code/`
- [x] `npx biome check src/` passes in `frontend/`
- [x] AddHostWizard shows four OS options; "Univention UCS" button
      selects correctly and install command is `curl … | sudo sh`
- [x] `GET /api/v1/hosts/install?os=ucs` returns a Linux bash script
      with `PATCHMON_OS="linux"` (not `ucs`)
- [x] On a UCS host (or a system with `/etc/univention/` present):
      agent detects `pkgManager = "ucs"`, dry-run shows `apt-get -s upgrade`,
      real patch run executes `univention-upgrade --noninteractive`

## AI Disclosure

- **Used AI:** yes
- **Model(s):** Claude Sonnet 4.6 (claude-sonnet-4-6)
- **Harness / tool:** Claude Code CLI
- **Scope:** code (agent, server, frontend), commit messages, PR description
- **Human review completed:** yes — reviewed by Max Furch and an additional colleague; all changed lines read and verified