### PR TITLE
feat(patching): use only-upgrade for apt

### DIFF
--- a/agent-source-code/cmd/patchmon-agent/commands/serve.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/serve.go
@@ -2380,13 +2380,13 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 			switch pkgManager {
 			case "apt":
 				if dryRun {
-					args := append([]string{"-s", "install"}, packageNames...)
-					if err, abort := runStep(false, "apt-get -s install", "apt-get -s install failed: %w", "apt-get", args...); abort {
+					args := append([]string{"-s", "--only-upgrade", "install"}, packageNames...)
+					if err, abort := runStep(false, "apt-get -s --only-upgrade install", "apt-get -s --only-upgrade install failed: %w", "apt-get", args...); abort {
 						stepErr = err
 					}
 				} else {
-					args := append([]string{"install", "-y"}, packageNames...)
-					if err, abort := runStep(false, "apt-get install", "apt-get install failed: %w", "apt-get", args...); abort {
+					args := append([]string{"--only-upgrade", "install", "-y"}, packageNames...)
+					if err, abort := runStep(false, "apt-get --only-upgrade install", "apt-get --only-upgrade install failed: %w", "apt-get", args...); abort {
 						stepErr = err
 					}
 				}


### PR DESCRIPTION
## Summary

Use `--only-upgrade` flage to only install upgradable packages. This prevents packages from being installed that were not already installed on the system.

Using the `--only-upgrade` flag ensures that packages are only installed if they are already present on the system. This helps to rule out timing issues.

Examples of such issues:
A package is included in a task as an upgrade. The task is marked for approval and gets approved and released the following day. In the meantime, the package is removed from the system (for various reasons). Using `--only-upgrade` now prevents it from being reinstalled by patchmon, thereby avoiding an inconsistent system state.

## AI Disclosure

No AI used.