### PR TITLE
Resolve the build version from the git tag

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,7 +16,6 @@ body:
         - ""
         - Docker
         - Proxmox-community script
-        - setup.sh native install script
         - Other
     validations:
       required: true

--- a/.github/actions/release-context/action.yml
+++ b/.github/actions/release-context/action.yml
@@ -1,0 +1,114 @@
+name: Release context
+description: >
+  Resolve the app version from the git tag and, on a release build, pull the
+  release notes out of the GitHub release into the source tree so they get
+  compiled into the binary.
+
+inputs:
+  token:
+    description: Token used for the GitHub API
+    required: true
+  tag:
+    description: >
+      Release tag. Defaults to the triggering tag or release. Leave blank for
+      branch and PR builds.
+    required: false
+    default: ''
+  fetch-notes:
+    description: >
+      Set to false for jobs that do not build the server binary, e.g. the agent
+      matrix. They still need the version but not the notes.
+    required: false
+    default: 'true'
+
+outputs:
+  version:
+    description: MAJOR.MINOR.PATCH, always valid, never with a suffix
+    value: ${{ steps.resolve.outputs.version }}
+  is-release:
+    description: '"true" when building a vX.Y.Z release tag'
+    value: ${{ steps.resolve.outputs.is-release }}
+
+runs:
+  using: composite
+  steps:
+    - id: resolve
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+        INPUT_TAG: ${{ inputs.tag }}
+        REF_TYPE: ${{ github.ref_type }}
+        REF_NAME: ${{ github.ref_name }}
+        RELEASE_TAG: ${{ github.event.release.tag_name }}
+        FETCH_NOTES: ${{ inputs.fetch-notes }}
+      run: |
+        set -euo pipefail
+
+        # Tag names reach the shell through env, never ${{ }} interpolation.
+        TAG="$INPUT_TAG"
+        if [ -z "$TAG" ] && [ "$REF_TYPE" = "tag" ]; then TAG="$REF_NAME"; fi
+        if [ -z "$TAG" ]; then TAG="$RELEASE_TAG"; fi
+
+        IS_RELEASE=false
+        if printf '%s' "$TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+          IS_RELEASE=true
+          VERSION="${TAG#v}"
+        else
+          # Branch or PR build. Report the last released version: it is what
+          # this tree is a descendant of, and it keeps the update checker
+          # honest. --abbrev=0 gives the bare tag, because the server parses
+          # versions as dot-separated ints and silently treats any suffix as 0,
+          # so v2.0.2-60-gABC would report as 2.0.0.
+          VERSION="$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || true)"
+          if [ -z "$VERSION" ]; then
+            # describe walks history to find the nearest tag, so it needs both
+            # the tags and the ancestry. Fetching tags into a shallow clone is
+            # not enough; unshallow first.
+            git fetch --unshallow --tags --quiet origin 2>/dev/null \
+              || git fetch --tags --quiet origin 2>/dev/null || true
+            VERSION="$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || true)"
+          fi
+        fi
+
+        if ! printf '%s' "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+          echo "::error::Could not resolve a MAJOR.MINOR.PATCH version (tag='$TAG', resolved='$VERSION')."
+          echo "::error::Set 'fetch-depth: 0' on actions/checkout. 'fetch-tags: true' is not sufficient: it fetches the tag refs but leaves the clone shallow, so git describe has no ancestry to walk."
+          exit 1
+        fi
+
+        {
+          echo "version=$VERSION"
+          echo "is-release=$IS_RELEASE"
+        } >> "$GITHUB_OUTPUT"
+        echo "Version: $VERSION (release: $IS_RELEASE)"
+
+        if [ "$IS_RELEASE" != "true" ] || [ "$FETCH_NOTES" != "true" ]; then
+          exit 0
+        fi
+
+        # The GitHub release is the source of truth for release notes. Pull the
+        # body into the tree so //go:embed compiles it into the binary; the
+        # in-app "What's New" modal then works with no network access. Nothing
+        # is committed: this file exists only in the build.
+        NOTES="server-source-code/internal/handler/release_notes_data/RELEASE_NOTES_${VERSION}.md"
+
+        # Publishing the release is what creates the tag, so the release should
+        # already exist when this runs. Retry briefly against propagation lag.
+        body=""
+        for attempt in 1 2 3 4 5; do
+          if body="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" --jq '.body' 2>/dev/null)"; then
+            [ -n "${body//[[:space:]]/}" ] && break
+          fi
+          echo "Release $TAG not readable yet (attempt $attempt), waiting..."
+          sleep 5
+          body=""
+        done
+
+        if [ -z "${body//[[:space:]]/}" ]; then
+          echo "::error::No release notes found for $TAG. Draft the release with its notes and publish it; do not push the tag by hand."
+          exit 1
+        fi
+
+        # GitHub stores release bodies with CRLF.
+        printf '%s\n' "$body" | tr -d '\r' > "$NOTES"
+        echo "Wrote $(wc -c < "$NOTES") bytes to $NOTES"

