### PR TITLE
fix(agent): don't parse subscription-manager messages as packages

### DIFF
--- a/agent-source-code/internal/packages/dnf.go
+++ b/agent-source-code/internal/packages/dnf.go
@@ -24,6 +24,45 @@ func NewDNFManager(logger *logrus.Logger) *DNFManager {
 	}
 }
 
+// knownArchitectures lists RPM architecture suffixes used to recognise
+// "name.arch" package identifiers in dnf/yum output.
+var knownArchitectures = map[string]bool{
+	"x86_64":  true,
+	"i686":    true,
+	"i386":    true,
+	"noarch":  true,
+	"aarch64": true,
+	"arm64":   true,
+	"armv7hl": true,
+	"ppc64":   true,
+	"ppc64le": true,
+	"s390x":   true,
+	"riscv64": true,
+	"src":     true,
+}
+
+// stripArchSuffix removes a trailing ".arch" from a package string when the
+// suffix is a known RPM architecture, e.g. "kernel.x86_64" -> "kernel".
+func stripArchSuffix(packageString string) string {
+	if idx := strings.LastIndex(packageString, "."); idx > 0 && knownArchitectures[packageString[idx+1:]] {
+		return packageString[:idx]
+	}
+	return packageString
+}
+
+// isPackageLine reports whether the fields of a "dnf list" / "dnf check-update"
+// output line describe a package. Package lines always start with "name.arch";
+// informational messages that plugins print to stdout do not. Without this
+// check, subscription-manager output such as "This system is not registered
+// with an entitlement server..." is parsed as a package named "This".
+func isPackageLine(fields []string) bool {
+	if len(fields) < 3 {
+		return false
+	}
+	name := fields[0]
+	return name != stripArchSuffix(name)
+}
+
 // detectPackageManager detects whether to use dnf or yum
 func (m *DNFManager) detectPackageManager() string {
 	// Prefer dnf over yum for modern RHEL-based systems
@@ -265,15 +304,7 @@ func (m *DNFManager) getSecurityPackages(packageManager string) map[string]bool 
 // - package-name.arch (from check-update)
 func (m *DNFManager) extractBasePackageName(packageString string) string {
 	// Remove architecture suffix first (e.g., .x86_64, .noarch)
-	baseName := packageString
-	if idx := strings.LastIndex(packageString, "."); idx > 0 {
-		archSuffix := packageString[idx+1:]
-		// Check if it's a known architecture
-		if archSuffix == "x86_64" || archSuffix == "i686" || archSuffix == "i386" ||
-			archSuffix == "noarch" || archSuffix == "aarch64" || archSuffix == "arm64" {
-			baseName = packageString[:idx]
-		}
-	}
+	baseName := stripArchSuffix(packageString)
 
 	// If the base name contains a version pattern (starts with a digit after a dash),
 	// extract just the package name part
@@ -309,7 +340,7 @@ func (m *DNFManager) parseUpgradablePackages(output string, packageManager strin
 		}
 
 		fields := slices.Collect(strings.FieldsSeq(line))
-		if len(fields) < 3 {
+		if !isPackageLine(fields) {
 			continue
 		}
 
@@ -328,33 +359,18 @@ func (m *DNFManager) parseUpgradablePackages(output string, packageManager strin
 		// or if packageName is "package.x86_64" but installed has "package"
 		if currentVersion == "" {
 			// Try to find by removing architecture suffix from packageName (if present)
-			basePackageName := packageName
-			if idx := strings.LastIndex(packageName, "."); idx > 0 {
-				archSuffix := packageName[idx+1:]
-				if archSuffix == "x86_64" || archSuffix == "i686" || archSuffix == "i386" ||
-					archSuffix == "noarch" || archSuffix == "aarch64" || archSuffix == "arm64" {
-					basePackageName = packageName[:idx]
-					if p, ok := installedPackages[basePackageName]; ok {
-						currentVersion = p.CurrentVersion
-					}
+			basePackageName := stripArchSuffix(packageName)
+			if basePackageName != packageName {
+				if p, ok := installedPackages[basePackageName]; ok {
+					currentVersion = p.CurrentVersion
 				}
 			}
 
 			// If still not found, search through installed packages for matching base name
 			if currentVersion == "" {
 				for installedName, p := range installedPackages {
-					// Remove architecture suffix if present (e.g., .x86_64, .noarch, .i686)
-					baseName := installedName
-					if idx := strings.LastIndex(installedName, "."); idx > 0 {
-						// Check if the part after the last dot looks like an architecture
-						archSuffix := installedName[idx+1:]
-						if archSuffix == "x86_64" || archSuffix == "i686" || archSuffix == "i386" ||
-							archSuffix == "noarch" || archSuffix == "aarch64" || archSuffix == "arm64" {
-							baseName = installedName[:idx]
-						}
-					}
-
 					// Compare base names (handles both cases: package vs package.x86_64)
+					baseName := stripArchSuffix(installedName)
 					if baseName == basePackageName || baseName == packageName {
 						currentVersion = p.CurrentVersion
 						break
@@ -377,7 +393,7 @@ func (m *DNFManager) parseUpgradablePackages(output string, packageManager strin
 				for _, currentLine := range strings.Split(string(getCurrentOutput), "\n") {
 					if strings.Contains(currentLine, packageName) && !strings.Contains(currentLine, "Installed") && !strings.Contains(currentLine, "Available") {
 						currentFields := slices.Collect(strings.FieldsSeq(currentLine))
-						if len(currentFields) >= 2 {
+						if isPackageLine(currentFields) {
 							currentVersion = currentFields[1]
 							break
 						}
@@ -434,8 +450,8 @@ func (m *DNFManager) parseInstalledPackages(output string) map[string]models.Pac
 		parts := strings.Fields(trimmed)
 
 		// Normal single-line format: "name.arch  version  repo"
-		if len(parts) >= 3 {
-			packageName := strings.Split(parts[0], ".")[0] // strip arch suffix
+		if isPackageLine(parts) {
+			packageName := stripArchSuffix(parts[0])
 			version := parts[1]
 			installedPackages[packageName] = models.Package{
 				Name:           packageName,
@@ -448,10 +464,11 @@ func (m *DNFManager) parseInstalledPackages(output string) map[string]models.Pac
 
 		// Wrapped format, line 1: just the package name (no version/repo yet).
 		// Detect by checking the original line starts without leading whitespace
-		// and the trimmed text has no spaces (single token).
-		if len(parts) == 1 && !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "\t") {
+		// and the trimmed text is a single "name.arch" token.
+		if len(parts) == 1 && parts[0] != stripArchSuffix(parts[0]) &&
+			!strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "\t") {
 			// Looks like a bare package name line - remember it
-			pendingName = strings.Split(parts[0], ".")[0]
+			pendingName = stripArchSuffix(parts[0])
 			continue
 		}
 

--- a/agent-source-code/internal/packages/dnf_test.go
+++ b/agent-source-code/internal/packages/dnf_test.go
@@ -41,6 +41,54 @@ bash.x86_64                          5.1.8-6.el9_1                        @baseo
 			input:    "",
 			expected: map[string]models.Package{},
 		},
+		{
+			name: "subscription-manager messages are not packages (issue #864)",
+			input: `Updating Subscription Management repositories.
+Unable to read consumer identity
+
+This system is not registered with an entitlement server. You can use subscription-manager to register.
+
+Installed Packages
+bash.x86_64                          5.1.8-6.el9_1                        @baseos`,
+			expected: map[string]models.Package{
+				"bash": {
+					Name:           "bash",
+					CurrentVersion: "5.1.8-6.el9_1",
+					NeedsUpdate:    false,
+				},
+			},
+		},
+		{
+			name: "package name containing dots keeps full name",
+			input: `Installed Packages
+python3.11.x86_64                    3.11.9-7.el9_5.2                     @appstream`,
+			expected: map[string]models.Package{
+				"python3.11": {
+					Name:           "python3.11",
+					CurrentVersion: "3.11.9-7.el9_5.2",
+					NeedsUpdate:    false,
+				},
+			},
+		},
+		{
+			name: "wrapped long package name (legacy yum)",
+			input: `Installed Packages
+NetworkManager-config-server.noarch
+                                     1:1.18.8-2.el7_9                     @updates
+bash.x86_64                          4.2.46-35.el7_9                      @updates`,
+			expected: map[string]models.Package{
+				"NetworkManager-config-server": {
+					Name:           "NetworkManager-config-server",
+					CurrentVersion: "1:1.18.8-2.el7_9",
+					NeedsUpdate:    false,
+				},
+				"bash": {
+					Name:           "bash",
+					CurrentVersion: "4.2.46-35.el7_9",
+					NeedsUpdate:    false,
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -85,6 +133,31 @@ systemd.x86_64                    252-14.el9_2.2                  baseos`,
 			},
 			expected:         2,
 			expectedSecurity: 1,
+		},
+		{
+			name: "subscription-manager messages are not upgradable packages (issue #864)",
+			input: `Updating Subscription Management repositories.
+Unable to read consumer identity
+
+This system is not registered with an entitlement server. You can use subscription-manager to register.
+
+Last metadata expiration check: 0:19:27 ago on Mon Jul  6 10:00:00 2026.
+kernel.x86_64                     5.14.0-284.30.1.el9_2           baseos`,
+			pkgMgr: "dnf",
+			// Simulate phantom entries created by older agents from the same
+			// noise lines: they must not turn the messages into packages.
+			installedPackages: map[string]models.Package{
+				"kernel.x86_64": {
+					Name:           "kernel.x86_64",
+					CurrentVersion: "5.14.0-284.30.1.el9_1",
+				},
+				"This":     {Name: "This", CurrentVersion: "system"},
+				"Unable":   {Name: "Unable", CurrentVersion: "to"},
+				"Updating": {Name: "Updating", CurrentVersion: "Subscription"},
+			},
+			securityPackages: map[string]bool{},
+			expected:         1,
+			expectedSecurity: 0,
 		},
 	}
 


### PR DESCRIPTION
Fixes #864

## Problem

On RHEL-family hosts where the `subscription-manager` dnf plugin is present (Oracle Linux, Rocky, RHEL), dnf prints informational messages to **stdout** before its real output:

```
Updating Subscription Management repositories.
Unable to read consumer identity

This system is not registered with an entitlement server. You can use subscription-manager to register.
```

The dnf parsers in `agent-source-code/internal/packages/dnf.go` accepted any line with 3+ whitespace-separated fields as a package (`name version repo`). These messages therefore became phantom packages:

| "Package" | "Version" |
|---|---|
| `This` | `system` |
| `Unable` | `to` |
| `Updating` | `Subscription` |

`parseInstalledPackages` recorded them as installed, `parseUpgradablePackages` then matched the same lines in `dnf check-update` output against those phantom entries and reported them as upgradable — exactly the names/versions reported in #864 (Oracle Linux) and its Rocky 9.8 comment. Selecting one for upgrade runs `dnf update This`, which fails with `Error: Unable to find a match: This`.

## Fix

Real package lines in `dnf list` / `dnf check-update` output always start with a `name.arch` identifier; plugin messages never do. This PR:

- adds an `isPackageLine()` check — the first field must end in a known RPM architecture suffix — used by `parseInstalledPackages` (both the single-line and legacy-yum wrapped-line formats), `parseUpgradablePackages`, and the `list installed <pkg>` fallback (whose output carries the same noise);
- centralises the arch-suffix handling into `knownArchitectures` / `stripArchSuffix()`, replacing the same inline check that was duplicated in three places (and extending it to `ppc64le`, `s390x`, `armv7hl`, etc.);
- as a side effect, installed package names containing dots (e.g. `python3.11`) are no longer truncated at the first dot (`python3`).

I chose parser-side filtering over passing `-q` / `--disableplugin=subscription-manager` to dnf because quiet-mode behaviour for these messages varies across dnf versions, and disabling the plugin could interfere with entitlement refresh on genuinely registered RHEL hosts.

Note: existing phantom entries in the UI will persist until the affected agents re-report with the fixed parser.

## Testing

- Added regression tests to both parsers using the exact message lines from the issue, including one that seeds the phantom `This`/`Unable`/`Updating` entries into the installed map to prove they cannot leak through, plus cases for dotted package names and the legacy-yum wrapped-line format.
- `go vet`, `go build ./...` and the full `go test ./...` suite pass in `agent-source-code/`; `gofmt` clean.

## AI Disclosure

- **Used AI:** yes
- **Model(s):** Claude Fable 5
- **Harness / tool:** Claude Code CLI
- **Scope:** investigation, code, tests, commit message and PR description
- **Human review completed:** partially — @Edzilla2000 reviewed the root-cause analysis, the proposed approach and the test results before submission