### PR TITLE
Rc number implementation and other bits and bobs

### DIFF
--- a/.github/actions/release-context/action.yml
+++ b/.github/actions/release-context/action.yml
@@ -23,7 +23,10 @@ inputs:
 
 outputs:
   version:
-    description: MAJOR.MINOR.PATCH, always valid, never with a suffix
+    description: >
+      MAJOR.MINOR.PATCH on a release tag. On branch and PR builds, the next
+      patch as a pre-release (2.0.3-rc.61) so edge sorts above the last release
+      and below the next one.
     value: ${{ steps.resolve.outputs.version }}
   is-release:
     description: '"true" when building a vX.Y.Z release tag'
@@ -57,24 +60,54 @@ runs:
           IS_RELEASE=true
           VERSION="${TAG#v}"
         else
-          # Branch or PR build. Report the last released version: it is what
-          # this tree is a descendant of, and it keeps the update checker
-          # honest. --abbrev=0 gives the bare tag, because the server parses
-          # versions as dot-separated ints and silently treats any suffix as 0,
-          # so v2.0.2-60-gABC would report as 2.0.0.
-          VERSION="$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || true)"
-          if [ -z "$VERSION" ]; then
+          # Branch or PR build. Report the NEXT patch version as a pre-release:
+          # last tag v2.0.2 plus 61 commits becomes 2.0.3-rc.61.
+          #
+          # Why not just the last tag: an :edge image built from main contains
+          # post-2.0.2 code, so reporting "2.0.2" understates it and edge agents
+          # never move. Why not a bare "2.0.3": it would collide with the real
+          # release, and because the agent's update gate is a string comparison,
+          # edge hosts would keep running mid-cycle binaries after 2.0.3 shipped.
+          #
+          # A pre-release sorts strictly between the two (2.0.2 < 2.0.3-rc.61 <
+          # 2.0.3), so edge instances converge onto the release on their own.
+          # util.CompareVersions and frontend/src/utils/version.js both implement
+          # that ordering; do not reintroduce a bare suffix without them.
+          #
+          # The counter is commit distance, not github.run_number, so rebuilding
+          # the same commit yields the same version. It resets at each tag, which
+          # is safe because the core bumps at the same moment.
+          BASE_TAG="$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || true)"
+          if [ -z "$BASE_TAG" ]; then
             # describe walks history to find the nearest tag, so it needs both
             # the tags and the ancestry. Fetching tags into a shallow clone is
             # not enough; unshallow first.
             git fetch --unshallow --tags --quiet origin 2>/dev/null \
               || git fetch --tags --quiet origin 2>/dev/null || true
-            VERSION="$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || true)"
+            BASE_TAG="$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || true)"
+          fi
+
+          if printf '%s' "$BASE_TAG" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            MAJOR="${BASE_TAG%%.*}"
+            REST="${BASE_TAG#*.}"
+            MINOR="${REST%%.*}"
+            PATCH="${REST#*.}"
+            DISTANCE="$(git rev-list --count "v${BASE_TAG}..HEAD" 2>/dev/null || echo 0)"
+            # Zero distance means we are sitting on the tagged commit without a
+            # tag ref build (e.g. a re-run of main at release time). rc.0 would
+            # be misleading, so fall back to the tag itself.
+            if [ "$DISTANCE" -eq 0 ]; then
+              VERSION="$BASE_TAG"
+            else
+              VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))-rc.${DISTANCE}"
+            fi
+          else
+            VERSION=""
           fi
         fi
 
-        if ! printf '%s' "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-          echo "::error::Could not resolve a MAJOR.MINOR.PATCH version (tag='$TAG', resolved='$VERSION')."
+        if ! printf '%s' "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'; then
+          echo "::error::Could not resolve a version (tag='$TAG', resolved='$VERSION')."
           echo "::error::Set 'fetch-depth: 0' on actions/checkout. 'fetch-tags: true' is not sufficient: it fetches the tag refs but leaves the clone shallow, so git describe has no ancestry to walk."
           exit 1
         fi

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -117,6 +117,30 @@ jobs:
         with:
           token: ${{ github.token }}
 