--- a/.github/scripts/publish-changelog.sh
+++ b/.github/scripts/publish-changelog.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Push a release's notes to the Quackback changelog at feedback.patchmon.net.
+#
+# Entries are created as drafts (publishedAt omitted) so the notes can be
+# proofread on the portal before they go public.
+#
+# Idempotent: entries are matched by exact title ("Version X.Y.Z"). A rerun for
+# the same version updates the existing entry rather than creating a duplicate,
+# so re-tagging or replaying a failed job is safe.
+#
+# Usage:
+#   QUACKBACK_API_KEY=qb_xxx ./publish-changelog.sh <version> <notes-file>
+#
+# Environment:
+#   QUACKBACK_API_KEY  required, from the portal under
+#                      Settings > Developers > API keys
+#   QUACKBACK_API_URL  optional, defaults to the production portal
+# =============================================================================
+
+set -euo pipefail
+
+API_URL="${QUACKBACK_API_URL:-https://feedback.patchmon.net/api/v1}"
+
+die() { echo "::error::$*" >&2; exit 1; }
+
+VERSION="${1:-}"
+NOTES_FILE="${2:-}"
+
+[ -n "$VERSION" ]    || die "usage: publish-changelog.sh <version> <notes-file>"
+[ -n "$NOTES_FILE" ] || die "usage: publish-changelog.sh <version> <notes-file>"
+[ -f "$NOTES_FILE" ] || die "notes file not found: $NOTES_FILE"
+[ -n "${QUACKBACK_API_KEY:-}" ] || die "QUACKBACK_API_KEY is not set"
+
+command -v jq >/dev/null 2>&1 || die "jq is required"
+
+TITLE="Version ${VERSION}"
+
+BODY_FILE="$(mktemp)"
+PAYLOAD_FILE="$(mktemp)"
+trap 'rm -f "$BODY_FILE" "$PAYLOAD_FILE"' EXIT
+
+# Strip a leading "# ..." heading: the portal renders the title separately, so
+# keeping it would show the version twice.
+CONTENT="$(sed '1{/^# /d;}' "$NOTES_FILE")"
+# grep, not ${CONTENT//[[:space:]]/}: bash pattern substitution over a
+# multi-kilobyte release-notes file takes tens of seconds on bash 3.2.
+printf '%s' "$CONTENT" | grep -q '[^[:space:]]' || die "notes file has no body: $NOTES_FILE"
+
+# Writes the response body to $BODY_FILE and prints the HTTP status. Bodies go
+# to a file rather than a shell variable so jq can stream them: changelog pages
+# run to hundreds of KB and bash string handling on that is painfully slow.
+api() {
+  local method="$1" path="$2"
+  shift 2
+  curl --silent --show-error --location \
+    --request "$method" \
+    --header "Authorization: Bearer ${QUACKBACK_API_KEY}" \
+    --header "Content-Type: application/json" \
+    --connect-timeout 10 --max-time 60 --retry 2 --retry-connrefused \
+    --output "$BODY_FILE" \
+    --write-out '%{http_code}' \
+    "${API_URL}${path}" "$@"
+}
+
+expect() {
+  local status="$1" want="$2" context="$3"
+  [ "$status" = "$want" ] || die "${context}: HTTP ${status} — $(head -c 500 "$BODY_FILE")"
+}
+
+echo "Looking for an existing changelog entry titled '${TITLE}'"
+ENTRY_ID=""
+CURSOR=""
+while :; do
+  query="?limit=100"
+  if [ -n "$CURSOR" ]; then
+    query="${query}&cursor=${CURSOR}"
+  fi
+  status="$(api GET "/changelog${query}")" || die "list changelog: request failed"
+  expect "$status" 200 "list changelog"
+
+  match="$(jq -r --arg t "$TITLE" 'first(.data[]? | select(.title == $t) | .id) // empty' "$BODY_FILE")"
+  if [ -n "$match" ]; then
+    ENTRY_ID="$match"
+    break
+  fi
+
+  # The schema puts pagination at the top level; tolerate a meta-nested shape too.
+  has_more="$(jq -r '(.pagination.hasMore // .meta.pagination.hasMore) // false' "$BODY_FILE")"
+  [ "$has_more" = "true" ] || break
+  CURSOR="$(jq -r '(.pagination.cursor // .meta.pagination.cursor) // empty' "$BODY_FILE")"
+  [ -n "$CURSOR" ] || break
+done
+
+jq -n --arg title "$TITLE" --arg content "$CONTENT" \
+  '{title: $title, content: $content}' > "$PAYLOAD_FILE"
+
+if [ -n "$ENTRY_ID" ]; then
+  echo "Updating existing entry ${ENTRY_ID}"
+  status="$(api PATCH "/changelog/${ENTRY_ID}" --data "@${PAYLOAD_FILE}")" || die "update changelog: request failed"
+  expect "$status" 200 "update changelog"
+else
+  echo "Creating a new draft entry"
+  status="$(api POST "/changelog" --data "@${PAYLOAD_FILE}")" || die "create changelog: request failed"
+  expect "$status" 201 "create changelog"
+fi
+
+ENTRY_ID="$(jq -r '.data.id' "$BODY_FILE")"
+PUBLISHED="$(jq -r '.data.publishedAt // "draft"' "$BODY_FILE")"
+
+echo "Changelog entry ${ENTRY_ID} (${PUBLISHED})"
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  {
+    echo "### Quackback changelog"
+    echo ""
+    echo "- Entry: \`${ENTRY_ID}\` (${PUBLISHED})"
+    echo "- Review and publish it from the changelog section of the Quackback admin dashboard."
+  } >> "$GITHUB_STEP_SUMMARY"
+fi

