### PR TITLE
feat: Homarr Integration - update documentation and integration references for dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The core of PatchMon - orchestrate updates across your fleet with validation, ap
 
 | Capability | What It Does |
 |---|---|
-| **Integrations** | 33+ integrations including Proxmox LXC auto-enrolment, getHomepage, Ansible and more. |
+| **Integrations** | 33+ integrations including Proxmox LXC auto-enrolment, GetHomepage, Homarr, Ansible and more. |
 | **REST API** | Full `/api/v1` with JWT authentication and interactive Swagger / OpenAPI docs at `/api-docs`. |
 
 ---
@@ -201,7 +201,7 @@ Full documentation at **[patchmon.net/docs](https://patchmon.net/docs)**.
 | Environment variables | [Env vars reference](https://patchmon.net/docs/patchmon-operator-guide#patchmon-environment-variables-reference) |
 | Integration API | [Integration API docs](https://patchmon.net/docs/patchmon-api-integrations-guide#integration-api-documentation) |
 | Proxmox LXC auto-enrolment | [Proxmox guide](https://patchmon.net/docs/patchmon-api-integrations-guide#proxmox-lxc-auto-enrollment-guide) |
-| getHomepage dashboard card | [getHomepage integration](https://patchmon.net/docs/patchmon-api-integrations-guide#gethomepage-dashboard-card) |
+| GetHomepage and Homarr dashboard widgets | [Dashboard widget integration](https://patchmon.net/docs/patchmon-api-integrations-guide#gethomepage-dashboard-card) |
 | Metrics collection | [Metrics info](https://patchmon.net/docs/patchmon-admin-guide#metrics-and-telemetry) |
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ read top-to-bottom and ships as a downloadable PDF on the website:
 | --- | --- |
 | `patchmon-admin-guide.md` | Day-to-day usage for admins/operators in the web UI |
 | `patchmon-operator-guide.md` | Install, configure, OIDC SSO, agent management, troubleshooting |
-| `patchmon-api-integrations-guide.md` | Discord, gethomepage, Ansible, Proxmox auto-enrollment, REST APIs |
+| `patchmon-api-integrations-guide.md` | Discord, GetHomepage, Homarr, Ansible, Proxmox auto-enrollment, REST APIs |
 | `patchmon-release-notes.md` | Version-by-version release notes (auto-built from `server-source-code/internal/handler/release_notes_data/`) |
 | `assets/` | Images referenced by the books |
 

--- a/docs/patchmon-admin-guide.md
+++ b/docs/patchmon-admin-guide.md
@@ -180,7 +180,7 @@ Some items only appear depending on your deployment or your edition. For example
 | Host Groups | `/settings/host-groups` | Organise hosts into groups for policy and visibility | `can_manage_settings` |
 | Agent Updates | `/settings/agent-config` | Global auto-update behaviour, update interval | `can_manage_settings` |
 | Agent Version | `/settings/agent-version` | Check and manage bundled agent binary versions | `can_manage_settings` |
-| API integrations | `/settings/integrations` | Auto-enrolment tokens, Proxmox LXC, getHomepage, etc. | `can_manage_settings` |
+| API integrations | `/settings/integrations` | Auto-enrolment tokens, Proxmox LXC, dashboard widgets, etc. | `can_manage_settings` |
 | AI Terminal | `/settings/ai-terminal` | Configure AI provider for SSH terminal assist (Max tier) | `can_manage_settings` + `ai` module |
 | Server URL | `/settings/server-url` | Protocol, host, and port agents use to connect back | `can_manage_settings` |
 | Environment | `/settings/environment` | Read and edit server environment variables from the UI | `can_manage_settings` |
@@ -289,8 +289,8 @@ See Managing the PatchMon Agent for how agents consume this information.
 
 Auto-enrolment tokens and per-integration API credentials:
 
-- **Auto-enrolment tokens**: one-shot or long-lived tokens that let enrolment scripts register new hosts without a human in the loop. Each token can be scoped to specific host groups and flagged for integrations like Proxmox LXC or getHomepage.
-- **Integration-type tokens**: the scoped token model used by the integration `/api/*` routes, including `gethomepage` for the dashboard widget.
+- **Auto-enrolment tokens**: one-shot or long-lived tokens that let enrolment scripts register new hosts without a human in the loop. Each token can be scoped to specific host groups and flagged for integrations like Proxmox LXC or dashboard widgets.
+- **Integration-type tokens**: the scoped token model used by the integration `/api/*` routes, including the historical `gethomepage` type for GetHomepage and Homarr dashboard widgets.
 
 #### AI Terminal
 

--- a/docs/patchmon-api-integrations-guide.md
+++ b/docs/patchmon-api-integrations-guide.md
@@ -1,16 +1,16 @@
 ---
 title: "PatchMon API & Integrations Guide"
-description: "Discord, gethomepage, Ansible, Proxmox auto-enrollment, plus the Auto-Enrollment and Integration REST APIs with an embedded OpenAPI browser."
+description: "Discord, GetHomepage, Homarr, Ansible, Proxmox auto-enrollment, plus the Auto-Enrollment and Integration REST APIs with an embedded OpenAPI browser."
 ---
 
 # PatchMon API & Integrations Guide
 
-This guide covers PatchMon's third-party integrations (Discord, gethomepage, Ansible, Proxmox LXC auto-enrollment) and the REST APIs exposed by the server (Auto-Enrollment API, Integration API). A live, interactive API browser rendered from the server's OpenAPI spec is embedded in the published version of this book on patchmon.net/docs.
+This guide covers PatchMon's third-party integrations (Discord, GetHomepage, Homarr, Ansible, Proxmox LXC auto-enrollment) and the REST APIs exposed by the server (Auto-Enrollment API, Integration API). A live, interactive API browser rendered from the server's OpenAPI spec is embedded in the published version of this book on patchmon.net/docs.
 
 ## Table of Contents
 
 - [Chapter 1: Discord Notifications](#discord-notifications)
-- [Chapter 2: gethomepage Dashboard Card](#gethomepage-dashboard-card)
+- [Chapter 2: Dashboard Widgets for GetHomepage and Homarr](#gethomepage-dashboard-card)
 - [Chapter 3: Ansible Dynamic Inventory](#ansible-dynamic-inventory)
 - [Chapter 4: Proxmox LXC Auto-Enrollment Guide](#proxmox-lxc-auto-enrollment-guide)
 - [Chapter 5: Auto-Enrollment API Documentation](#auto-enrolment-api-docs)
@@ -327,9 +327,9 @@ The webhook URL encodes the target channel. In Discord, go to server settings �
 
 ---
 
-## Chapter 2: gethomepage Dashboard Card {#gethomepage-dashboard-card}
+## Chapter 2: Dashboard Widgets for GetHomepage and Homarr {#gethomepage-dashboard-card}
 
-PatchMon exposes a dedicated read-only endpoint designed to be consumed by a [GetHomepage](https://gethomepage.dev/) (formerly *Homepage*) `customapi` widget. Drop a PatchMon card into your existing homepage to see total hosts, pending updates, and security updates at a glance.
+PatchMon exposes a dedicated read-only endpoint designed for dashboard widgets. It supports [GetHomepage](https://gethomepage.dev/) (formerly *Homepage*) through a `customapi` widget and Homarr through its PatchMon integration/widget. Add PatchMon to either dashboard to see total hosts, pending updates, security updates, and OS distribution at a glance.
 
 > **Related pages:**
 > - [Integration API Documentation](#integration-api-documentation): the generic scoped API (a different integration type)
@@ -340,10 +340,11 @@ PatchMon exposes a dedicated read-only endpoint designed to be consumed by a [Ge
 ### At a glance
 
 - **Endpoint:** `GET /api/v1/gethomepage/stats`
-- **Auth:** HTTP Basic, using a PatchMon-issued API key dedicated to the GetHomepage integration
-- **Widget type:** [`customapi`](https://gethomepage.dev/widgets/services/customapi/) in GetHomepage
+- **Auth:** HTTP Basic, using a PatchMon-issued dashboard widget API key
+- **GetHomepage widget type:** [`customapi`](https://gethomepage.dev/widgets/services/customapi/)
+- **Homarr widget type:** PatchMon integration + PatchMon widget
 - **Fields available:** 8 core metrics + a top-3 OS breakdown + a full `os_distribution` array
-- **Rate limit:** shares the standard API rate limit; GetHomepage polls every 60 seconds, well within the limit
+- **Rate limit:** shares the standard API rate limit; normal GetHomepage and Homarr polling intervals sit well within the limit
 
 #### Default widget
 
@@ -353,29 +354,29 @@ Out of the box the widget shows three metrics:
 - **Hosts Needing Updates**
 - **Security Updates**
 
-Additional metrics can be added by editing the `mappings:` in your GetHomepage `services.yml`. See [Configuration options](#configuration-options) below.
+GetHomepage users can add metrics by editing the `mappings:` in `services.yml`. Homarr users configure the available stats inside the PatchMon widget options.
 
 ---
 
 ### Prerequisites
 
-- A running PatchMon 2.x instance reachable from the machine running GetHomepage.
-- GetHomepage already installed and rendering at least one page.
-- Network path between GetHomepage and PatchMon on HTTP or HTTPS. HTTPS is strongly recommended.
+- A running PatchMon 2.x instance reachable from the machine running GetHomepage or Homarr.
+- GetHomepage or Homarr already installed and rendering at least one dashboard.
+- Network path between the dashboard app and PatchMon on HTTP or HTTPS. HTTPS is strongly recommended.
 - PatchMon admin access (you need `can_manage_settings` to create API keys).
 
 ---
 
 ### Setup
 
-#### Step 1: Create a GetHomepage API key
+#### Step 1: Create a dashboard widget API key
 
 1. Sign in to PatchMon as an admin.
 2. Go to **Settings → Integrations**.
-3. Open the **GetHomepage** tab.
+3. Open the **Dashboard Widgets** tab.
 4. Click **New API Key** and fill in:
-   - **Token Name**: e.g. `GetHomepage dashboard`.
-   - **Allowed IP Addresses** *(optional)*: restrict to the IP of the machine running GetHomepage.
+   - **Token Name**: e.g. `Homarr dashboard` or `GetHomepage dashboard`.
+   - **Allowed IP Addresses** *(optional)*: restrict to the outbound IP of the machine running the dashboard app.
    - **Expiration Date** *(optional)*: set one if this is a temporary key.
 5. Click **Create Token**.
 
@@ -385,12 +386,28 @@ A success modal is shown with:
 
 - **Token Key**: the API username.
 - **Token Secret**: the API password. **Shown only once. Save it immediately.**
-- **Base64-encoded credentials**: pre-built `Authorization: Basic` value, ready to paste.
-- **Complete widget configuration**: a ready-to-drop-in YAML snippet.
+- **Base64-encoded credentials**: pre-built `Authorization: Basic` value for GetHomepage.
+- **Complete GetHomepage widget configuration**: a ready-to-drop-in YAML snippet.
+- **Homarr configuration values**: the PatchMon URL, API key, and API secret.
 
-> Click **Copy Config** to copy the full YAML block. The secret is never retrievable again after you close this modal. If you lose it, you have to delete the key and create a new one.
+> The secret is never retrievable again after you close this modal. If you lose it, you have to delete the key and create a new one.
 
-#### Step 3: Configure GetHomepage
+#### Step 3A: Configure Homarr
+
+1. In Homarr, add a new **PatchMon** integration.
+2. Set the URL to your PatchMon base URL, for example `https://patchmon.example.com`.
+3. Paste the PatchMon **Token Key** into Homarr's API key field.
+4. Paste the PatchMon **Token Secret** into Homarr's API secret field.
+5. Save the integration and run the connection test.
+6. Add the **PatchMon** widget to a board and choose the stats you want to display.
+
+Homarr handles the Basic authentication header automatically and calls:
+
+```text
+GET https://patchmon.example.com/api/v1/gethomepage/stats
+```
+
+#### Step 3B: Configure GetHomepage
 
 ##### Option A: Paste the copied YAML (quickest)
 
@@ -463,7 +480,7 @@ The YAML looks like this:
 
 #### Customising the fields displayed
 
-The default configuration displays **3 metrics**. You can add more. PatchMon returns **8 numeric metrics** and the top-3 OS breakdown, and the widget supports 6–8 comfortably before it becomes cluttered.
+The default GetHomepage configuration displays **3 metrics**. You can add more. PatchMon returns **8 numeric metrics** and the top-3 OS breakdown. GetHomepage supports 6–8 mappings comfortably before it becomes cluttered, while Homarr exposes its own widget options for choosing stats, thresholds, and OS distribution display.
 
 Each `mappings` entry has two parts:
 
@@ -476,9 +493,9 @@ Each `mappings` entry has two parts:
 |-------|------|-------------|---------------------|
 | `total_hosts` | Number | Total active hosts in PatchMon | Yes |
 | `hosts_needing_updates` | Number | Hosts with at least one outdated package | Yes |
-| `security_updates` | Number | Total security updates available across all hosts | Yes |
+| `security_updates` | Number | Distinct security updates available across active hosts | Yes |
 | `up_to_date_hosts` | Number | Hosts with zero outdated packages | No |
-| `total_outdated_packages` | Number | Sum of all outdated packages across hosts | No |
+| `total_outdated_packages` | Number | Distinct outdated packages across active hosts | No |
 | `hosts_with_security_updates` | Number | Hosts requiring at least one security patch | No |
 | `total_repos` | Number | Active repositories being monitored | No |
 | `recent_updates_24h` | Number | Successful updates in the last 24 hours | No |
@@ -488,7 +505,7 @@ Each `mappings` entry has two parts:
 | `top_os_2_count` | Number | Count of the 2nd most common OS | No |
 | `top_os_3_name` | String | Name of the 3rd most common OS | No |
 | `top_os_3_count` | Number | Count of the 3rd most common OS | No |
-| `os_distribution` | Array | Full OS breakdown (advanced use only; GetHomepage cannot render arrays directly) | No |
+| `os_distribution` | Array | Full OS breakdown (used directly by Homarr; advanced use only in GetHomepage because `customapi` cannot render arrays directly) | No |
 | `last_updated` | String (ISO 8601) | Timestamp the stats were generated | No |
 
 > The `top_os_*_name` string fields render poorly in `customapi` widgets. Use the corresponding `_count` fields and put the OS name in the `label:`. See [Displaying OS distribution](#displaying-os-distribution).
@@ -721,14 +738,16 @@ icon: /icons/patchmon.png
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `GET` | `/api/v1/gethomepage/stats` | Returns the widget payload described above |
+| `GET` | `/api/v1/gethomepage/stats` | Returns the shared dashboard widget payload used by GetHomepage and Homarr |
 | `GET` | `/api/v1/gethomepage/health` | Simple liveness probe. Returns `status: "ok"`, the current timestamp, and the name of the API key used. |
 
 #### Authentication
 
 - **Type:** HTTP Basic Authentication
 - **Format:** `Authorization: Basic <base64(token_key:token_secret)>`
-- **Token type:** `gethomepage` (enforced server-side; a credential created under the **API** tab won't work here, and vice versa)
+- **Token type:** `gethomepage` (the historical internal token type for dashboard widgets; a credential created under the **API** tab won't work here, and vice versa)
+
+Homarr asks for the API key and API secret separately and builds this header for you. GetHomepage expects you to provide the already-encoded `Authorization` header in `services.yml`.
 
 #### Stats response
 
@@ -763,7 +782,7 @@ icon: /icons/patchmon.png
 {
   "status": "ok",
   "timestamp": "2026-04-24T12:34:56Z",
-  "api_key": "GetHomepage dashboard"
+  "api_key": "Homarr dashboard"
 }
 ```
 
@@ -773,7 +792,7 @@ icon: /icons/patchmon.png
 
 #### Viewing existing keys
 
-Go to **Settings → Integrations → GetHomepage**. For each key you see:
+Go to **Settings → Integrations → Dashboard Widgets**. For each key you see:
 
 - Token name
 - Creation date
@@ -799,18 +818,19 @@ Go to **Settings → Integrations → GetHomepage**. For each key you see:
 
 #### Error: "Missing or invalid authorization header"
 
-GetHomepage is not sending the `Authorization` header correctly.
+The dashboard app is not sending the `Authorization` header correctly.
 
-- Verify the `headers:` section is properly indented in `services.yml`.
-- Re-encode the credentials; make sure you used `-n` with `echo` so no trailing newline ends up in the base64.
-- Confirm you're using `type: customapi`, as other widget types ignore arbitrary headers.
+- For GetHomepage, verify the `headers:` section is properly indented in `services.yml`.
+- For GetHomepage, re-encode the credentials; make sure you used `-n` with `echo` so no trailing newline ends up in the base64.
+- For GetHomepage, confirm you're using `type: customapi`, as other widget types ignore arbitrary headers.
+- For Homarr, verify the PatchMon integration has the Token Key in the API key field and the Token Secret in the API secret field.
 
 #### Error: "Invalid API key"
 
 The key does not exist in PatchMon.
 
-- Check **Settings → Integrations → GetHomepage** for the key.
-- Re-create the key if it's missing, update the GetHomepage config with the new credentials.
+- Check **Settings → Integrations → Dashboard Widgets** for the key.
+- Re-create the key if it's missing, then update Homarr or GetHomepage with the new credentials.
 
 #### Error: "API key is disabled" / "API key has expired"
 
@@ -818,18 +838,19 @@ Enable the key, or create a new one with a later expiration.
 
 #### Error: "IP address not allowed"
 
-Your GetHomepage instance's outbound IP is not in the credential's allowlist. Either add it, or remove the allowlist if not needed.
+Your dashboard app's outbound IP is not in the credential's allowlist. Either add it, or remove the allowlist if not needed.
 
 #### Widget shows nothing
 
 Work through this checklist:
 
-- Can GetHomepage reach PatchMon at all? Test with `curl` from inside the GetHomepage container: `curl -v https://patchmon.example.com/api/v1/gethomepage/health -H "Authorization: Basic ..."`
+- Can the dashboard app reach PatchMon at all? Test with `curl` from inside the Homarr or GetHomepage container: `curl -v https://patchmon.example.com/api/v1/gethomepage/health -H "Authorization: Basic ..."`
 - Is the API key active and not expired?
-- Is the base64 credential correct?
-- Is `services.yml` valid YAML? (run `yamllint services.yml` if unsure)
-- Has GetHomepage been restarted since the last change?
-- Check GetHomepage's container logs for error messages.
+- For GetHomepage, is the base64 credential correct?
+- For GetHomepage, is `services.yml` valid YAML? (run `yamllint services.yml` if unsure)
+- For GetHomepage, has the container or service been restarted since the last change?
+- For Homarr, did the PatchMon integration connection test pass before adding the widget?
+- Check the dashboard app's logs for error messages.
 
 #### Testing the endpoint directly
 
@@ -848,12 +869,12 @@ Every numeric field in the response (including `top_os_*_count`) can be used in 
 
 ### Security best practices
 
-- **Always use HTTPS.** The credentials are sent on every 60-second poll. Don't put them on the wire in the clear.
-- **IP-restrict the key** to the GetHomepage instance's IP.
+- **Always use HTTPS.** The credentials are sent on dashboard widget requests. Don't put them on the wire in the clear.
+- **IP-restrict the key** to the dashboard app's outbound IP.
 - **Give the key an expiration** and rotate it as part of your normal credential rotation.
 - **Monitor the last-used timestamp** to spot suspicious activity.
-- **One key per GetHomepage instance** if you're running several, to make rotation and revocation easier.
-- **Store `services.yml` with appropriate file permissions** on the GetHomepage host.
+- **One key per dashboard instance** if you're running several, to make rotation and revocation easier.
+- **Store dashboard configuration securely**, including Homarr secrets and GetHomepage `services.yml`.
 
 ---
 
@@ -861,11 +882,11 @@ Every numeric field in the response (including `top_os_*_count`) can be used in 
 
 ```
 ┌──────────────────┐
-│   GetHomepage    │
-│    Dashboard     │
+│ GetHomepage or   │
+│ Homarr Dashboard │
 └────────┬─────────┘
          │
-         │ HTTP(S) GET, every 60s
+         │ HTTP(S) GET widget request
          │ Authorization: Basic <base64>
          │
          ▼
@@ -895,7 +916,7 @@ Every numeric field in the response (including `top_os_*_count`) can be used in 
 
 ### Rate limiting
 
-The `/api/v1/gethomepage/*` endpoints are subject to PatchMon's general API rate limit of 100 requests per 15 minutes per IP by default. GetHomepage's default poll interval of 60 seconds sits well within this limit (15 requests per 15 minutes). If you lower GetHomepage's poll interval aggressively, you may start hitting `429 Too Many Requests`; stay above 10 seconds.
+The `/api/v1/gethomepage/*` endpoints are subject to PatchMon's general API rate limit of 100 requests per 15 minutes per IP by default. GetHomepage's default poll interval of 60 seconds and Homarr's cached widget requests sit well within this limit. If you lower polling intervals aggressively, you may start hitting `429 Too Many Requests`; stay above 10 seconds.
 
 ---
 
@@ -903,6 +924,7 @@ The `/api/v1/gethomepage/*` endpoints are subject to PatchMon's general API rate
 
 - **PatchMon documentation:** [patchmon.net/docs](https://patchmon.net/docs)
 - **GetHomepage documentation:** [gethomepage.dev](https://gethomepage.dev)
+- **Homarr documentation:** [homarr.dev](https://homarr.dev)
 - **PatchMon Discord:** [patchmon.net/discord](https://patchmon.net/discord)
 - **GitHub issues:** [github.com/PatchMon/PatchMon/issues](https://github.com/PatchMon/PatchMon/issues)
 

--- a/frontend/src/constants/tiers.js
+++ b/frontend/src/constants/tiers.js
@@ -55,7 +55,7 @@ export const TIER_FEATURES = [
 		max: true,
 	},
 	{
-		label: "Host groups, dashboards, search, Gethomepage",
+		label: "Host groups, dashboards, search, GetHomepage, Homarr",
 		starter: true,
 		plus: true,
 		max: true,

--- a/frontend/src/pages/settings/Integrations.jsx
+++ b/frontend/src/pages/settings/Integrations.jsx
@@ -532,7 +532,7 @@ const Integrations = () => {
 								: "bg-secondary-50 dark:bg-secondary-700 text-secondary-700 dark:text-white border border-secondary-200 dark:border-secondary-600 hover:bg-secondary-100 dark:hover:bg-secondary-600"
 						}`}
 					>
-						<span>GetHomepage</span>
+						<span>Dashboard Widgets</span>
 						{activeTab === "gethomepage" && (
 							<CheckCircle className="h-5 w-5 text-primary-600 dark:text-primary-400" />
 						)}
@@ -612,7 +612,7 @@ const Integrations = () => {
 									: "text-secondary-500 dark:text-white hover:text-secondary-700 dark:hover:text-secondary-300 hover:bg-secondary-50 dark:hover:bg-secondary-700/50"
 							}`}
 						>
-							GetHomepage
+							Dashboard Widgets
 						</button>
 						<button
 							type="button"
@@ -1289,7 +1289,7 @@ const Integrations = () => {
 						</div>
 					)}
 
-					{/* GetHomepage Tab */}
+					{/* Dashboard Widgets Tab */}
 					{activeTab === "gethomepage" && (
 						<div className="space-y-6">
 							{/* Header with New API Key Button */}
@@ -1300,11 +1300,11 @@ const Integrations = () => {
 									</div>
 									<div className="min-w-0">
 										<h3 className="text-base md:text-lg font-semibold text-secondary-900 dark:text-white">
-											GetHomepage Widget Integration
+											Dashboard Widget Integrations
 										</h3>
 										<p className="text-xs md:text-sm text-secondary-600 dark:text-white">
 											Create API keys to display PatchMon statistics in your
-											GetHomepage dashboard
+											GetHomepage or Homarr dashboard
 										</p>
 									</div>
 								</div>
@@ -1327,9 +1327,9 @@ const Integrations = () => {
 									(token) => token.metadata?.integration_type === "gethomepage",
 								).length === 0 ? (
 								<div className="text-center py-8 text-secondary-600 dark:text-white">
-									<p>No GetHomepage API keys created yet.</p>
+									<p>No dashboard widget API keys created yet.</p>
 									<p className="text-sm mt-2">
-										Create an API key to enable GetHomepage widget integration.
+										Create an API key to enable GetHomepage or Homarr widgets.
 									</p>
 								</div>
 							) : (
@@ -1351,7 +1351,7 @@ const Integrations = () => {
 																{token.token_name}
 															</h4>
 															<span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200">
-																GetHomepage
+																Dashboard Widget
 															</span>
 															{token.is_active ? (
 																<span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
@@ -1437,7 +1437,7 @@ const Integrations = () => {
 							<div className="bg-primary-50 dark:bg-primary-900/20 border border-primary-200 dark:border-primary-800 rounded-lg p-4 md:p-6">
 								<div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-4">
 									<h3 className="text-base md:text-lg font-semibold text-primary-900 dark:text-primary-200">
-										How to Use GetHomepage Integration
+										How to Use Dashboard Widget Integrations
 									</h3>
 									<a
 										href="https://patchmon.net/docs/patchmon-api-integrations-guide#gethomepage-dashboard-card"
@@ -1453,15 +1453,36 @@ const Integrations = () => {
 									<li>Create a new API key using the button above</li>
 									<li>Copy the API key and secret from the success dialog</li>
 									<li>
-										Add the following widget configuration to your GetHomepage{" "}
-										<code className="bg-primary-100 dark:bg-primary-900/40 px-1 py-0.5 rounded text-xs">
-											services.yml
-										</code>{" "}
-										file:
+										Use the key and secret in Homarr, or paste the YAML into
+										GetHomepage.
 									</li>
 								</ol>
 
 								<div className="mt-4 p-3 bg-primary-100 dark:bg-primary-900/40 rounded border border-primary-200 dark:border-primary-700">
+									<h4 className="text-sm font-semibold text-primary-900 dark:text-primary-200 mb-2">
+										Homarr setup
+									</h4>
+									<ol className="list-decimal list-inside space-y-1 text-xs text-primary-800 dark:text-primary-300">
+										<li>Add a PatchMon integration in Homarr.</li>
+										<li>
+											Set the URL to{" "}
+											<code className="bg-primary-50 dark:bg-primary-900/60 px-1 rounded">
+												{server_url}
+											</code>
+											.
+										</li>
+										<li>
+											Paste the API key as the username and the API secret as
+											the password.
+										</li>
+										<li>Add the PatchMon widget to a Homarr board.</li>
+									</ol>
+								</div>
+
+								<div className="mt-4 p-3 bg-primary-100 dark:bg-primary-900/40 rounded border border-primary-200 dark:border-primary-700">
+									<h4 className="text-sm font-semibold text-primary-900 dark:text-primary-200 mb-2">
+										GetHomepage customapi setup
+									</h4>
 									<pre className="text-xs text-primary-800 dark:text-primary-300 whitespace-pre-wrap overflow-x-auto font-mono">
 										{`- PatchMon:
     href: ${server_url}
@@ -1473,11 +1494,11 @@ const Integrations = () => {
       headers:
         Authorization: Basic BASE64_ENCODED_CREDENTIALS
       mappings:
-       - field: total_hosts
+        - field: total_hosts
           label: Total Hosts
-       - field: hosts_needing_updates
+        - field: hosts_needing_updates
           label: Needs Updates
-       - field: security_updates
+        - field: security_updates
           label: Security Updates`}
 									</pre>
 								</div>
@@ -1769,7 +1790,7 @@ const Integrations = () => {
 							<div className="flex items-center justify-between mb-4">
 								<h2 className="text-lg md:text-xl font-bold text-secondary-900 dark:text-white">
 									{activeTab === "gethomepage"
-										? "Create GetHomepage API Key"
+										? "Create Dashboard Widget API Key"
 										: activeTab === "proxmox"
 											? "Create Proxmox Token"
 											: activeTab === "auto-enrollment-direct"
@@ -1805,7 +1826,7 @@ const Integrations = () => {
 										}
 										placeholder={
 											activeTab === "gethomepage"
-												? "e.g., GetHomepage Widget"
+												? "e.g., Homarr Dashboard"
 												: activeTab === "proxmox"
 													? "e.g., Proxmox Production"
 													: activeTab === "auto-enrollment-direct"
@@ -1992,7 +2013,7 @@ const Integrations = () => {
 									<h2 className="text-base md:text-lg font-bold text-secondary-900 dark:text-white truncate">
 										{new_token.metadata?.integration_type === "gethomepage" ||
 										activeTab === "gethomepage"
-											? "API Key Created Successfully"
+											? "Dashboard Widget API Key Created Successfully"
 											: new_token.metadata?.integration_type === "api" ||
 													activeTab === "scoped-credentials"
 												? "API Credential Created Successfully"
@@ -2366,12 +2387,37 @@ const Integrations = () => {
 								{(new_token.metadata?.integration_type === "gethomepage" ||
 									activeTab === "gethomepage") && (
 									<div className="mt-3 space-y-3">
+										<div className="p-3 bg-primary-50 dark:bg-primary-900/20 border border-primary-200 dark:border-primary-800 rounded">
+											<h3 className="text-sm font-semibold text-primary-900 dark:text-primary-200 mb-2">
+												Homarr configuration
+											</h3>
+											<div className="space-y-1 text-xs text-primary-800 dark:text-primary-300">
+												<p>
+													<strong>URL:</strong>{" "}
+													<code className="bg-primary-100 dark:bg-primary-900/40 px-1 rounded">
+														{server_url}
+													</code>
+												</p>
+												<p>
+													<strong>API key:</strong> use the Token Key above.
+												</p>
+												<p>
+													<strong>API secret:</strong> use the Token Secret
+													above.
+												</p>
+												<p>
+													Homarr handles the Basic authentication header
+													automatically.
+												</p>
+											</div>
+										</div>
+
 										<div>
 											<label
 												htmlFor={token_base64_id}
 												className="block text-xs font-medium text-secondary-700 dark:text-white mb-1"
 											>
-												Base64 Encoded Credentials
+												Base64 Encoded Credentials for GetHomepage
 											</label>
 											<div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2">
 												<input
@@ -2429,11 +2475,11 @@ const Integrations = () => {
       headers:
         Authorization: Basic ${base64Creds}
       mappings:
-       - field: total_hosts
+        - field: total_hosts
           label: Total Hosts
-       - field: hosts_needing_updates
+        - field: hosts_needing_updates
           label: Needs Updates
-       - field: security_updates
+        - field: security_updates
           label: Security Updates`;
 														copy_to_clipboard(config, "gethomepage-config");
 													}}
@@ -2468,11 +2514,11 @@ const Integrations = () => {
       headers:
         Authorization: Basic ${base64Creds}
       mappings:
-       - field: total_hosts
+        - field: total_hosts
           label: Total Hosts
-       - field: hosts_needing_updates
+        - field: hosts_needing_updates
           label: Needs Updates
-       - field: security_updates
+        - field: security_updates
           label: Security Updates`;
 												})()}
 												readOnly
@@ -2480,7 +2526,7 @@ const Integrations = () => {
 												className="w-full px-3 py-2 border border-secondary-300 dark:border-secondary-600 rounded-md bg-secondary-50 dark:bg-secondary-900 text-secondary-900 dark:text-white font-mono text-xs resize-none"
 											/>
 											<p className="text-xs text-secondary-500 dark:text-white mt-1">
-												💡 Paste into your GetHomepage{" "}
+												Tip: Paste into your GetHomepage{" "}
 												<code className="bg-secondary-100 dark:bg-secondary-700 px-1 rounded">
 													services.yml
 												</code>

--- a/server-source-code/internal/db/dashboard.sql.go
+++ b/server-source-code/internal/db/dashboard.sql.go
@@ -113,8 +113,9 @@ package_counts AS (
     SELECT
         COUNT(DISTINCT package_id)::int AS total_outdated,
         COUNT(DISTINCT package_id) FILTER (WHERE is_security_update)::int AS security_updates
-    FROM host_packages
-    WHERE needs_update = true
+    FROM host_packages hp
+    JOIN active_hosts ah ON ah.id = hp.host_id
+    WHERE hp.needs_update = true
 )
 SELECT
     hc.total_hosts,
@@ -123,7 +124,10 @@ SELECT
     pc.security_updates AS security_updates,
     hws.cnt AS hosts_with_security_updates,
     (SELECT COUNT(*)::int FROM repositories WHERE is_active = true) AS total_repos,
-    (SELECT COUNT(*)::int FROM update_history WHERE timestamp >= $1 AND status = 'success') AS recent_updates_24h
+    (SELECT COUNT(*)::int
+     FROM update_history uh
+     JOIN active_hosts ah ON ah.id = uh.host_id
+     WHERE uh.timestamp >= $1 AND uh.status = 'success') AS recent_updates_24h
 FROM host_counts hc
 CROSS JOIN hosts_needing_updates hnu
 CROSS JOIN hosts_with_security hws

--- a/server-source-code/internal/handler/gethomepage.go
+++ b/server-source-code/internal/handler/gethomepage.go
@@ -18,7 +18,7 @@ func NewGetHomepageHandler(dashboard *store.DashboardStore) *GetHomepageHandler 
 	return &GetHomepageHandler{dashboard: dashboard}
 }
 
-// Stats handles GET /gethomepage/stats. Returns widget statistics for GetHomepage dashboard.
+// Stats handles GET /gethomepage/stats. Returns shared dashboard widget statistics.
 func (h *GetHomepageHandler) Stats(w http.ResponseWriter, r *http.Request) {
 	stats, err := h.dashboard.GetHomepageStats(r.Context())
 	if err != nil {

--- a/server-source-code/internal/server/router.go
+++ b/server-source-code/internal/server/router.go
@@ -379,9 +379,9 @@ func NewRouter(ctx context.Context, cfg *config.Config, db *database.DB, rdb *re
 			r.With(middleware.RequireApiScope("host", "delete")).Delete("/hosts/{id}", apiHostsHandler.DeleteHost)
 		})
 
-		// GetHomepage widget API (Basic Auth with auto_enrollment_tokens, integration_type "gethomepage")
+		// Dashboard widget API (Basic Auth with auto_enrollment_tokens, integration_type "gethomepage")
 		gethomepageHandler := handler.NewGetHomepageHandler(dashboardStore)
-		r.Route("/gethomepage", func(r chi.Router) {
+		r.With(middleware.RateLimit(redisResolver, resolved, middleware.RateLimitGeneral)).Route("/gethomepage", func(r chi.Router) {
 			r.Use(middleware.ApiAuthForIntegration(autoEnrollmentStore, "gethomepage", log))
 			r.Get("/stats", gethomepageHandler.Stats)
 			r.Get("/health", gethomepageHandler.Health)

--- a/server-source-code/internal/sqlc/queries/dashboard.sql
+++ b/server-source-code/internal/sqlc/queries/dashboard.sql
@@ -164,8 +164,9 @@ package_counts AS (
     SELECT
         COUNT(DISTINCT package_id)::int AS total_outdated,
         COUNT(DISTINCT package_id) FILTER (WHERE is_security_update)::int AS security_updates
-    FROM host_packages
-    WHERE needs_update = true
+    FROM host_packages hp
+    JOIN active_hosts ah ON ah.id = hp.host_id
+    WHERE hp.needs_update = true
 )
 SELECT
     hc.total_hosts,
@@ -174,7 +175,10 @@ SELECT
     pc.security_updates AS security_updates,
     hws.cnt AS hosts_with_security_updates,
     (SELECT COUNT(*)::int FROM repositories WHERE is_active = true) AS total_repos,
-    (SELECT COUNT(*)::int FROM update_history WHERE timestamp >= sqlc.arg('since') AND status = 'success') AS recent_updates_24h
+    (SELECT COUNT(*)::int
+     FROM update_history uh
+     JOIN active_hosts ah ON ah.id = uh.host_id
+     WHERE uh.timestamp >= sqlc.arg('since') AND uh.status = 'success') AS recent_updates_24h
 FROM host_counts hc
 CROSS JOIN hosts_needing_updates hnu
 CROSS JOIN hosts_with_security hws

--- a/server-source-code/internal/store/dashboard.go
+++ b/server-source-code/internal/store/dashboard.go
@@ -126,7 +126,7 @@ func (s *DashboardStore) GetStats(ctx context.Context) (map[string]interface{}, 
 	}, nil
 }
 
-// GetHomepageStats returns statistics for the GetHomepage widget (matches Node backend structure).
+// GetHomepageStats returns statistics for dashboard widgets using the legacy GetHomepage-compatible contract.
 func (s *DashboardStore) GetHomepageStats(ctx context.Context) (map[string]interface{}, error) {
 	d := s.db.DB(ctx)
 	now := time.Now()

--- a/server-source-code/internal/swagger/openapi.json
+++ b/server-source-code/internal/swagger/openapi.json
@@ -3,7 +3,7 @@
 	"info": {
 		"title": "PatchMon Integration API",
 		"version": "1.0.0",
-		"description": "PatchMon API documentation for integrations. Covers scoped credentials, GetHomepage widget, agent endpoints, and auto-enrollment. For full application documentation, see: https://patchmon.net/docs/patchmon-api-integrations-guide#integration-api-documentation"
+		"description": "PatchMon API documentation for integrations. Covers scoped credentials, GetHomepage and Homarr dashboard widgets, agent endpoints, and auto-enrollment. For full application documentation, see: https://patchmon.net/docs/patchmon-api-integrations-guide#integration-api-documentation"
 	},
 	"servers": [
 		{
@@ -16,7 +16,7 @@
 			"basicAuth": {
 				"type": "http",
 				"scheme": "basic",
-				"description": "Basic Auth using API credentials (token_key:token_secret). Used for Scoped API and GetHomepage endpoints."
+				"description": "Basic Auth using API credentials (token_key:token_secret). Used for Scoped API and dashboard widget endpoints."
 			},
 			"apiKeyAuth": {
 				"type": "apiKey",
@@ -50,8 +50,8 @@
 			"description": "Endpoints using scoped credentials (Basic Auth, integration_type api)"
 		},
 		{
-			"name": "GetHomepage",
-			"description": "Widget statistics for GetHomepage dashboard (Basic Auth, integration_type gethomepage)"
+			"name": "Dashboard Widgets",
+			"description": "Widget statistics for GetHomepage and Homarr dashboards (Basic Auth, integration_type gethomepage)"
 		},
 		{
 			"name": "Agent / Install",
@@ -815,9 +815,9 @@
 		},
 		"/gethomepage/stats": {
 			"get": {
-				"tags": ["GetHomepage"],
-				"summary": "Get homepage widget statistics",
-				"description": "Returns widget statistics for GetHomepage dashboard (total hosts, outdated packages, security updates, OS distribution, etc.). Requires Basic Auth with GetHomepage credentials.",
+				"tags": ["Dashboard Widgets"],
+				"summary": "Get dashboard widget statistics",
+				"description": "Returns shared widget statistics for GetHomepage and Homarr dashboards (total hosts, outdated packages, security updates, OS distribution, etc.). Requires Basic Auth with dashboard widget credentials.",
 				"security": [{ "basicAuth": [] }],
 				"responses": {
 					"200": {
@@ -874,9 +874,9 @@
 		},
 		"/gethomepage/health": {
 			"get": {
-				"tags": ["GetHomepage"],
-				"summary": "GetHomepage health check",
-				"description": "Simple health check for the GetHomepage API. Requires Basic Auth with GetHomepage credentials.",
+				"tags": ["Dashboard Widgets"],
+				"summary": "Dashboard widget health check",
+				"description": "Simple health check for the dashboard widget API used by GetHomepage and Homarr. Requires Basic Auth with dashboard widget credentials.",
 				"security": [{ "basicAuth": [] }],
 				"responses": {
 					"200": {
@@ -887,7 +887,7 @@
 								"example": {
 									"status": "ok",
 									"timestamp": "2025-03-01T12:00:00Z",
-									"api_key": "GetHomepage Widget"
+									"api_key": "Homarr Dashboard"
 								}
 							}
 						}


### PR DESCRIPTION
Updates to PatchMon to show support for Homarr -- see https://github.com/homarr-labs/homarr/pull/6119

The integration from Homarr is mostly complete.  It works using the existing PatchMon API used by GetHomepage without code changes.  This is to merely show the steps and process needed both in the UI and documentation.

- Enhanced README and integration guides to include Homarr alongside GetHomepage.
- Updated terminology in the admin and API integration guides to reflect the new dashboard widget capabilities.
- Adjusted API endpoint descriptions and comments to clarify usage for both GetHomepage and Homarr.
- Modified frontend components to replace "GetHomepage" with "Dashboard Widgets" for consistency across the application.
- Updated a couple dashboard queries to align with existing patterns.

Did NOT create a new endpoint, reused the existing API.

## AI Disclosure

- **Used AI:** yes
- **Model(s):** Unknown?
- **Harness / tool:** Cursor
- **Scope:** code (cleaned a couple SQL queries), docs, partial PR
- **Human review completed:** yes, @mrjoshuap in local development -- verbiage, rendering, links and doc reviews

## Screenshots

### PatchMon

<img width="1783" height="1361" alt="Screenshot 2026-07-03 at 17 04 50" src="https://github.com/user-attachments/assets/2b8fc904-c483-4fba-873f-3082bb97d7ca" />

### Homarr

Light Mode:
<img width="1763" height="1302" alt="homarr-screenshot" src="https://github.com/user-attachments/assets/15368693-8715-4b97-953b-3cea6e862b1e" />

Dark Mode:
<img width="1773" height="1303" alt="homarr-screenshot-dark" src="https://github.com/user-attachments/assets/0d8d8dcd-920e-4e1d-97ee-8052d431246c" />

Additional screenshots available on the Homarr PR.