### PR TITLE
Stop the release-context manifest failing to parse

### DIFF
--- a/.github/actions/release-context/action.yml
+++ b/.github/actions/release-context/action.yml
@@ -44,7 +44,10 @@ runs:
       run: |
         set -euo pipefail
 
-        # Tag names reach the shell through env, never ${{ }} interpolation.
+        # Tag names reach the shell through env, never template interpolation.
+        # Do not write the interpolation braces here either: Actions evaluates
+        # them inside run blocks regardless of the shell comment, and an empty
+        # pair fails the manifest with "An expression was expected".
         TAG="$INPUT_TAG"
         if [ -z "$TAG" ] && [ "$REF_TYPE" = "tag" ]; then TAG="$REF_NAME"; fi
         if [ -z "$TAG" ]; then TAG="$RELEASE_TAG"; fi


### PR DESCRIPTION
A shell comment inside the run block contained an empty interpolation pair. Actions evaluates those inside run blocks regardless of the surrounding shell comment, so the manifest failed to load with "An expression was expected" and every job using the action died before its first line ran.

<!--
Thanks for contributing to PatchMon!

Before you open this PR, please check the box below that matches what you are
submitting. PRs that add a new feature need an accepted request on
feedback.patchmon.net first — see CONTRIBUTING.md for why.
-->

## What does this PR do?

<!-- A short description. If it fixes a bug, write "Fixes #123" so the issue closes automatically. -->

Fixes #

## Type of change

- [ ] 🐛 Bug fix — references an open issue with `Fixes #N`
- [ ] 💡 Feature — has an **Accepted** request on [feedback.patchmon.net](https://feedback.patchmon.net) (link it below)
- [ ] 📚 Documentation
- [ ] 🔧 Refactor / chore / CI

**Feature request link:** <!-- required for features -->

## Checklist

- [ ] I have signed the Contributor Licence Agreement (the bot will prompt you on your first PR)
- [ ] I have disclosed any AI assistance, as required by [AI-DECLARATION.md](../AI-DECLARATION.md)
- [ ] Tests and linters pass locally
- [ ] I have tested this against a real PatchMon install

## Testing performed

<!-- How did you verify this works? Which OS/distro, which install method, which version? -->

---

<!--
A note on feature PRs:

We are currently prioritising stability over new features. If your PR adds a
feature, it may be labelled `deferred-stability-phase` and revisited in a later
cycle. That is not a rejection — it is a scheduling decision, and your work is
not lost.

If your PR adds a feature that has not been through the request process, we will
label it `needs-accepted-request` and link the feedback post rather than closing
it. Please raise the idea at feedback.patchmon.net so it can gather votes and be
reviewed before we merge the code.
-->