--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -1,6 +1,10 @@
 name: Release Binaries
 
-# Fires when a GitHub release is published (draft → published, or direct publish).
+# Fires when you publish a release in the GitHub UI. Publishing is what creates
+# the tag, so this and docker.yml (on the tag push) run in parallel off the same
+# action. Both pull the release notes out of the release body and compile them
+# into the binaries they build.
+#
 # NOTE: the `tags:` filter is not a valid key under `on.release` in GitHub Actions
 # and was silently ignored. If you want to restrict by tag pattern, add
 # `if: startsWith(github.event.release.tag_name, 'v')` to each job.
@@ -10,6 +14,9 @@ on:
 
 permissions:
   contents: write
+
+env:
+  TAG_NAME: ${{ github.event.release.tag_name }}
 
 jobs:
   agent:
@@ -43,6 +50,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
+      - name: Resolve version
+        id: ctx
+        uses: ./.github/actions/release-context
+        with:
+          token: ${{ github.token }}
+          tag: ${{ env.TAG_NAME }}
+          fetch-notes: 'false'
+
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417
         with:
@@ -59,13 +74,12 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
           GOARM: ${{ (matrix.goos == 'linux' || matrix.goos == 'freebsd') && matrix.goarch == 'arm' && '6' || '' }}
           CGO_ENABLED: 0
+          # Already v-stripped; diagnostics.go prints "v%s" and would otherwise
+          # emit "vv2.0.0".
+          VERSION: ${{ steps.ctx.outputs.version }}
         run: |
           OUTPUT_BASE="patchmon-agent-${{ matrix.goos }}-${{ matrix.goarch }}"
           OUTPUT_NAME="${OUTPUT_BASE}${{ matrix.goos == 'windows' && '.exe' || '' }}"
-          # Strip leading "v" so "v2.0.0" becomes "2.0.0" — diagnostics.go prints
-          # "v%s" and would otherwise emit "vv2.0.0".
-          VERSION="${{ github.event.release.tag_name }}"
-          VERSION="${VERSION#v}"
           go build -buildvcs=false \
             -ldflags="-s -w -X patchmon-agent/internal/pkgversion.Version=${VERSION}" \
             -o "${OUTPUT_NAME}" ./cmd/patchmon-agent
