### PR TITLE
fix(patchmon-agent): use only --version flag

### DIFF
--- a/agents/patchmon_install.sh
+++ b/agents/patchmon_install.sh
@@ -646,7 +646,7 @@ curl $CURL_FLAGS \
 chmod +x /usr/local/bin/patchmon-agent
 
 # Get the agent version from the binary
-AGENT_VERSION=$(/usr/local/bin/patchmon-agent version 2>/dev/null || echo "Unknown")
+AGENT_VERSION=$(/usr/local/bin/patchmon-agent --version 2>/dev/null || echo "Unknown")
 info "Agent version: $AGENT_VERSION"
 
 # Handle existing log files and create log directory

--- a/docs/patchmon-operator-guide.md
+++ b/docs/patchmon-operator-guide.md
@@ -3386,8 +3386,6 @@ Downloads the latest agent binary from the PatchMon server and performs an in-pl
 #### `version`: Print Version
 
 ```bash
-patchmon-agent version
-# or
 patchmon-agent --version
 ```
 
@@ -4186,7 +4184,7 @@ sudo journalctl -u patchmon-agent --since "30 minutes ago" --no-pager
 
 ```bash
 # Check current version
-patchmon-agent version
+patchmon-agent --version
 
 # Check if update is available
 sudo patchmon-agent check-version
@@ -5966,7 +5964,7 @@ The agent log contains `update failed`, `hash mismatch`, `binary verification fa
 **Diagnose:**
 
 ```bash
-sudo patchmon-agent version
+sudo patchmon-agent --version
 sudo patchmon-agent check-version
 ls -la /etc/patchmon/.last_update_timestamp
 ls -la /usr/local/bin/patchmon-agent.backup.*

--- a/server-source-code/internal/agents/patchmon_install.sh
+++ b/server-source-code/internal/agents/patchmon_install.sh
@@ -647,7 +647,7 @@ curl $CURL_FLAGS \
 chmod +x /usr/local/bin/patchmon-agent
 
 # Get the agent version from the binary
-AGENT_VERSION=$(/usr/local/bin/patchmon-agent version 2>/dev/null || echo "Unknown")
+AGENT_VERSION=$(/usr/local/bin/patchmon-agent --version 2>/dev/null || echo "Unknown")
 info "Agent version: $AGENT_VERSION"
 
 # Handle existing log files and create log directory


### PR DESCRIPTION
While running the installation script and reviewing its output, I noticed that it still invoked the legacy version command instead of the supported --version flag.

This PR updates the installation scripts to use --version consistently and aligns the operator guide with the current CLI interface.

Replace the legacy version command with --version in the installation scripts.
Update the operator guide to reflect the correct version check command.

Fixes https://github.com/PatchMon/PatchMon/issues/876