+      - name: Fetch community counts
+        id: social
+        # Bakes the current GitHub/Discord/YouTube/LinkedIn counts into the
+        # binary so the nav, login footer and setup wizard are accurate as of
+        # the release. patchmon.net/socialstats is public and unauthenticated,
+        # so this works on forks with no secrets configured.
+        #
+        # Never fails the build: an unreachable endpoint leaves the outputs
+        # empty and the server keeps its compiled-in defaults, while a
+        # deliberate 0 from the endpoint hides that number instead.
+        continue-on-error: true
+        run: |
+          for platform in github discord youtube linkedin; do
+            count="$(curl -fsS --max-time 10 --retry 2 --retry-delay 2 \
+              "https://patchmon.net/socialstats/${platform}" 2>/dev/null || true)"
+            count="$(printf '%s' "$count" | tr -dc '0-9')"
+            if [ -z "$count" ]; then
+              echo "::notice::no count for ${platform}; keeping compiled-in default"
+            else
+              echo "${platform}=${count}" >> "$GITHUB_OUTPUT"
+              echo "${platform}: ${count}"
+            fi
+          done
+
       - name: Download agent binaries
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
@@ -199,6 +223,10 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             VERSION=${{ steps.ctx.outputs.version }}
+            GITHUB_STARS=${{ steps.social.outputs.github }}
+            DISCORD_MEMBERS=${{ steps.social.outputs.discord }}
+            YOUTUBE_SUBSCRIBERS=${{ steps.social.outputs.youtube }}
+            LINKEDIN_FOLLOWERS=${{ steps.social.outputs.linkedin }}
           push: ${{ github.event_name != 'workflow_dispatch' || inputs.push == 'true' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -224,6 +252,10 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             VERSION=${{ steps.ctx.outputs.version }}
+            GITHUB_STARS=${{ steps.social.outputs.github }}
+            DISCORD_MEMBERS=${{ steps.social.outputs.discord }}
+            YOUTUBE_SUBSCRIBERS=${{ steps.social.outputs.youtube }}
+            LINKEDIN_FOLLOWERS=${{ steps.social.outputs.linkedin }}
           push: ${{ github.event_name != 'workflow_dispatch' || inputs.push == 'true' }}
           tags: ${{ steps.meta-harbor.outputs.tags }}
           labels: ${{ steps.meta-harbor.outputs.labels }}

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -91,7 +91,12 @@ cp -f "${agent_bins[@]}" agents-prebuilt/
 echo "==> Staged ${#agent_bins[@]} agent binaries"
 
 echo "==> Building frontend for embed"
-npm ci --workspace=frontend --include=dev
+# --include-workspace-root is load-bearing. `npm ci` wipes node_modules and then
+# reinstalls only what it is told to, so without it the root devDependencies are
+# dropped, taking lefthook and biome with them. The visible symptom is a
+# pre-commit hook that stops running and reports "Can't find lefthook in PATH",
+# silently, on every commit after a local image build.
+npm ci --workspace=frontend --include=dev --include-workspace-root
 npm run build --workspace=frontend
 mkdir -p server-source-code/cmd/server/static/frontend
 cp -r frontend/dist server-source-code/cmd/server/static/frontend/

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -43,10 +43,14 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-# `--abbrev=0` gives the bare nearest tag (v2.0.2), not v2.0.2-60-gABC. The
-# server parses versions as dot-separated integers and silently treats any
-# suffix as 0, so a describe with a suffix would report 2.0.0 and make the
-# instance think an update is available.
+# `--abbrev=0` gives the bare nearest tag (v2.0.2), not v2.0.2-60-gABC. A
+# suffix is read as a pre-release, so v2.0.2-60-gABC sorts just below 2.0.2 and
+# the instance would believe it is behind the current release, offering an
+# update that can never satisfy it.
+#
+# Local builds always produce a bare release version. The only deliberate
+# pre-release is the one CI mints for edge images, in
+# .github/actions/release-context.
 if [ -z "$VERSION" ]; then
   VERSION="$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || true)"
 fi
@@ -61,7 +65,8 @@ if [ -z "$VERSION" ]; then
 fi
 
 if ! printf '%s' "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-  die "version '$VERSION' is not MAJOR.MINOR.PATCH. Anything else is parsed as 0."
+  die "version '$VERSION' is not MAJOR.MINOR.PATCH. Local builds must pass a bare
+  release version; edge pre-releases like 2.0.3-rc.61 are minted by CI only."
 fi
 
 echo "==> Version: $VERSION"

--- a/docker/server.Dockerfile
+++ b/docker/server.Dockerfile
@@ -96,6 +96,19 @@ ARG TARGETARCH
 # "2.0.2-60-gABC" or "dev" would report as 2.0.0 and make the instance believe
 # an update is available.
 ARG VERSION=""
+# Community counts for the nav, login footer and setup wizard, read from
+# https://patchmon.net/socialstats/<platform> by the caller and passed in the
+# same way as VERSION. The build never fetches them itself, so it stays
+# hermetic and works with no network beyond the module proxy.
+#
+# Each is an integer. Omitted means "keep the compiled-in default"; 0 means the
+# endpoint could not determine the count and the number should be hidden.
+# Anything non-numeric is dropped rather than failing the build, because a bad
+# social count is never a reason to block a release.
+ARG GITHUB_STARS=""
+ARG DISCORD_MEMBERS=""
+ARG YOUTUBE_SUBSCRIBERS=""
+ARG LINKEDIN_FOLLOWERS=""
 RUN go mod download && \
     VER="${VERSION#v}"; \
     LDFLAGS="-s -w"; \
@@ -106,6 +119,17 @@ RUN go mod download && \
     else \
       echo "ERROR: VERSION='$VER' is not MAJOR.MINOR.PATCH" >&2; exit 1; \
     fi; \
+    SOCIAL_PKG="github.com/PatchMon/PatchMon/server-source-code/internal/social"; \
+    for pair in "GitHubStars:$GITHUB_STARS" "DiscordMembers:$DISCORD_MEMBERS" \
+                "YouTubeSubscribers:$YOUTUBE_SUBSCRIBERS" "LinkedInFollowers:$LINKEDIN_FOLLOWERS"; do \
+      name="${pair%%:*}"; value="${pair#*:}"; \
+      if [ -z "$value" ]; then continue; fi; \
+      if printf '%s' "$value" | grep -qE '^[0-9]+$'; then \
+        LDFLAGS="$LDFLAGS -X $SOCIAL_PKG.$name=$value"; \
+      else \
+        echo "WARNING: ignoring non-numeric social count $name='$value'" >&2; \
+      fi; \
+    done; \
     CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -buildvcs=false -ldflags="$LDFLAGS" -o /app/patchmon-server ./cmd/server
 
 # SSG content stage — download ComplianceAsCode datastream files at build time.

--- a/docker/server.Dockerfile
+++ b/docker/server.Dockerfile
@@ -114,10 +114,10 @@ RUN go mod download && \
     LDFLAGS="-s -w"; \
     if [ -z "$VER" ]; then \
       echo "WARNING: no VERSION build arg; this image will report 0.0.0. Use docker/build.sh." >&2; \
-    elif printf '%s' "$VER" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then \
+    elif printf '%s' "$VER" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'; then \
       LDFLAGS="$LDFLAGS -X github.com/PatchMon/PatchMon/server-source-code/internal/config.DefaultVersion=$VER"; \
     else \
-      echo "ERROR: VERSION='$VER' is not MAJOR.MINOR.PATCH" >&2; exit 1; \
+      echo "ERROR: VERSION='$VER' is not MAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH-PRERELEASE" >&2; exit 1; \
     fi; \
     SOCIAL_PKG="github.com/PatchMon/PatchMon/server-source-code/internal/social"; \
     for pair in "GitHubStars:$GITHUB_STARS" "DiscordMembers:$DISCORD_MEMBERS" \

--- a/docs/patchmon-admin-guide.md
+++ b/docs/patchmon-admin-guide.md
@@ -86,7 +86,8 @@ PatchMon uses a lightweight agent model:
 - Proxmox LXC Auto-Enrollment Guide
 - PatchMon Environment Variables Reference
 - [Metrics and Telemetry](#metrics-and-telemetry)
-- [Roadmap & Issues](https://github.com/orgs/PatchMon/projects/2)
+- [Feature Roadmap](https://feedback.patchmon.net/roadmap) (request and vote on features)
+- [Report a Bug](https://github.com/PatchMon/PatchMon/issues) (bugs are tracked in GitHub, not the feedback portal)
 - [YouTube](https://www.youtube.com/@patchmonTV)
 - [Discord Community](https://patchmon.net/discord)
 - [GitHub Repository](https://github.com/PatchMon/PatchMon)

--- a/docs/patchmon-operator-guide.md
+++ b/docs/patchmon-operator-guide.md
@@ -1412,7 +1412,7 @@ This step is hidden if the server's login-settings response includes `show_newsl
 
 ### Step 5: Get in Touch
 
-The final screen lists community and support links: Discord, GitHub, documentation, and the public roadmap. Click **Access Dashboard** to finish setup.
+The final screen lists community and support links: Discord, GitHub, documentation, the feature roadmap, and bug reporting. Feature requests go to the feedback portal; bugs go to GitHub Issues. Click **Access Dashboard** to finish setup.
 
 #### What happens when you finish
 

--- a/frontend/src/__tests__/utils/version.test.js
+++ b/frontend/src/__tests__/utils/version.test.js
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { compareVersions, isUpdateAvailable } from "../../utils/version";
+
+// These cases mirror version_test.go in the server. If one side changes, change
+// both: the login screen and the server's update alert must agree.
+describe("compareVersions", () => {
+	it.each([
+		["equal", "2.0.2", "2.0.2", 0],
+		["patch newer", "2.0.3", "2.0.2", 1],
+		["patch older", "2.0.2", "2.0.3", -1],
+		["minor beats patch", "2.1.0", "2.0.9", 1],
+		["major beats minor", "3.0.0", "2.9.9", 1],
+		["v prefix ignored", "v2.0.3", "2.0.3", 0],
+		["whitespace ignored", " 2.0.3 ", "2.0.3", 0],
+		["missing parts are zero", "2.0", "2.0.0", 0],
+		["extra part outranks", "2.0.3.1", "2.0.3", 1],
+	])("%s", (_name, a, b, want) => {
+		expect(compareVersions(a, b)).toBe(want);
+	});
+
+	// The edge-release relationship the whole scheme depends on.
+	it.each([
+		["rc ranks below its release", "2.0.3-rc.4", "2.0.3", -1],
+		["release outranks its rc", "2.0.3", "2.0.3-rc.4", 1],
+		["rc still outranks previous release", "2.0.3-rc.1", "2.0.2", 1],
+		["previous release below rc", "2.0.2", "2.0.3-rc.1", -1],
+		["rc numbers compare numerically", "2.0.3-rc.9", "2.0.3-rc.10", -1],
+		["rc numbers are not lexical", "2.0.3-rc.10", "2.0.3-rc.9", 1],
+		["identical rc", "2.0.3-rc.4", "2.0.3-rc.4", 0],
+		["rc below next release", "2.0.3-rc.99", "2.0.4", -1],
+	])("%s", (_name, a, b, want) => {
+		expect(compareVersions(a, b)).toBe(want);
+	});
+
+	it.each([
+		["numeric ranks below alphanumeric", "1.0.0-1", "1.0.0-alpha", -1],
+		["alpha before beta", "1.0.0-alpha", "1.0.0-beta", -1],
+		["longer identifier list wins", "1.0.0-alpha.1", "1.0.0-alpha", 1],
+		["shorter identifier list loses", "1.0.0-alpha", "1.0.0-alpha.1", -1],
+		["build metadata ignored", "2.0.3+abc", "2.0.3", 0],
+		["build metadata on rc ignored", "2.0.3-rc.4+abc", "2.0.3-rc.4", 0],
+	])("%s", (_name, a, b, want) => {
+		expect(compareVersions(a, b)).toBe(want);
+	});
+
+	it.each([
+		["git describe output", "2.0.2-60-gABC", "2.0.2", -1],
+		["empty is lowest", "", "2.0.2", -1],
+		["null is lowest", null, "2.0.2", -1],
+		["both empty", "", "", 0],
+	])("handles malformed input: %s", (_name, a, b, want) => {
+		expect(compareVersions(a, b)).toBe(want);
+	});
+
+	it("is antisymmetric across an ascending fixture", () => {
+		const versions = [
+			"2.0.2",
+			"2.0.3-rc.1",
+			"2.0.3-rc.2",
+			"2.0.3-rc.10",
+			"2.0.3",
+			"2.0.4-rc.1",
+			"2.1.0",
+			"3.0.0",
+		];
+		versions.forEach((a, i) => {
+			versions.forEach((b, j) => {
+				// Asserting both directions against the fixture order implies
+				// antisymmetry. `|| 0` normalises -0, which toBe treats as
+				// distinct from 0.
+				expect(compareVersions(a, b)).toBe(Math.sign(i - j) || 0);
+				expect(compareVersions(b, a)).toBe(Math.sign(j - i) || 0);
+			});
+		});
+	});
+});
+
+describe("isUpdateAvailable", () => {
+	it("flags a newer release", () => {
+		expect(isUpdateAvailable("2.0.2", "2.0.3")).toBe(true);
+	});
+
+	it("flags the release as an update for an edge build", () => {
+		expect(isUpdateAvailable("2.0.3-rc.61", "2.0.3")).toBe(true);
+	});
+
+	it("does not flag an edge build as an update for the release", () => {
+		expect(isUpdateAvailable("2.0.3", "2.0.3-rc.61")).toBe(false);
+	});
+
+	it("does not flag equal versions", () => {
+		expect(isUpdateAvailable("2.0.3", "2.0.3")).toBe(false);
+	});
+
+	it("does not flag when either side is missing", () => {
+		expect(isUpdateAvailable("", "2.0.3")).toBe(false);
+		expect(isUpdateAvailable("2.0.3", "")).toBe(false);
+		expect(isUpdateAvailable(null, undefined)).toBe(false);
+	});
+});

--- a/frontend/src/components/CommunityLinks.jsx
+++ b/frontend/src/components/CommunityLinks.jsx
@@ -7,6 +7,7 @@
 import { useQuery } from "@tanstack/react-query";
 import {
 	BookOpen,
+	Bug,
 	CreditCard,
 	Github,
 	Globe,
@@ -22,7 +23,9 @@ import DiscordIcon from "./DiscordIcon";
 const ICON_MAP = {
 	discord: DiscordIcon,
 	github: Github,
-	github_issues: Github,
+	// Bug, not Github: this sits next to the repo link in the login footer and
+	// the two were indistinguishable when both rendered the same GitHub mark.
+	github_issues: Bug,
 	email: Mail,
 	linkedin: FaLinkedin,
 	youtube: FaYoutube,
@@ -183,6 +186,7 @@ export const LoginCommunityLinks = () => {
 		"linkedin",
 		"youtube",
 		"roadmap",
+		"github_issues",
 		"docs",
 		"website",
 	];
@@ -234,9 +238,15 @@ export const LoginCommunityLinks = () => {
 							</span>
 						)}
 						{!link.stat &&
-							["roadmap", "docs", "website", "buymeacoffee"].includes(
-								link.id,
-							) && <span className="sr-only">{link.label}</span>}
+							[
+								"roadmap",
+								"github_issues",
+								"docs",
+								"website",
+								"buymeacoffee",
+							].includes(link.id) && (
+								<span className="sr-only">{link.label}</span>
+							)}
 					</a>
 				);
 			})}

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -421,7 +421,14 @@ const Layout = ({ children }) => {
 				});
 			}
 
-			const sidebarLinkIds = ["roadmap", "docs", "email", "website", "billing"];
+			const sidebarLinkIds = [
+				"roadmap",
+				"github_issues",
+				"docs",
+				"email",
+				"website",
+				"billing",
+			];
 			const linkChildren = communityLinks
 				.filter((l) => sidebarLinkIds.includes(l.id))
 				.map((l) => ({

--- a/frontend/src/pages/Automation.jsx
+++ b/frontend/src/pages/Automation.jsx
@@ -73,8 +73,17 @@ const Automation = () => {
 		if (queue?.includes("compliance-scan-cleanup"))
 			return "compliance-scan-cleanup";
 		if (queue?.includes("patch-run-cleanup")) return "patch-run-cleanup";
+		if (queue?.includes("agent-reports-cleanup"))
+			return "agent-reports-cleanup";
 		if (queue?.includes("ssg-update-check")) return "ssg-update-check";
 		return null;
+	};
+
+	// triggeringJob is null when idle, so an unmapped queue would compare
+	// null === null and render every row as permanently spinning.
+	const isTriggering = (queue) => {
+		const jobType = getJobTypeForQueue(queue);
+		return jobType !== null && triggeringJob === jobType;
 	};
 
 	const getStatusBadge = (status) => {
@@ -408,8 +417,15 @@ const Automation = () => {
 				endpoint = "/compliance/scans/cleanup";
 			} else if (jobType === "patch-run-cleanup") {
 				endpoint = "/automation/trigger/patch-run-cleanup";
+			} else if (jobType === "agent-reports-cleanup") {
+				endpoint = "/automation/trigger/agent-reports-cleanup";
 			} else if (jobType === "ssg-update-check") {
 				endpoint = "/automation/trigger/ssg-update-check";
+			}
+
+			if (!endpoint) {
+				toast.error(`No manual trigger available for ${jobType}`);
+				return;
 			}
 
 			const response = await api.post(endpoint, data);
@@ -644,15 +660,11 @@ const Automation = () => {
 														);
 														if (jobType) triggerManualJob(jobType);
 													}}
-													disabled={
-														triggeringJob ===
-														getJobTypeForQueue(automation.queue)
-													}
+													disabled={isTriggering(automation.queue)}
 													className="inline-flex items-center justify-center w-8 h-8 border border-transparent rounded text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 transition-colors duration-200 flex-shrink-0 disabled:opacity-60 disabled:cursor-not-allowed"
 													title="Run Now"
 												>
-													{triggeringJob ===
-													getJobTypeForQueue(automation.queue) ? (
+													{isTriggering(automation.queue) ? (
 														<span className="animate-spin h-4 w-4 border-2 border-white border-t-transparent rounded-full" />
 													) : (
 														<Play className="h-4 w-4" />
@@ -773,15 +785,11 @@ const Automation = () => {
 																);
 																if (jobType) triggerManualJob(jobType);
 															}}
-															disabled={
-																triggeringJob ===
-																getJobTypeForQueue(automation.queue)
-															}
+															disabled={isTriggering(automation.queue)}
 															className="inline-flex items-center justify-center w-6 h-6 border border-transparent rounded text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 transition-colors duration-200 disabled:opacity-60 disabled:cursor-not-allowed"
 															title="Run Now"
 														>
-															{triggeringJob ===
-															getJobTypeForQueue(automation.queue) ? (
+															{isTriggering(automation.queue) ? (
 																<span className="animate-spin h-3 w-3 border-2 border-white border-t-transparent rounded-full" />
 															) : (
 																<Play className="h-3 w-3" />

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -15,6 +15,7 @@ import DiscordIcon from "../components/DiscordIcon";
 import { useAuth } from "../contexts/AuthContext";
 import { authAPI, getGlobalTimezone, isCorsError } from "../utils/api";
 import { resolveLogoPath } from "../utils/logoPaths";
+import { compareVersions, isUpdateAvailable } from "../utils/version";
 
 const Login = () => {
 	const usernameId = useId();
@@ -504,28 +505,16 @@ const Login = () => {
 										<div className="flex items-center gap-3">
 											<div className="flex items-center gap-2">
 												{(() => {
-													// Normalise versions for comparison (strip leading "v")
-													const strip = (v) =>
-														v ? v.replace(/^v/i, "").trim() : "";
-													// Compare two semver strings. Returns positive if a > b, negative if a < b, 0 if equal.
-													const semverCmp = (a, b) => {
-														const pa = a.split(".").map(Number);
-														const pb = b.split(".").map(Number);
-														const len = Math.max(pa.length, pb.length);
-														for (let i = 0; i < len; i++) {
-															const diff = (pa[i] || 0) - (pb[i] || 0);
-															if (diff !== 0) return diff;
-														}
-														return 0;
-													};
-													const installed = strip(currentVersion);
-													const latest = strip(latestRelease.version);
-													// Only show "Update Available" when latest is strictly newer than installed
-													const isUpdateAvailable =
-														installed &&
-														latest &&
-														semverCmp(latest, installed) > 0;
-													if (isUpdateAvailable) {
+													// Only show "Update Available" when latest is strictly newer
+													// than installed. Shared with the server's comparison so an
+													// edge build (2.0.3-rc.61) correctly reads as older than the
+													// 2.0.3 release rather than equal to it.
+													if (
+														isUpdateAvailable(
+															currentVersion,
+															latestRelease.version,
+														)
+													) {
 														return (
 															<>
 																<div className="w-2 h-2 bg-amber-400 rounded-full animate-pulse" />
@@ -535,7 +524,14 @@ const Login = () => {
 															</>
 														);
 													}
-													if (installed && latest && installed === latest) {
+													if (
+														currentVersion &&
+														latestRelease.version &&
+														compareVersions(
+															currentVersion,
+															latestRelease.version,
+														) === 0
+													) {
 														return (
 															<>
 																<div className="w-2 h-2 bg-green-400 rounded-full animate-pulse" />

--- a/frontend/src/utils/version.js
+++ b/frontend/src/utils/version.js
@@ -1,0 +1,87 @@
+// Version comparison mirroring util.CompareVersions in the Go server
+// (server-source-code/internal/util/version.go). Keep the two in step: the
+// login screen and the server's update alert must agree on whether an update
+// is available, or the UI contradicts the notification.
+//
+// Pre-releases rank below their release (2.0.3-rc.4 < 2.0.3) per semver §11.
+// Edge images built from main carry a pre-release version, so this ordering is
+// what lets an edge instance recognise the eventual release as an upgrade.
+
+const stripPrefix = (v) =>
+	String(v ?? "")
+		.trim()
+		.replace(/^v/i, "");
+
+// "2.0.3-rc.4" -> { core: "2.0.3", pre: "rc.4" }. Build metadata ("+abc") is
+// discarded: semver gives it no ordering weight.
+const splitPreRelease = (version) => {
+	const v = stripPrefix(version).split("+")[0];
+	const dash = v.indexOf("-");
+	if (dash < 0) return { core: v, pre: "" };
+	return { core: v.slice(0, dash), pre: v.slice(dash + 1) };
+};
+
+const compareNumericParts = (a, b) => {
+	const pa = a.split(".");
+	const pb = b.split(".");
+	const len = Math.max(pa.length, pb.length);
+	for (let i = 0; i < len; i++) {
+		// Number("") is 0 and Number("x") is NaN; both collapse to 0 so a
+		// malformed part cannot outrank a real one.
+		const na = Number(pa[i]) || 0;
+		const nb = Number(pb[i]) || 0;
+		if (na !== nb) return na > nb ? 1 : -1;
+	}
+	return 0;
+};
+
+const isNumeric = (s) => s !== "" && /^\d+$/.test(s);
+
+// Semver §11.4: numeric identifiers compare numerically and rank below
+// alphanumeric ones, and a longer identifier list wins when all shared fields
+// are equal.
+const comparePreRelease = (pre1, pre2) => {
+	const a = pre1.split(".");
+	const b = pre2.split(".");
+	const len = Math.max(a.length, b.length);
+	for (let i = 0; i < len; i++) {
+		if (i >= a.length) return -1;
+		if (i >= b.length) return 1;
+		const na = isNumeric(a[i]);
+		const nb = isNumeric(b[i]);
+		if (na && nb) {
+			const diff = Number(a[i]) - Number(b[i]);
+			if (diff !== 0) return diff > 0 ? 1 : -1;
+		} else if (na) {
+			return -1;
+		} else if (nb) {
+			return 1;
+		} else if (a[i] !== b[i]) {
+			return a[i] > b[i] ? 1 : -1;
+		}
+	}
+	return 0;
+};
+
+/**
+ * Compare two version strings.
+ * @returns {number} 1 if v1 > v2, -1 if v1 < v2, 0 if equal.
+ */
+export const compareVersions = (v1, v2) => {
+	const a = splitPreRelease(v1);
+	const b = splitPreRelease(v2);
+
+	const core = compareNumericParts(a.core, b.core);
+	if (core !== 0) return core;
+
+	if (!a.pre && !b.pre) return 0;
+	if (!a.pre) return 1;
+	if (!b.pre) return -1;
+	return comparePreRelease(a.pre, b.pre);
+};
+
+/** True when `latest` is strictly newer than `installed`. */
+export const isUpdateAvailable = (installed, latest) => {
+	if (!stripPrefix(installed) || !stripPrefix(latest)) return false;
+	return compareVersions(latest, installed) > 0;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "patchmon",
-	"version": "2.0.3",
+	"version": "0.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "patchmon",
-			"version": "2.0.3",
+			"version": "0.0.0",
 			"license": "AGPL-3.0",
 			"workspaces": [
 				"frontend"
@@ -23,7 +23,7 @@
 		},
 		"frontend": {
 			"name": "patchmon-frontend",
-			"version": "2.0.3",
+			"version": "0.0.0",
 			"license": "AGPL-3.0",
 			"dependencies": {
 				"@dnd-kit/core": "6.3.1",
@@ -2469,9 +2469,9 @@
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-			"integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+			"integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/server-source-code/Makefile
+++ b/server-source-code/Makefile
@@ -15,9 +15,25 @@ BUILD_OUT_DIR ?= $(BUILD_DIR)
 VERSION ?= $(patsubst v%,%,$(shell git describe --tags --abbrev=0 2>/dev/null))
 VERSION_PKG := github.com/PatchMon/PatchMon/server-source-code/internal/config
 VERSION_X := $(if $(strip $(VERSION)),-X $(VERSION_PKG).DefaultVersion=$(strip $(VERSION)))
-LDFLAGS := -ldflags "-s -w $(VERSION_X)"
-# Dev builds keep symbols for debugging, so they take the version flag alone.
-DEV_LDFLAGS := $(if $(VERSION_X),-ldflags "$(VERSION_X)")
+
+# Community counts shown in the nav, login footer and setup wizard. The build
+# pipeline reads them from https://patchmon.net/socialstats/<platform> and
+# passes them in; see internal/social. Deliberately not fetched here, so
+# `make build` never touches the network. Empty values are normal and make the
+# handler fall back to its compiled-in defaults.
+SOCIAL_PKG := github.com/PatchMon/PatchMon/server-source-code/internal/social
+GITHUB_STARS ?=
+DISCORD_MEMBERS ?=
+YOUTUBE_SUBSCRIBERS ?=
+LINKEDIN_FOLLOWERS ?=
+SOCIAL_X := $(if $(strip $(GITHUB_STARS)),-X $(SOCIAL_PKG).GitHubStars=$(strip $(GITHUB_STARS))) \
+	$(if $(strip $(DISCORD_MEMBERS)),-X $(SOCIAL_PKG).DiscordMembers=$(strip $(DISCORD_MEMBERS))) \
+	$(if $(strip $(YOUTUBE_SUBSCRIBERS)),-X $(SOCIAL_PKG).YouTubeSubscribers=$(strip $(YOUTUBE_SUBSCRIBERS))) \
+	$(if $(strip $(LINKEDIN_FOLLOWERS)),-X $(SOCIAL_PKG).LinkedInFollowers=$(strip $(LINKEDIN_FOLLOWERS)))
+
+LDFLAGS := -ldflags "-s -w $(VERSION_X) $(SOCIAL_X)"
+# Dev builds keep symbols for debugging, so they take the injected flags alone.
+DEV_LDFLAGS := $(if $(strip $(VERSION_X)$(SOCIAL_X)),-ldflags "$(VERSION_X) $(SOCIAL_X)")
 BUILD_FLAGS := -buildvcs=false
 GO_CMD ?= $(shell command -v go 2>/dev/null || echo go)
 GOLANGCI_LINT_CMD ?= $(shell command -v golangci-lint 2>/dev/null || echo golangci-lint)

--- a/server-source-code/internal/handler/agent_version.go
+++ b/server-source-code/internal/handler/agent_version.go
@@ -18,7 +18,12 @@ import (
 
 const (
 	agentDNSDomain = "agent.vcheck.patchmon.net"
-	agentVersionRe = `(?i)(?:PatchMon Agent v|patchmon-agent v|version )?([0-9]+\.[0-9]+\.[0-9]+)`
+	// The pre-release group is required, not cosmetic: edge agents are stamped
+	// 2.0.3-rc.61, and capturing only the numeric core would report them as
+	// "2.0.3" here while the agent itself reports the full string. The two would
+	// never match, so every check would look like a pending update and the agent
+	// would re-download itself forever.
+	agentVersionRe = `(?i)(?:PatchMon Agent v|patchmon-agent v|version )?([0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?)`
 )
 
 // AgentVersionHandler handles agent version routes.

--- a/server-source-code/internal/handler/agent_version_test.go
+++ b/server-source-code/internal/handler/agent_version_test.go
@@ -1,0 +1,42 @@
+package handler
+
+import (
+	"regexp"
+	"testing"
+)
+
+// The bundled-agent version is parsed out of the binary's own output. If the
+// pre-release suffix is dropped here, the version the server advertises stops
+// matching the version the agent reports, and the agent self-updates on every
+// check forever.
+func TestAgentVersionRe_CapturesPreRelease(t *testing.T) {
+	re := regexp.MustCompile(agentVersionRe)
+
+	tests := []struct {
+		name   string
+		output string
+		want   string
+	}{
+		{"bare release", "2.0.2", "2.0.2"},
+		{"prefixed release", "PatchMon Agent v2.0.2", "2.0.2"},
+		{"lowercase binary name", "patchmon-agent v2.0.2", "2.0.2"},
+		{"version word", "version 2.0.2", "2.0.2"},
+		{"edge build", "PatchMon Agent v2.0.3-rc.61", "2.0.3-rc.61"},
+		{"bare edge build", "2.0.3-rc.61", "2.0.3-rc.61"},
+		{"edge build with trailing text", "PatchMon Agent v2.0.3-rc.61 (linux/amd64)", "2.0.3-rc.61"},
+		{"edge build with newline", "PatchMon Agent v2.0.3-rc.61\n", "2.0.3-rc.61"},
+		{"git describe style", "2.0.2-60-gABC123", "2.0.2-60-gABC123"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := re.FindStringSubmatch(tt.output)
+			if len(m) < 2 {
+				t.Fatalf("no match for %q", tt.output)
+			}
+			if m[1] != tt.want {
+				t.Errorf("parsed %q from %q, want %q", m[1], tt.output, tt.want)
+			}
+		})
+	}
+}

--- a/server-source-code/internal/handler/community.go
+++ b/server-source-code/internal/handler/community.go
@@ -24,14 +24,17 @@ type CommunityLinksResponse struct {
 // Default community links and stats. The counts below are the last known good
 // values and are only used when the build injected nothing; see internal/social.
 var defaultCommunityLinks = []CommunityLink{
-	{ID: "discord", URL: "https://patchmon.net/discord", Label: "Discord", Stat: "600", StatLabel: "members"},
-	{ID: "github", URL: "https://github.com/PatchMon/PatchMon", Label: "GitHub", Stat: "2.7K", StatLabel: "stars"},
-	{ID: "github_issues", URL: "https://github.com/PatchMon/PatchMon/issues", Label: "GitHub Issues"},
+	{ID: "discord", URL: "https://patchmon.net/discord", Label: "Discord", Stat: "811", StatLabel: "members"},
+	{ID: "github", URL: "https://github.com/PatchMon/PatchMon", Label: "GitHub", Stat: "3.2K", StatLabel: "stars"},
 	{ID: "email", URL: "mailto:support@patchmon.net", Label: "Email", Stat: "support@patchmon.net"},
-	{ID: "linkedin", URL: "https://linkedin.com/company/patchmon", Label: "LinkedIn", Stat: "400"},
-	{ID: "youtube", URL: "https://www.youtube.com/@PatchMonTV", Label: "YouTube", Stat: "130"},
+	{ID: "linkedin", URL: "https://linkedin.com/company/patchmon", Label: "LinkedIn", Stat: "803"},
+	{ID: "youtube", URL: "https://www.youtube.com/@PatchMonTV", Label: "YouTube", Stat: "194"},
 	{ID: "buymeacoffee", URL: "https://buymeacoffee.com/iby___", Label: "Buy Me a Coffee"},
-	{ID: "roadmap", URL: "https://github.com/orgs/PatchMon/projects/2/views/1", Label: "Roadmap"},
+	// Feature requests and bugs are tracked in two separate places: the feedback
+	// portal owns the feature roadmap, GitHub Issues owns bugs. Bugs never enter
+	// the portal, so these must not be collapsed back into one link.
+	{ID: "roadmap", URL: "https://feedback.patchmon.net/roadmap", Label: "Feature Roadmap"},
+	{ID: "github_issues", URL: "https://github.com/PatchMon/PatchMon/issues", Label: "Report a Bug"},
 	{ID: "docs", URL: "https://patchmon.net/docs", Label: "Documentation"},
 	{ID: "website", URL: "https://patchmon.net", Label: "Website"},
 }

--- a/server-source-code/internal/handler/community.go
+++ b/server-source-code/internal/handler/community.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/PatchMon/PatchMon/server-source-code/internal/config"
+	"github.com/PatchMon/PatchMon/server-source-code/internal/social"
 )
 
 // CommunityLink represents a single community/social link with optional stat.
@@ -20,7 +21,8 @@ type CommunityLinksResponse struct {
 	Links []CommunityLink `json:"links"`
 }
 
-// Default community links and stats. Override via env or config if needed.
+// Default community links and stats. The counts below are the last known good
+// values and are only used when the build injected nothing; see internal/social.
 var defaultCommunityLinks = []CommunityLink{
 	{ID: "discord", URL: "https://patchmon.net/discord", Label: "Discord", Stat: "600", StatLabel: "members"},
 	{ID: "github", URL: "https://github.com/PatchMon/PatchMon", Label: "GitHub", Stat: "2.7K", StatLabel: "stars"},
@@ -32,6 +34,32 @@ var defaultCommunityLinks = []CommunityLink{
 	{ID: "roadmap", URL: "https://github.com/orgs/PatchMon/projects/2/views/1", Label: "Roadmap"},
 	{ID: "docs", URL: "https://patchmon.net/docs", Label: "Documentation"},
 	{ID: "website", URL: "https://patchmon.net", Label: "Website"},
+}
+
+// injectedCounts maps a link ID to the raw count baked in at build time.
+var injectedCounts = map[string]*string{
+	"github":   &social.GitHubStars,
+	"discord":  &social.DiscordMembers,
+	"youtube":  &social.YouTubeSubscribers,
+	"linkedin": &social.LinkedInFollowers,
+}
+
+// applyInjectedStat overwrites a link's stat with the build-time count when one
+// was injected. A count of 0 clears the stat and its label so the UI renders the
+// link without a number, rather than showing a stale one.
+func applyInjectedStat(l *CommunityLink) {
+	raw, tracked := injectedCounts[l.ID]
+	if !tracked {
+		return
+	}
+	n, ok := social.Count(*raw)
+	if !ok {
+		return
+	}
+	l.Stat = social.Format(n)
+	if l.Stat == "" {
+		l.StatLabel = ""
+	}
 }
 
 // CommunityHandler handles community/social links (public).
@@ -57,6 +85,7 @@ func (h *CommunityHandler) GetLinks(w http.ResponseWriter, r *http.Request) {
 		if h.cfg != nil && h.cfg.AdminMode && l.ID == "buymeacoffee" {
 			continue
 		}
+		applyInjectedStat(&l)
 		links = append(links, l)
 	}
 	if h.cfg != nil && h.cfg.AdminMode && h.cfg.BillingPortalURL != "" {

--- a/server-source-code/internal/handler/community_test.go
+++ b/server-source-code/internal/handler/community_test.go
@@ -1,0 +1,96 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/PatchMon/PatchMon/server-source-code/internal/social"
+)
+
+// setInjected swaps the build-time counts for the duration of a test.
+func setInjected(t *testing.T, github, discord, youtube, linkedin string) {
+	t.Helper()
+	prev := [4]string{social.GitHubStars, social.DiscordMembers, social.YouTubeSubscribers, social.LinkedInFollowers}
+	t.Cleanup(func() {
+		social.GitHubStars, social.DiscordMembers, social.YouTubeSubscribers, social.LinkedInFollowers =
+			prev[0], prev[1], prev[2], prev[3]
+	})
+	social.GitHubStars, social.DiscordMembers, social.YouTubeSubscribers, social.LinkedInFollowers =
+		github, discord, youtube, linkedin
+}
+
+func TestApplyInjectedStat_NoInjectionKeepsDefault(t *testing.T) {
+	setInjected(t, "", "", "", "")
+
+	link := CommunityLink{ID: "github", Stat: "2.7K", StatLabel: "stars"}
+	applyInjectedStat(&link)
+
+	if link.Stat != "2.7K" || link.StatLabel != "stars" {
+		t.Errorf("got stat=%q label=%q, want the compiled-in default to survive", link.Stat, link.StatLabel)
+	}
+}
+
+func TestApplyInjectedStat_OverridesDefault(t *testing.T) {
+	setInjected(t, "3412", "755", "1200", "418")
+
+	tests := []struct {
+		id    string
+		want  string
+		label string
+	}{
+		{"github", "3.4K", "stars"},
+		{"discord", "755", "members"},
+		{"youtube", "1.2K", ""},
+		{"linkedin", "418", ""},
+	}
+
+	for _, tt := range tests {
+		link := CommunityLink{ID: tt.id, Stat: "stale", StatLabel: tt.label}
+		applyInjectedStat(&link)
+		if link.Stat != tt.want {
+			t.Errorf("%s: got stat %q, want %q", tt.id, link.Stat, tt.want)
+		}
+		if link.StatLabel != tt.label {
+			t.Errorf("%s: label changed to %q, want %q", tt.id, link.StatLabel, tt.label)
+		}
+	}
+}
+
+// A 0 means the endpoint could not determine the count. The label has to be
+// cleared with the number: LoginCommunityLinks renders the star icon off
+// statLabel alone, so a label with no stat leaves an orphan icon in the UI.
+func TestApplyInjectedStat_ZeroClearsStatAndLabel(t *testing.T) {
+	setInjected(t, "0", "0", "0", "0")
+
+	link := CommunityLink{ID: "github", Stat: "2.7K", StatLabel: "stars"}
+	applyInjectedStat(&link)
+
+	if link.Stat != "" {
+		t.Errorf("got stat %q, want it cleared", link.Stat)
+	}
+	if link.StatLabel != "" {
+		t.Errorf("got label %q, want it cleared so no orphan star icon renders", link.StatLabel)
+	}
+}
+
+func TestApplyInjectedStat_LeavesUntrackedLinksAlone(t *testing.T) {
+	setInjected(t, "3412", "755", "1200", "418")
+
+	link := CommunityLink{ID: "email", Stat: "support@patchmon.net"}
+	applyInjectedStat(&link)
+
+	if link.Stat != "support@patchmon.net" {
+		t.Errorf("got stat %q, want the email address untouched", link.Stat)
+	}
+}
+
+// Garbage from a proxy or an HTML error page must not blank the UI.
+func TestApplyInjectedStat_MalformedValueKeepsDefault(t *testing.T) {
+	setInjected(t, "<!DOCTYPE html>", "", "", "")
+
+	link := CommunityLink{ID: "github", Stat: "2.7K", StatLabel: "stars"}
+	applyInjectedStat(&link)
+
+	if link.Stat != "2.7K" {
+		t.Errorf("got stat %q, want the compiled-in default to survive", link.Stat)
+	}
+}

--- a/server-source-code/internal/social/social.go
+++ b/server-source-code/internal/social/social.go
@@ -1,0 +1,66 @@
+// Package social exposes community follower counts that are baked into the
+// binary at build time.
+//
+// The server never contacts GitHub, Discord, YouTube or LinkedIn. The build
+// reads https://patchmon.net/socialstats/<platform> once and injects the
+// numbers through -ldflags, so self-hosted instances make no outbound calls,
+// carry no API credentials, and work air-gapped.
+package social
+
+import (
+	"math"
+	"strconv"
+	"strings"
+)
+
+// Injected at build time via -ldflags -X. See server-source-code/Makefile and
+// docker/server.Dockerfile.
+//
+// Empty means the build supplied nothing (offline build, endpoint down, or a
+// plain `go build`), and callers keep their compiled-in default. "0" means the
+// endpoint reported an unknown count and the number should be hidden rather
+// than shown stale.
+var (
+	GitHubStars        = ""
+	DiscordMembers     = ""
+	YouTubeSubscribers = ""
+	LinkedInFollowers  = ""
+)
+
+// Count parses a raw injected value. ok is false when nothing usable was
+// injected, which tells the caller to keep its own default.
+func Count(raw string) (int, bool) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return 0, false
+	}
+	n, err := strconv.Atoi(trimmed)
+	if err != nil || n < 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+// Format renders a count for display: 2712 becomes "2.7K", 3400000 becomes
+// "3.4M", 612 stays "612", and anything at or below zero becomes "" so the UI
+// hides it. Mirrors formatCount in the website's social-stats.ts.
+func Format(n int) string {
+	if n <= 0 {
+		return ""
+	}
+	if n < 1000 {
+		return strconv.Itoa(n)
+	}
+	// 999500 rather than 1000000: above it the K form would round to "1000K".
+	if n < 999500 {
+		return unit(float64(n)/1000, "K")
+	}
+	return unit(float64(n)/1000000, "M")
+}
+
+func unit(value float64, suffix string) string {
+	if value >= 10 {
+		return strconv.Itoa(int(math.Round(value))) + suffix
+	}
+	return strconv.FormatFloat(math.Round(value*10)/10, 'g', -1, 64) + suffix
+}

--- a/server-source-code/internal/social/social_test.go
+++ b/server-source-code/internal/social/social_test.go
@@ -1,0 +1,63 @@
+package social
+
+import "testing"
+
+func TestCount(t *testing.T) {
+	tests := []struct {
+		name  string
+		raw   string
+		want  int
+		wanto bool
+	}{
+		{"empty means not injected", "", 0, false},
+		{"whitespace means not injected", "   ", 0, false},
+		{"zero is injected and means hide", "0", 0, true},
+		{"plain number", "2712", 2712, true},
+		{"trailing newline from curl", "612\n", 612, true},
+		{"non-numeric falls back", "2.7K", 0, false},
+		{"html error page falls back", "<!DOCTYPE html>", 0, false},
+		{"negative falls back", "-5", 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := Count(tt.raw)
+			if got != tt.want || ok != tt.wanto {
+				t.Errorf("Count(%q) = (%d, %v), want (%d, %v)", tt.raw, got, ok, tt.want, tt.wanto)
+			}
+		})
+	}
+}
+
+func TestFormat(t *testing.T) {
+	tests := []struct {
+		n    int
+		want string
+	}{
+		{0, ""},
+		{-1, ""},
+		{1, "1"},
+		{130, "130"},
+		{612, "612"},
+		{999, "999"},
+		{1000, "1K"},
+		{1049, "1K"},
+		{1050, "1.1K"},
+		{2712, "2.7K"},
+		{9949, "9.9K"},
+		{10000, "10K"},
+		{12345, "12K"},
+		{999499, "999K"},
+		{999500, "1M"},
+		{999999, "1M"},
+		{1000000, "1M"},
+		{3400000, "3.4M"},
+		{12345678, "12M"},
+	}
+
+	for _, tt := range tests {
+		if got := Format(tt.n); got != tt.want {
+			t.Errorf("Format(%d) = %q, want %q", tt.n, got, tt.want)
+		}
+	}
+}

--- a/server-source-code/internal/util/version.go
+++ b/server-source-code/internal/util/version.go
@@ -8,9 +8,47 @@ import (
 
 // CompareVersions compares two semantic versions.
 // Returns 1 if v1 > v2, -1 if v1 < v2, 0 if equal.
+//
+// Pre-release versions are supported and rank BELOW their release, per semver
+// §11: 2.0.3-rc.4 < 2.0.3. Edge images built from main carry a pre-release
+// version (see .github/actions/release-context), so this ordering is what lets
+// an edge instance recognise the eventual release as an upgrade. Getting it
+// backwards would strand edge users on a mid-cycle build forever.
 func CompareVersions(v1, v2 string) int {
-	p1 := parseVersionParts(v1)
-	p2 := parseVersionParts(v2)
+	c1, pre1 := splitPreRelease(v1)
+	c2, pre2 := splitPreRelease(v2)
+
+	if c := compareNumericParts(parseVersionParts(c1), parseVersionParts(c2)); c != 0 {
+		return c
+	}
+
+	// Cores are equal, so the pre-release decides. Absent pre-release wins:
+	// 2.0.3 outranks 2.0.3-rc.4.
+	switch {
+	case pre1 == "" && pre2 == "":
+		return 0
+	case pre1 == "":
+		return 1
+	case pre2 == "":
+		return -1
+	}
+	return comparePreRelease(pre1, pre2)
+}
+
+// splitPreRelease divides "2.0.3-rc.4" into "2.0.3" and "rc.4". Build metadata
+// ("+abc") is discarded: semver says it carries no ordering weight.
+func splitPreRelease(v string) (core, pre string) {
+	v = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(v), "v"))
+	if i := strings.IndexByte(v, '+'); i >= 0 {
+		v = v[:i]
+	}
+	if i := strings.IndexByte(v, '-'); i >= 0 {
+		return v[:i], v[i+1:]
+	}
+	return v, ""
+}
+
+func compareNumericParts(p1, p2 []int) int {
 	maxLen := len(p1)
 	if len(p2) > maxLen {
 		maxLen = len(p2)
@@ -28,6 +66,50 @@ func CompareVersions(v1, v2 string) int {
 		}
 		if a < b {
 			return -1
+		}
+	}
+	return 0
+}
+
+// comparePreRelease orders dot-separated pre-release identifiers per semver
+// §11.4: numeric identifiers compare numerically and rank below alphanumeric
+// ones, and a longer identifier list wins when all shared fields are equal.
+func comparePreRelease(pre1, pre2 string) int {
+	a := strings.Split(pre1, ".")
+	b := strings.Split(pre2, ".")
+	maxLen := len(a)
+	if len(b) > maxLen {
+		maxLen = len(b)
+	}
+	for i := 0; i < maxLen; i++ {
+		// Running out of identifiers means the shorter list ranks lower.
+		if i >= len(a) {
+			return -1
+		}
+		if i >= len(b) {
+			return 1
+		}
+		na, errA := strconv.Atoi(a[i])
+		nb, errB := strconv.Atoi(b[i])
+		switch {
+		case errA == nil && errB == nil:
+			if na != nb {
+				if na > nb {
+					return 1
+				}
+				return -1
+			}
+		case errA == nil:
+			return -1
+		case errB == nil:
+			return 1
+		default:
+			if a[i] != b[i] {
+				if a[i] > b[i] {
+					return 1
+				}
+				return -1
+			}
 		}
 	}
 	return 0

--- a/server-source-code/internal/util/version_test.go
+++ b/server-source-code/internal/util/version_test.go
@@ -1,0 +1,102 @@
+package util
+
+import "testing"
+
+func TestCompareVersions(t *testing.T) {
+	tests := []struct {
+		name string
+		v1   string
+		v2   string
+		want int
+	}{
+		{"equal", "2.0.2", "2.0.2", 0},
+		{"patch newer", "2.0.3", "2.0.2", 1},
+		{"patch older", "2.0.2", "2.0.3", -1},
+		{"minor beats patch", "2.1.0", "2.0.9", 1},
+		{"major beats minor", "3.0.0", "2.9.9", 1},
+		{"v prefix ignored", "v2.0.3", "2.0.3", 0},
+		{"whitespace ignored", " 2.0.3 ", "2.0.3", 0},
+		{"missing parts are zero", "2.0", "2.0.0", 0},
+		{"extra part outranks", "2.0.3.1", "2.0.3", 1},
+
+		// The edge-release relationship this whole scheme depends on.
+		{"rc ranks below its release", "2.0.3-rc.4", "2.0.3", -1},
+		{"release outranks its rc", "2.0.3", "2.0.3-rc.4", 1},
+		{"rc still outranks previous release", "2.0.3-rc.1", "2.0.2", 1},
+		{"previous release below rc", "2.0.2", "2.0.3-rc.1", -1},
+		{"rc numbers compare numerically", "2.0.3-rc.9", "2.0.3-rc.10", -1},
+		{"rc numbers are not lexical", "2.0.3-rc.10", "2.0.3-rc.9", 1},
+		{"identical rc", "2.0.3-rc.4", "2.0.3-rc.4", 0},
+		{"rc below next release", "2.0.3-rc.99", "2.0.4", -1},
+
+		// Semver §11.4 identifier rules.
+		{"numeric ranks below alphanumeric", "1.0.0-1", "1.0.0-alpha", -1},
+		{"alpha before beta", "1.0.0-alpha", "1.0.0-beta", -1},
+		{"longer identifier list wins", "1.0.0-alpha.1", "1.0.0-alpha", 1},
+		{"shorter identifier list loses", "1.0.0-alpha", "1.0.0-alpha.1", -1},
+
+		// Build metadata carries no ordering weight.
+		{"build metadata ignored", "2.0.3+abc", "2.0.3", 0},
+		{"build metadata on rc ignored", "2.0.3-rc.4+abc", "2.0.3-rc.4", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CompareVersions(tt.v1, tt.v2); got != tt.want {
+				t.Errorf("CompareVersions(%q, %q) = %d, want %d", tt.v1, tt.v2, got, tt.want)
+			}
+		})
+	}
+}
+
+// A malformed version must not panic or silently outrank a real one. The old
+// parser discarded Atoi errors, so "2.0.2-60-gABC" compared as 2.0.0.
+func TestCompareVersions_MalformedInput(t *testing.T) {
+	tests := []struct {
+		name string
+		v1   string
+		v2   string
+		want int
+	}{
+		{"git describe output is a pre-release of its tag", "2.0.2-60-gABC", "2.0.2", -1},
+		{"empty is lowest", "", "2.0.2", -1},
+		{"garbage parses as zero", "not-a-version", "0.0.0", -1},
+		{"both empty", "", "", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CompareVersions(tt.v1, tt.v2); got != tt.want {
+				t.Errorf("CompareVersions(%q, %q) = %d, want %d", tt.v1, tt.v2, got, tt.want)
+			}
+		})
+	}
+}
+
+// Ordering must be antisymmetric: if a > b then b < a. A one-sided bug here
+// would make the update checker agree in one direction only.
+func TestCompareVersions_IsAntisymmetric(t *testing.T) {
+	versions := []string{
+		"2.0.2", "2.0.3-rc.1", "2.0.3-rc.2", "2.0.3-rc.10", "2.0.3", "2.0.4-rc.1", "2.1.0", "3.0.0",
+	}
+	for i, a := range versions {
+		for j, b := range versions {
+			got := CompareVersions(a, b)
+			rev := CompareVersions(b, a)
+			if got != -rev {
+				t.Errorf("CompareVersions(%q, %q) = %d but reverse = %d", a, b, got, rev)
+			}
+			// The slice is in ascending order, so index order must match.
+			var want int
+			switch {
+			case i < j:
+				want = -1
+			case i > j:
+				want = 1
+			}
+			if got != want {
+				t.Errorf("CompareVersions(%q, %q) = %d, want %d (ascending fixture)", a, b, got, want)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Implementation of Major.Minor.Patch-rc.<pr> versioning so that we can still have version increments when code is pushed to main branch (:edge) for better testing and auto-updating of agents.