@@ -162,7 +176,7 @@ jobs:
       - name: Upload agent binary to release
         uses: softprops/action-gh-release@b25b93d384199fc0fc8c2e126b2d937a0cbeb2ae
         with:
-          tag_name: ${{ github.event.release.tag_name }}
+          tag_name: ${{ env.TAG_NAME }}
           files: agent-source-code/patchmon-agent-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.goos == 'windows' && '.exe' || '' }}
 
       - name: Build summary
@@ -193,17 +207,25 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
+      # Resolves the version and writes the release notes from the GitHub
+      # release into release_notes_data/ so //go:embed compiles them into the
+      # binary. Nothing is committed.
+      - name: Resolve version and inject release notes
+        id: ctx
+        uses: ./.github/actions/release-context
+        with:
+          token: ${{ github.token }}
+          tag: ${{ env.TAG_NAME }}
+
       - name: Set up Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version-file: "package.json"
           cache: "npm"
 
+      # The UI reads its version from /api/v1/version/current, not from a Vite
+      # build-time variable, so nothing is injected here.
       - name: Build frontend for embed
-        env:
-          # Inject the release tag into the Vite build so the UI reports the
-          # correct version, overriding the placeholder in frontend/env.example.
-          VITE_APP_VERSION: ${{ github.event.release.tag_name }}
         run: |
           npm ci
           npm run build --workspace=frontend
@@ -226,12 +248,9 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
           GOARM: ${{ matrix.goarch == 'arm' && '6' || '' }}
           CGO_ENABLED: 0
+          VERSION: ${{ steps.ctx.outputs.version }}
         run: |
           OUTPUT_NAME="patchmon-server-${{ matrix.goos }}-${{ matrix.goarch }}"
-          # Strip leading "v" so a "v2.0.0" tag becomes "2.0.0" (matches semver
-          # in config.go and what the UI expects for version comparisons).
-          VERSION="${{ github.event.release.tag_name }}"
-          VERSION="${VERSION#v}"
           go build -buildvcs=false \
             -ldflags="-s -w -X 'github.com/PatchMon/PatchMon/server-source-code/internal/config.DefaultVersion=${VERSION}'" \
             -o "${OUTPUT_NAME}" ./cmd/server
@@ -240,5 +259,35 @@ jobs:
       - name: Upload patchmon-server to release
         uses: softprops/action-gh-release@b25b93d384199fc0fc8c2e126b2d937a0cbeb2ae
         with:
-          tag_name: ${{ github.event.release.tag_name }}
+          tag_name: ${{ env.TAG_NAME }}
           files: patchmon-server-${{ matrix.goos }}-${{ matrix.goarch }}
+
+  changelog:
+    name: Draft the feedback portal changelog
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+
+      - name: Resolve version and fetch release notes
+        id: ctx
+        uses: ./.github/actions/release-context
+        with:
+          token: ${{ github.token }}
+          tag: ${{ env.TAG_NAME }}
+
+      # Creates the entry as a draft so the notes can be proofread on the portal
+      # before they go public. Idempotent: entries are matched by the exact
+      # title "Version X.Y.Z" and updated in place, so a rerun is safe.
+      - name: Push notes to the Quackback changelog
+        env:
+          QUACKBACK_API_KEY: ${{ secrets.QUACKBACK_API_KEY }}
+          VERSION: ${{ steps.ctx.outputs.version }}
+        run: |
+          if [ -z "${QUACKBACK_API_KEY}" ]; then
+            echo "::warning::QUACKBACK_API_KEY is not set — skipping the feedback portal changelog."
+            exit 0
+          fi
+          chmod +x .github/scripts/publish-changelog.sh
+          .github/scripts/publish-changelog.sh "$VERSION" \
+            "server-source-code/internal/handler/release_notes_data/RELEASE_NOTES_${VERSION}.md"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,6 +41,18 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
+          # Branch and PR builds resolve their version with `git describe`,
+          # which walks history to find the nearest tag. fetch-tags alone is not
+          # enough: it fetches the tag refs, but a shallow clone has no ancestry
+          # to walk, so describe fails with "No tags can describe".
+          fetch-depth: 0
+
+      - name: Resolve version
+        id: ctx
+        uses: ./.github/actions/release-context
+        with:
+          token: ${{ github.token }}
+          fetch-notes: 'false'
 
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417
@@ -51,9 +63,9 @@ jobs:
         working-directory: agent-source-code
         env:
           CGO_ENABLED: 0
+          VERSION: ${{ steps.ctx.outputs.version }}
         run: |
           mkdir -p ../agents-prebuilt
-          VERSION=${{ github.ref_type == 'tag' && github.ref_name || 'dev' }}
           for target in "linux/amd64" "linux/arm64" "linux/386" "linux/arm" \
                         "freebsd/amd64" "freebsd/arm64" "freebsd/386" "freebsd/arm" \
                         "windows/amd64" "windows/arm64"; do
@@ -90,6 +102,20 @@ jobs:
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
+          # Branch and PR builds resolve their version with `git describe`,
+          # which walks history to find the nearest tag. fetch-tags alone is not
+          # enough: it fetches the tag refs, but a shallow clone has no ancestry
+          # to walk, so describe fails with "No tags can describe".
+          fetch-depth: 0
+
+      # Resolves the version and, on a release tag, writes the release notes
+      # from the GitHub release into release_notes_data/ so //go:embed compiles
+      # them into the image. Nothing is committed.
+      - name: Resolve version and inject release notes
+        id: ctx
+        uses: ./.github/actions/release-context
+        with:
+          token: ${{ github.token }}
 
       - name: Download agent binaries
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
@@ -172,7 +198,7 @@ jobs:
           file: docker/server.Dockerfile
           platforms: linux/amd64,linux/arm64
           build-args: |
-            VERSION=${{ github.ref_type == 'tag' && github.ref_name || 'dev' }}
+            VERSION=${{ steps.ctx.outputs.version }}
           push: ${{ github.event_name != 'workflow_dispatch' || inputs.push == 'true' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -197,7 +223,7 @@ jobs:
           file: docker/server.Dockerfile
           platforms: linux/amd64,linux/arm64
           build-args: |
-            VERSION=${{ github.ref_type == 'tag' && github.ref_name || 'dev' }}
+            VERSION=${{ steps.ctx.outputs.version }}
           push: ${{ github.event_name != 'workflow_dispatch' || inputs.push == 'true' }}
           tags: ${{ steps.meta-harbor.outputs.tags }}
           labels: ${{ steps.meta-harbor.outputs.labels }}
@@ -223,12 +249,29 @@ jobs:
           # See: https://github.com/PatchMon/PatchMon/issues/679
           outputs: type=image,compression=gzip,force-compression=true
 
+      # Locate a previous image comment by its marker so a re-push updates it
+      # instead of appending another one. `synchronize` is a trigger, so
+      # without this every push to the PR leaves a fresh near-identical comment.
+      - name: Find existing image comment
+        id: find-comment
+        if: github.event_name == 'pull_request_target' && steps.build-harbor.outcome == 'success' && steps.build-harbor.outputs.digest != ''
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '<!-- patchmon-docker-pr -->'
+
+      # comment-id empty (first run) creates against issue-number; set (re-push)
+      # updates that comment. edit-mode: replace, or the body is appended to and
+      # the comment grows a copy per push.
       - name: Comment on PR with image URL
         if: github.event_name == 'pull_request_target' && steps.build-harbor.outcome == 'success' && steps.build-harbor.outputs.digest != ''
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          edit-mode: replace
           body: |
             <!-- patchmon-docker-pr -->
             ## Docker image for testing


### PR DESCRIPTION
Branch and PR builds passed VERSION=dev, which the server Dockerfile is about to start rejecting: the version parser reads dot-separated ints and discards the rest, so "dev" would compile in as 0.0.0 and every instance would believe an update was available.

A composite action now resolves MAJOR.MINOR.PATCH for every build. Release tags use the tag itself and pull the release body into the tree so the notes embed; branch and PR builds fall back to the last released tag via git describe, which needs fetch-depth 0 because a shallow clone has no ancestry to walk.

Landing this before the Dockerfile change, since pull_request_target runs the workflow from the base branch against the pull request's code.