### PR TITLE
fix(agent): correct reboot detection across Debian, Arch, Raspberry Pi and Windows

### DIFF
--- a/agent-source-code/internal/system/reboot.go
+++ b/agent-source-code/internal/system/reboot.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 	"runtime"
 	"sort"
 	"strconv"
@@ -22,13 +23,14 @@ func (d *Detector) CheckRebootRequired() (bool, string) {
 	}
 
 	runningKernel := d.getRunningKernel()
-	latestKernel := d.getLatestInstalledKernel()
+	latestKernel := d.latestInstalledKernel(runningKernel)
+	kernelStale := kernelIsOutdated(runningKernel, latestKernel)
 
 	// Check Debian/Ubuntu - reboot-required flag file
 	if _, err := os.Stat("/var/run/reboot-required"); err == nil {
 		d.logger.Debug("Reboot required: /var/run/reboot-required file exists")
 		reason := "Reboot flag file exists (/var/run/reboot-required)"
-		if runningKernel != latestKernel && latestKernel != "" {
+		if kernelStale {
 			reason += fmt.Sprintf(" | Running kernel: %s, Installed kernel: %s", runningKernel, latestKernel)
 		}
 		return true, reason
@@ -37,14 +39,17 @@ func (d *Detector) CheckRebootRequired() (bool, string) {
 	// Check RHEL/Fedora - needs-restarting utility
 	if needsRestart, reason := d.checkNeedsRestarting(); needsRestart {
 		d.logger.WithField("reason", reason).Debug("Reboot required: needs-restarting check")
-		if runningKernel != latestKernel && latestKernel != "" {
+		if kernelStale {
 			reason += fmt.Sprintf(" | Running kernel: %s, Installed kernel: %s", runningKernel, latestKernel)
 		}
 		return true, reason
 	}
 
-	// Universal kernel check - compare running vs latest installed
-	if runningKernel != latestKernel && latestKernel != "" {
+	// Universal kernel check - a reboot is only needed when the running kernel is
+	// genuinely older than the newest installed kernel of the same line. Comparing
+	// the two as raw strings reports a reboot for any formatting difference, and
+	// never clears once the host has actually rebooted.
+	if kernelStale {
 		d.logger.WithFields(logutil.SanitizeMap(map[string]interface{}{
 			"running": runningKernel,
 			"latest":  latestKernel,
@@ -55,6 +60,15 @@ func (d *Detector) CheckRebootRequired() (bool, string) {
 
 	d.logger.Debug("No reboot required")
 	return false, ""
+}
+
+// kernelIsOutdated reports whether the running kernel is older than the newest
+// installed one. Equal or newer means no reboot is pending.
+func kernelIsOutdated(running, latest string) bool {
+	if running == "" || latest == "" {
+		return false
+	}
+	return compareKernelVersions(running, latest) < 0
 }
 
 // checkWindowsRebootRequired checks if Windows requires a reboot (per UsoClient/WUA docs)
@@ -131,38 +145,81 @@ func (d *Detector) getRunningKernel() string {
 
 // GetLatestInstalledKernel gets the latest installed kernel version (public method)
 func (d *Detector) GetLatestInstalledKernel() string {
-	return d.getLatestInstalledKernel()
+	return d.latestInstalledKernel(d.getRunningKernel())
 }
 
-// getLatestInstalledKernel gets the latest installed kernel version
-func (d *Detector) getLatestInstalledKernel() string {
-	// Try different methods based on common distro patterns
+// latestInstalledKernel returns the newest installed kernel that belongs to the
+// same line as the running one. Sources are tried in order of authority; the
+// first that yields a usable candidate wins.
+func (d *Detector) latestInstalledKernel(runningKernel string) string {
+	flavour := kernelFlavour(runningKernel)
 
-	// Method 1: Debian/Ubuntu - check /boot for vmlinuz files
-	if latest := d.getLatestKernelFromBoot(); latest != "" {
-		return latest
+	sources := []struct {
+		name    string
+		collect func() []string
+	}{
+		{"boot", d.collectKernelsFromBoot},
+		{"rpm", d.collectKernelsFromRPM},
+		{"dpkg", d.collectKernelsFromDpkg},
+		{"modules", d.collectKernelsFromModules},
 	}
 
-	// Method 2: RHEL/Fedora - use rpm to query installed kernels
-	if latest := d.getLatestKernelFromRPM(); latest != "" {
-		return latest
-	}
-
-	// Method 3: Try dpkg for Debian-based systems
-	if latest := d.getLatestKernelFromDpkg(); latest != "" {
-		return latest
+	for _, source := range sources {
+		if latest := selectLatestKernel(source.collect(), flavour); latest != "" {
+			return latest
+		}
 	}
 
 	d.logger.Debug("Could not determine latest installed kernel")
 	return ""
 }
 
-// getLatestKernelFromBoot scans /boot for vmlinuz files
-func (d *Detector) getLatestKernelFromBoot() string {
+// selectLatestKernel narrows candidates to the given flavour and returns the
+// highest version among them.
+//
+// Filtering by flavour is what keeps hosts with several kernel lines installed
+// side by side honest. A Raspberry Pi ships both the 2712 and v8 builds, and
+// neither is an upgrade of the other, so a 2712 host must only ever be compared
+// against 2712 kernels. If nothing matches the running flavour the whole set is
+// considered, which keeps behaviour sane when the running kernel is unknown.
+func selectLatestKernel(candidates []string, flavour string) string {
+	usable := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		if hasVersionCore(candidate) {
+			usable = append(usable, candidate)
+		}
+	}
+
+	if len(usable) == 0 {
+		return ""
+	}
+
+	matching := usable
+	if flavour != "" {
+		matching = make([]string, 0, len(usable))
+		for _, candidate := range usable {
+			if kernelFlavour(candidate) == flavour {
+				matching = append(matching, candidate)
+			}
+		}
+		if len(matching) == 0 {
+			matching = usable
+		}
+	}
+
+	sort.Slice(matching, func(i, j int) bool {
+		return compareKernelVersions(matching[i], matching[j]) < 0
+	})
+
+	return matching[len(matching)-1]
+}
+
+// collectKernelsFromBoot scans /boot for vmlinuz files
+func (d *Detector) collectKernelsFromBoot() []string {
 	entries, err := os.ReadDir("/boot")
 	if err != nil {
 		d.logger.WithError(err).Debug("Failed to read /boot directory")
-		return ""
+		return nil
 	}
 
 	var kernels []string
@@ -179,23 +236,54 @@ func (d *Detector) getLatestKernelFromBoot() string {
 		}
 	}
 
-	if len(kernels) == 0 {
-		return ""
+	return kernels
+}
+
+// collectKernelsFromModules lists /lib/modules, whose directory names are always
+// full kernel release strings. This is the fallback for distributions that install
+// an unversioned image such as Arch's /boot/vmlinuz-linux, where no version can be
+// recovered from the boot directory at all.
+func (d *Detector) collectKernelsFromModules() []string {
+	entries, err := os.ReadDir("/lib/modules")
+	if err != nil {
+		d.logger.WithError(err).Debug("Failed to read /lib/modules directory")
+		return nil
 	}
 
-	// Sort kernels by version and return the latest
-	sort.Slice(kernels, func(i, j int) bool {
-		return compareKernelVersions(kernels[i], kernels[j]) < 0
-	})
+	var kernels []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			kernels = append(kernels, entry.Name())
+		}
+	}
 
-	return kernels[len(kernels)-1]
+	return kernels
+}
+
+// kernelCoreRe matches a leading numeric MAJOR.MINOR version.
+var kernelCoreRe = regexp.MustCompile(`^\d+\.\d+`)
+
+// hasVersionCore reports whether a release string carries a numeric version at
+// all. Arch installs /boot/vmlinuz-linux, which yields the "version" linux and
+// can never match a running release such as 6.12.4-arch1-1.
+func hasVersionCore(release string) bool {
+	return kernelCoreRe.MatchString(release)
+}
+
+// kernelFlavour returns the component identifying which kernel line a release
+// belongs to, which is its final component: amd64, pve, generic, 2712, v8.
+func kernelFlavour(release string) string {
+	parts := parseKernelVersion(release)
+	if len(parts) == 0 {
+		return ""
+	}
+	return parts[len(parts)-1]
 }
 
 // compareKernelVersions compares two kernel version strings
 // Returns: -1 if v1 < v2, 0 if v1 == v2, 1 if v1 > v2
 // Handles formats like "6.14.11-2-pve" and "6.8.12-9-pve"
 func compareKernelVersions(v1, v2 string) int {
-	// Split version into parts: "6.14.11-2-pve" -> ["6", "14", "11", "2", "pve"]
 	parts1 := parseKernelVersion(v1)
 	parts2 := parseKernelVersion(v2)
 
@@ -214,11 +302,23 @@ func compareKernelVersions(v1, v2 string) int {
 			p2 = parts2[i]
 		}
 
-		// Try to compare as numbers first
+		if p1 == p2 {
+			continue
+		}
+
+		// A version that has run out of components ranks below one that has not.
+		if p1 == "" {
+			return -1
+		}
+		if p2 == "" {
+			return 1
+		}
+
 		n1, err1 := strconv.Atoi(p1)
 		n2, err2 := strconv.Atoi(p2)
 
-		if err1 == nil && err2 == nil {
+		switch {
+		case err1 == nil && err2 == nil:
 			// Both are numbers
 			if n1 < n2 {
 				return -1
@@ -226,72 +326,78 @@ func compareKernelVersions(v1, v2 string) int {
 			if n1 > n2 {
 				return 1
 			}
-		} else {
-			// At least one is not a number, compare as strings
+		case err1 == nil:
+			// A numeric sub-revision outranks a label at the same position, so
+			// 6.12.90+deb13.1-amd64 is newer than 6.12.90+deb13-amd64.
+			return 1
+		case err2 == nil:
+			return -1
+		default:
+			// Both are labels
 			if p1 < p2 {
 				return -1
 			}
-			if p1 > p2 {
-				return 1
-			}
+			return 1
 		}
 	}
 
 	return 0
 }
 
-// parseKernelVersion parses a kernel version string into comparable parts
-// "6.14.11-2-pve" -> ["6", "14", "11", "2", "pve"]
+// parseKernelVersion parses a kernel version string into comparable parts.
+// Splitting on "+" as well as "." and "-" keeps the patch number separate from
+// any distribution suffix, so 6.12.101+deb13-amd64 does not tokenise to
+// "101+deb13", which compares as text and ranks below "96+deb13".
+//
+//	"6.14.11-2-pve"          -> ["6" "14" "11" "2" "pve"]
+//	"6.12.90+deb13.1-amd64"  -> ["6" "12" "90" "deb13" "1" "amd64"]
 func parseKernelVersion(version string) []string {
-	// Replace dots and dashes with spaces, then split
-	version = strings.ReplaceAll(version, ".", " ")
-	version = strings.ReplaceAll(version, "-", " ")
-	parts := strings.Fields(version)
-	return parts
+	return strings.FieldsFunc(version, func(r rune) bool {
+		return r == '.' || r == '-' || r == '+'
+	})
 }
 
-// getLatestKernelFromRPM queries RPM for installed kernel packages
-func (d *Detector) getLatestKernelFromRPM() string {
+// collectKernelsFromRPM queries RPM for installed kernel packages
+func (d *Detector) collectKernelsFromRPM() []string {
 	// Check if rpm command exists
 	if _, err := exec.LookPath("rpm"); err != nil {
-		return ""
+		return nil
 	}
 
 	cmd := exec.Command("rpm", "-q", "kernel", "--last")
 	output, err := cmd.Output()
 	if err != nil {
 		d.logger.WithError(err).Debug("Failed to query RPM for kernel packages")
-		return ""
+		return nil
 	}
 
-	lines := strings.Split(string(output), "\n")
-	if len(lines) > 0 && lines[0] != "" {
-		// Parse first line which should be the latest kernel
+	var kernels []string
+	for _, line := range strings.Split(string(output), "\n") {
 		// Format: kernel-VERSION DATE
-		parts := strings.Fields(lines[0])
-		if len(parts) > 0 {
-			// Extract version from kernel-X.Y.Z
-			kernelPkg := parts[0]
-			version := strings.TrimPrefix(kernelPkg, "kernel-")
-			return version
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		if version := strings.TrimPrefix(fields[0], "kernel-"); version != fields[0] {
+			kernels = append(kernels, version)
 		}
 	}
 
-	return ""
+	return kernels
 }
 
-// getLatestKernelFromDpkg queries dpkg for installed kernel packages
-func (d *Detector) getLatestKernelFromDpkg() string {
+// collectKernelsFromDpkg queries dpkg for installed kernel packages
+func (d *Detector) collectKernelsFromDpkg() []string {
 	// Check if dpkg command exists
 	if _, err := exec.LookPath("dpkg"); err != nil {
-		return ""
+		return nil
 	}
 
 	cmd := exec.Command("dpkg", "-l")
 	output, err := cmd.Output()
 	if err != nil {
 		d.logger.WithError(err).Debug("Failed to query dpkg for kernel packages")
-		return ""
+		return nil
 	}
 
 	var kernels []string
@@ -309,13 +415,7 @@ func (d *Detector) getLatestKernelFromDpkg() string {
 			pkgName := fields[1]
 			version := strings.TrimPrefix(pkgName, "linux-image-")
 
-			// Identify meta-packages (generic, virtual, lowlatency, etc.)
-			// Also handle generic-hwe and generic-* patterns (like generic-hwe-22.04)
-			isMetaPackage := version == "generic" || version == "virtual" || version == "lowlatency" ||
-				version == "server" || version == "cloud" || version == "kvm" ||
-				version == "generic-hwe" || strings.HasPrefix(version, "generic-")
-
-			if isMetaPackage {
+			if isKernelMetaPackage(version) {
 				metaPackages[pkgName] = true
 			} else {
 				// This is an actual kernel package with version
@@ -324,23 +424,26 @@ func (d *Detector) getLatestKernelFromDpkg() string {
 		}
 	}
 
-	// If we found actual kernel versions, return the latest
 	if len(kernels) > 0 {
-		// Sort kernels by version and return the latest
-		sort.Slice(kernels, func(i, j int) bool {
-			return compareKernelVersions(kernels[i], kernels[j]) < 0
-		})
-		return kernels[len(kernels)-1]
+		return kernels
 	}
 
 	// If we only found meta-packages, resolve dependencies to find actual kernels
 	for metaPkg := range metaPackages {
 		if actualVersion := d.resolveMetaPackage(metaPkg); actualVersion != "" {
-			return actualVersion
+			kernels = append(kernels, actualVersion)
 		}
 	}
 
-	return ""
+	return kernels
+}
+
+// isKernelMetaPackage identifies meta-packages (generic, virtual, lowlatency,
+// etc.) including generic-hwe and other generic-* patterns.
+func isKernelMetaPackage(version string) bool {
+	return version == "generic" || version == "virtual" || version == "lowlatency" ||
+		version == "server" || version == "cloud" || version == "kvm" ||
+		version == "generic-hwe" || strings.HasPrefix(version, "generic-")
 }
 
 // resolveMetaPackage resolves a meta-package (like linux-image-virtual) to the actual kernel version
@@ -371,10 +474,7 @@ func (d *Detector) resolveMetaPackage(metaPkg string) string {
 			version := strings.TrimPrefix(part, "linux-image-")
 
 			// Skip if this is another meta-package
-			// Also handle generic-hwe and generic-* patterns
-			if version == "generic" || version == "virtual" || version == "lowlatency" ||
-				version == "server" || version == "cloud" || version == "kvm" ||
-				version == "generic-hwe" || strings.HasPrefix(version, "generic-") {
+			if isKernelMetaPackage(version) {
 				continue
 			}
 

--- a/agent-source-code/internal/system/reboot.go
+++ b/agent-source-code/internal/system/reboot.go
@@ -72,7 +72,11 @@ func kernelIsOutdated(running, latest string) bool {
 }
 
 // checkWindowsRebootRequired checks if Windows requires a reboot (per UsoClient/WUA docs)
-// Checks: RebootRequired registry, PendingFileRenameOperations, CBS reboot-pending
+// Checks: Windows Update RebootRequired and Component Based Servicing reboot-pending.
+//
+// PendingFileRenameOperations is deliberately not consulted. Ordinary application
+// updaters write to that key during routine self-updates, so treating it as a
+// reboot signal marks healthy hosts as needing a reboot indefinitely.
 func (d *Detector) checkWindowsRebootRequired() (bool, string) {
 	psScript := `
 $ErrorActionPreference = "SilentlyContinue"
@@ -81,10 +85,6 @@ $reasons = @()
 # Windows Update RebootRequired
 $wu = Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired" -ErrorAction SilentlyContinue
 if ($wu) { $reasons += "Windows Update requires reboot" }
-
-# Pending file rename operations (installer pending reboot)
-$pfro = Get-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager" -Name PendingFileRenameOperations -ErrorAction SilentlyContinue
-if ($pfro -and $pfro.PendingFileRenameOperations) { $reasons += "Pending file rename operations" }
 
 # Component Based Servicing (CBS) reboot pending
 $cbs = Get-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending" -ErrorAction SilentlyContinue

--- a/agent-source-code/internal/system/reboot.go
+++ b/agent-source-code/internal/system/reboot.go
@@ -134,6 +134,12 @@ func (d *Detector) checkNeedsRestarting() (bool, string) {
 
 // getRunningKernel gets the currently running kernel version
 func (d *Detector) getRunningKernel() string {
+	// Windows has no uname and no kernel-package model, so asking would fork a
+	// process per report only to fail and warn.
+	if runtime.GOOS == "windows" {
+		return ""
+	}
+
 	cmd := exec.Command("uname", "-r")
 	output, err := cmd.Output()
 	if err != nil {
@@ -165,7 +171,11 @@ func (d *Detector) latestInstalledKernel(runningKernel string) string {
 	}
 
 	for _, source := range sources {
-		if latest := selectLatestKernel(source.collect(), flavour); latest != "" {
+		if latest := d.selectLatestKernel(source.collect(), flavour); latest != "" {
+			d.logger.WithFields(logutil.SanitizeMap(map[string]interface{}{
+				"source": source.name,
+				"latest": latest,
+			})).Debug("Resolved latest installed kernel")
 			return latest
 		}
 	}
@@ -182,7 +192,7 @@ func (d *Detector) latestInstalledKernel(runningKernel string) string {
 // neither is an upgrade of the other, so a 2712 host must only ever be compared
 // against 2712 kernels. If nothing matches the running flavour the whole set is
 // considered, which keeps behaviour sane when the running kernel is unknown.
-func selectLatestKernel(candidates []string, flavour string) string {
+func (d *Detector) selectLatestKernel(candidates []string, flavour string) string {
 	usable := make([]string, 0, len(candidates))
 	for _, candidate := range candidates {
 		if hasVersionCore(candidate) {
@@ -203,6 +213,10 @@ func selectLatestKernel(candidates []string, flavour string) string {
 			}
 		}
 		if len(matching) == 0 {
+			d.logger.WithFields(logutil.SanitizeMap(map[string]interface{}{
+				"flavour":    flavour,
+				"candidates": usable,
+			})).Debug("No installed kernel matches the running line, comparing against all")
 			matching = usable
 		}
 	}
@@ -270,14 +284,24 @@ func hasVersionCore(release string) bool {
 	return kernelCoreRe.MatchString(release)
 }
 
-// kernelFlavour returns the component identifying which kernel line a release
-// belongs to, which is its final component: amd64, pve, generic, 2712, v8.
+// kernelFlavour returns a key identifying which kernel line a release belongs
+// to: amd64, pve, generic, rpt-rpi for the Pi 5 build, arch or zen.
+//
+// It keeps the components that name the line and discards those that only carry
+// a revision, so that releases from one line always agree. Purely numeric
+// components are revisions (the 1 in deb13.1, the pkgrel in arch1-1), and a
+// trailing number on a label marks a point release (el9_4 and el9_5 are both
+// el), so both are dropped. A release with no labels at all yields an empty
+// flavour, which means the running line is unknown and every candidate counts.
 func kernelFlavour(release string) string {
-	parts := parseKernelVersion(release)
-	if len(parts) == 0 {
-		return ""
+	var labels []string
+	for _, part := range parseKernelVersion(release) {
+		if _, err := strconv.Atoi(part); err == nil {
+			continue
+		}
+		labels = append(labels, strings.TrimRight(part, "0123456789_"))
 	}
-	return parts[len(parts)-1]
+	return strings.Join(labels, "-")
 }
 
 // compareKernelVersions compares two kernel version strings
@@ -414,6 +438,9 @@ func (d *Detector) collectKernelsFromDpkg() []string {
 		if fields[0] == "ii" && strings.HasPrefix(fields[1], "linux-image-") {
 			pkgName := fields[1]
 			version := strings.TrimPrefix(pkgName, "linux-image-")
+			// Ubuntu ships linux-image-unsigned-<release>-<flavour> alongside
+			// the signed build; both name the same kernel.
+			version = strings.TrimPrefix(version, "unsigned-")
 
 			if isKernelMetaPackage(version) {
 				metaPackages[pkgName] = true

--- a/agent-source-code/internal/system/reboot_test.go
+++ b/agent-source-code/internal/system/reboot_test.go
@@ -1,6 +1,17 @@
 package system
 
-import "testing"
+import (
+	"io"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func newTestLogger() *logrus.Logger {
+	logger := logrus.New()
+	logger.SetOutput(io.Discard)
+	return logger
+}
 
 // Cases marked with an issue number reproduce a reported bug. Cases from the
 // community pull requests #818 (egrueda) and #834 (jbcr) are carried over here.
@@ -96,15 +107,23 @@ func TestKernelFlavour(t *testing.T) {
 		release string
 		want    string
 	}{
-		{"6.12.101+deb13-amd64", "amd64"},
-		{"6.12.90+deb13.1-amd64", "amd64"},
+		{"6.12.101+deb13-amd64", "deb-amd"},
+		{"6.12.90+deb13.1-amd64", "deb-amd"},
 		{"6.14.11-2-pve", "pve"},
 		{"5.15.0-100-generic", "generic"},
 		{"5.15.0-100-lowlatency", "lowlatency"},
-		{"5.14.0-427.13.1.el9_4.x86_64", "x86_64"},
+		{"5.14.0-427.13.1.el9_4.x86_64", "el-x"},
+		{"6.6.60-0-lts", "lts"},
+		{"5.14.21-150500.55.83-default", "default"},
 		// Issue #647: the Pi 5 and Pi 4 builds are separate kernel lines.
-		{"6.12.47+rpt-rpi-2712", "2712"},
-		{"6.12.47+rpt-rpi-v8", "v8"},
+		{"6.12.47+rpt-rpi-2712", "rpt-rpi"},
+		{"6.12.47+rpt-rpi-v8", "rpt-rpi-v"},
+		// Arch keeps several lines side by side, all with pkgrel 1.
+		{"6.12.4-arch1-1", "arch"},
+		{"6.12.4-zen1-1", "zen"},
+		{"6.12.4-lts1-1", "lts"},
+		// A release with no labels leaves the line unknown, so every candidate counts.
+		{"6.12.4", ""},
 		{"", ""},
 	}
 
@@ -112,6 +131,46 @@ func TestKernelFlavour(t *testing.T) {
 		t.Run(tt.release, func(t *testing.T) {
 			if got := kernelFlavour(tt.release); got != tt.want {
 				t.Errorf("kernelFlavour(%q) = %q, want %q", tt.release, got, tt.want)
+			}
+		})
+	}
+}
+
+// Kernels of one line must always agree on a flavour, or a real pending reboot
+// goes unreported. Kernels of different lines must not, or an unrelated build
+// masquerades as an upgrade.
+func TestKernelFlavourGrouping(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        string
+		b        string
+		sameLine bool
+	}{
+		{"debian revision", "6.12.90+deb13-amd64", "6.12.90+deb13.1-amd64", true},
+		{"debian patch", "6.12.101+deb13-amd64", "6.12.96+deb13-amd64", true},
+		{"rhel point release", "5.14.0-427.13.1.el9_4.x86_64", "5.14.0-503.11.1.el9_5.x86_64", true},
+		{"ubuntu abi bump", "5.15.0-100-generic", "5.15.0-91-generic", true},
+		{"ubuntu ga to hwe", "5.15.0-119-generic", "6.8.0-51-generic", true},
+		{"proxmox", "6.14.11-2-pve", "6.8.12-9-pve", true},
+		{"suse", "5.14.21-150500.55.83-default", "5.14.21-150500.55.91-default", true},
+		{"alpine", "6.6.60-0-lts", "6.6.72-0-lts", true},
+		{"arch pkgrel bump", "6.12.4-arch1-1", "6.13.1-arch1-2", true},
+		{"unversioned pair", "6.12.4", "6.13.9", true},
+
+		{"pi 2712 against v8", "6.12.47+rpt-rpi-2712", "6.12.47+rpt-rpi-v8", false},
+		{"ubuntu generic against lowlatency", "5.15.0-100-generic", "5.15.0-100-lowlatency", false},
+		{"arch against zen", "6.12.4-arch1-1", "6.12.4-zen1-1", false},
+		{"arch against lts", "6.12.4-arch1-1", "6.12.4-lts1-1", false},
+		{"debian against cloud", "6.1.0-18-amd64", "6.1.0-18-cloud-amd64", false},
+		{"debian against realtime", "6.1.0-18-amd64", "6.1.0-18-rt-amd64", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			same := kernelFlavour(tt.a) == kernelFlavour(tt.b)
+			if same != tt.sameLine {
+				t.Errorf("kernelFlavour(%q)=%q vs kernelFlavour(%q)=%q: same line = %v, want %v",
+					tt.a, kernelFlavour(tt.a), tt.b, kernelFlavour(tt.b), same, tt.sameLine)
 			}
 		})
 	}
@@ -142,6 +201,8 @@ func TestHasVersionCore(t *testing.T) {
 }
 
 func TestSelectLatestKernel(t *testing.T) {
+	d := &Detector{logger: newTestLogger()}
+
 	tests := []struct {
 		name       string
 		candidates []string
@@ -153,13 +214,13 @@ func TestSelectLatestKernel(t *testing.T) {
 			// behind once apt autoremove cleared the intermediate kernel.
 			name:       "946 picks the highest patch",
 			candidates: []string{"6.12.90+deb13.1-amd64", "6.12.96+deb13-amd64", "6.12.101+deb13-amd64"},
-			flavour:    "amd64",
+			flavour:    kernelFlavour("6.12.96+deb13-amd64"),
 			want:       "6.12.101+deb13-amd64",
 		},
 		{
 			name:       "946 still correct after autoremove",
 			candidates: []string{"6.12.90+deb13.1-amd64", "6.12.101+deb13-amd64"},
-			flavour:    "amd64",
+			flavour:    kernelFlavour("6.12.96+deb13-amd64"),
 			want:       "6.12.101+deb13-amd64",
 		},
 		{
@@ -167,13 +228,13 @@ func TestSelectLatestKernel(t *testing.T) {
 			// even when the v8 build carries a higher version.
 			name:       "647 keeps to the running SoC variant",
 			candidates: []string{"6.12.47+rpt-rpi-2712", "6.12.50+rpt-rpi-v8"},
-			flavour:    "2712",
+			flavour:    kernelFlavour("6.12.47+rpt-rpi-2712"),
 			want:       "6.12.47+rpt-rpi-2712",
 		},
 		{
 			name:       "647 v8 host sees only v8",
 			candidates: []string{"6.12.47+rpt-rpi-2712", "6.12.50+rpt-rpi-v8"},
-			flavour:    "v8",
+			flavour:    kernelFlavour("6.12.47+rpt-rpi-v8"),
 			want:       "6.12.50+rpt-rpi-v8",
 		},
 		{
@@ -181,19 +242,41 @@ func TestSelectLatestKernel(t *testing.T) {
 			// caller falls through to a source that reports real versions.
 			name:       "553 discards unversioned entries",
 			candidates: []string{"linux"},
-			flavour:    "1",
+			flavour:    kernelFlavour("6.12.4-arch1-1"),
 			want:       "",
 		},
 		{
 			name:       "553 modules directory resolves arch",
 			candidates: []string{"6.12.4-arch1-1", "6.13.1-arch1-1"},
-			flavour:    "1",
+			flavour:    kernelFlavour("6.12.4-arch1-1"),
 			want:       "6.13.1-arch1-1",
+		},
+		{
+			// Arch keeps linux and linux-zen side by side and both carry pkgrel 1,
+			// so the zen build must not be mistaken for an upgrade of linux.
+			name:       "arch ignores the zen line",
+			candidates: []string{"6.12.4-arch1-1", "6.12.4-zen1-1"},
+			flavour:    kernelFlavour("6.12.4-arch1-1"),
+			want:       "6.12.4-arch1-1",
+		},
+		{
+			name:       "debian ignores the cloud line",
+			candidates: []string{"6.1.0-18-amd64", "6.1.0-20-cloud-amd64"},
+			flavour:    kernelFlavour("6.1.0-18-amd64"),
+			want:       "6.1.0-18-amd64",
+		},
+		{
+			// A release with no labels leaves the line unknown, so a genuine
+			// upgrade must still be seen rather than filtered out by its patch number.
+			name:       "unlabelled release still sees an upgrade",
+			candidates: []string{"6.12.4", "6.13.9"},
+			flavour:    kernelFlavour("6.12.4"),
+			want:       "6.13.9",
 		},
 		{
 			name:       "falls back to all when flavour matches nothing",
 			candidates: []string{"6.14.11-2-pve", "6.8.12-9-pve"},
-			flavour:    "amd64",
+			flavour:    kernelFlavour("6.12.101+deb13-amd64"),
 			want:       "6.14.11-2-pve",
 		},
 		{
@@ -205,15 +288,15 @@ func TestSelectLatestKernel(t *testing.T) {
 		{
 			name:       "ignores the other ubuntu line",
 			candidates: []string{"5.15.0-100-lowlatency", "5.15.0-91-generic"},
-			flavour:    "generic",
+			flavour:    kernelFlavour("5.15.0-91-generic"),
 			want:       "5.15.0-91-generic",
 		},
-		{"no candidates", nil, "amd64", ""},
+		{"no candidates", nil, "deb-amd", ""},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := selectLatestKernel(tt.candidates, tt.flavour); got != tt.want {
+			if got := d.selectLatestKernel(tt.candidates, tt.flavour); got != tt.want {
 				t.Errorf("selectLatestKernel(%q, %q) = %q, want %q", tt.candidates, tt.flavour, got, tt.want)
 			}
 		})

--- a/agent-source-code/internal/system/reboot_test.go
+++ b/agent-source-code/internal/system/reboot_test.go
@@ -1,0 +1,247 @@
+package system
+
+import "testing"
+
+// Cases marked with an issue number reproduce a reported bug. Cases from the
+// community pull requests #818 (egrueda) and #834 (jbcr) are carried over here.
+
+func TestParseKernelVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    []string
+	}{
+		{"proxmox", "6.14.11-2-pve", []string{"6", "14", "11", "2", "pve"}},
+		{"debian", "6.12.90+deb13-amd64", []string{"6", "12", "90", "deb13", "amd64"}},
+		{"debian sub-revision", "6.12.90+deb13.1-amd64", []string{"6", "12", "90", "deb13", "1", "amd64"}},
+		{"ubuntu", "5.15.0-100-generic", []string{"5", "15", "0", "100", "generic"}},
+		{"raspberry pi", "6.12.47+rpt-rpi-2712", []string{"6", "12", "47", "rpt", "rpi", "2712"}},
+		{"rhel", "5.14.0-427.13.1.el9_4.x86_64", []string{"5", "14", "0", "427", "13", "1", "el9_4", "x86_64"}},
+		{"arch unversioned", "linux", []string{"linux"}},
+		{"empty", "", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseKernelVersion(tt.version)
+			if len(got) != len(tt.want) {
+				t.Fatalf("parseKernelVersion(%q) = %q, want %q", tt.version, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("parseKernelVersion(%q) = %q, want %q", tt.version, got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestCompareKernelVersions(t *testing.T) {
+	tests := []struct {
+		name string
+		v1   string
+		v2   string
+		want int
+	}{
+		// Issue #946: the patch number must not fuse to the Debian suffix.
+		// "101+deb13" compares as text and ranks below "96+deb13".
+		{"946 higher patch wins", "6.12.101+deb13-amd64", "6.12.96+deb13-amd64", 1},
+		{"946 lower patch loses", "6.12.96+deb13-amd64", "6.12.101+deb13-amd64", -1},
+		{"946 latest beats both", "6.12.101+deb13-amd64", "6.12.90+deb13.1-amd64", 1},
+
+		// Issue #814: a Debian sub-revision is newer than the base revision.
+		{"814 deb13.1 newer than deb13", "6.12.90+deb13.1-amd64", "6.12.90+deb13-amd64", 1},
+		{"814 deb13 older than deb13.1", "6.12.90+deb13-amd64", "6.12.90+deb13.1-amd64", -1},
+		{"814 identical", "6.12.90+deb13.1-amd64", "6.12.90+deb13.1-amd64", 0},
+		{"814 upstream beats sub-revision", "6.12.91+deb13-amd64", "6.12.90+deb13.1-amd64", 1},
+		{"deb13.2 newer than deb13.1", "6.12.90+deb13.2-amd64", "6.12.90+deb13.1-amd64", 1},
+		{"major wins over deb suffix", "7.0.10+deb13-amd64", "6.12.90+deb13.1-amd64", 1},
+		{"minor compared numerically", "7.0.10+deb13-amd64", "7.0.7+deb13-amd64", 1},
+
+		// Proxmox, the format the original implementation documented.
+		{"pve higher minor", "6.14.11-2-pve", "6.8.12-9-pve", 1},
+		{"pve higher build", "6.8.12-10-pve", "6.8.12-9-pve", 1},
+		{"pve lower build", "6.8.12-2-pve", "6.8.12-9-pve", -1},
+		{"pve higher patch", "6.8.15-1-pve", "6.8.12-9-pve", 1},
+		{"pve identical", "6.14.11-2-pve", "6.14.11-2-pve", 0},
+		{"pve beats ubuntu major", "6.14.11-2-pve", "5.19.0-1-generic", 1},
+
+		// Ubuntu ABI numbers must compare numerically, not as text.
+		{"ubuntu higher abi", "5.15.0-100-generic", "5.15.0-91-generic", 1},
+		{"ubuntu identical", "5.15.0-91-generic", "5.15.0-91-generic", 0},
+
+		// RHEL point releases.
+		{"rhel newer point release", "5.14.0-503.11.1.el9_5.x86_64", "5.14.0-427.13.1.el9_4.x86_64", 1},
+		{"rhel identical", "5.14.0-427.13.1.el9_4.x86_64", "5.14.0-427.13.1.el9_4.x86_64", 0},
+
+		// Arch.
+		{"arch identical", "7.0.9-hardened1-1-hardened", "7.0.9-hardened1-1-hardened", 0},
+		{"arch newer patch", "6.13.1-arch1-1", "6.12.4-arch1-1", 1},
+
+		// Raspberry Pi, same version across two SoC variants.
+		{"rpi same version", "6.12.62+rpt-rpi-2712", "6.12.62+rpt-rpi-2712", 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := compareKernelVersions(tt.v1, tt.v2); got != tt.want {
+				t.Errorf("compareKernelVersions(%q, %q) = %d, want %d", tt.v1, tt.v2, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKernelFlavour(t *testing.T) {
+	tests := []struct {
+		release string
+		want    string
+	}{
+		{"6.12.101+deb13-amd64", "amd64"},
+		{"6.12.90+deb13.1-amd64", "amd64"},
+		{"6.14.11-2-pve", "pve"},
+		{"5.15.0-100-generic", "generic"},
+		{"5.15.0-100-lowlatency", "lowlatency"},
+		{"5.14.0-427.13.1.el9_4.x86_64", "x86_64"},
+		// Issue #647: the Pi 5 and Pi 4 builds are separate kernel lines.
+		{"6.12.47+rpt-rpi-2712", "2712"},
+		{"6.12.47+rpt-rpi-v8", "v8"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.release, func(t *testing.T) {
+			if got := kernelFlavour(tt.release); got != tt.want {
+				t.Errorf("kernelFlavour(%q) = %q, want %q", tt.release, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHasVersionCore(t *testing.T) {
+	tests := []struct {
+		release string
+		want    bool
+	}{
+		{"6.12.101+deb13-amd64", true},
+		{"6.14.11-2-pve", true},
+		{"6.12.4-arch1-1", true},
+		// Issue #553: Arch installs an unversioned image, which carries no
+		// version information and must never be treated as the latest kernel.
+		{"linux", false},
+		{"linux-lts", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.release, func(t *testing.T) {
+			if got := hasVersionCore(tt.release); got != tt.want {
+				t.Errorf("hasVersionCore(%q) = %v, want %v", tt.release, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSelectLatestKernel(t *testing.T) {
+	tests := []struct {
+		name       string
+		candidates []string
+		flavour    string
+		want       string
+	}{
+		{
+			// Issue #946: the true latest was never selected, and dropped further
+			// behind once apt autoremove cleared the intermediate kernel.
+			name:       "946 picks the highest patch",
+			candidates: []string{"6.12.90+deb13.1-amd64", "6.12.96+deb13-amd64", "6.12.101+deb13-amd64"},
+			flavour:    "amd64",
+			want:       "6.12.101+deb13-amd64",
+		},
+		{
+			name:       "946 still correct after autoremove",
+			candidates: []string{"6.12.90+deb13.1-amd64", "6.12.101+deb13-amd64"},
+			flavour:    "amd64",
+			want:       "6.12.101+deb13-amd64",
+		},
+		{
+			// Issue #647: a 2712 host must never be compared against the v8 build,
+			// even when the v8 build carries a higher version.
+			name:       "647 keeps to the running SoC variant",
+			candidates: []string{"6.12.47+rpt-rpi-2712", "6.12.50+rpt-rpi-v8"},
+			flavour:    "2712",
+			want:       "6.12.47+rpt-rpi-2712",
+		},
+		{
+			name:       "647 v8 host sees only v8",
+			candidates: []string{"6.12.47+rpt-rpi-2712", "6.12.50+rpt-rpi-v8"},
+			flavour:    "v8",
+			want:       "6.12.50+rpt-rpi-v8",
+		},
+		{
+			// Issue #553: an unversioned Arch image yields no candidate, so the
+			// caller falls through to a source that reports real versions.
+			name:       "553 discards unversioned entries",
+			candidates: []string{"linux"},
+			flavour:    "1",
+			want:       "",
+		},
+		{
+			name:       "553 modules directory resolves arch",
+			candidates: []string{"6.12.4-arch1-1", "6.13.1-arch1-1"},
+			flavour:    "1",
+			want:       "6.13.1-arch1-1",
+		},
+		{
+			name:       "falls back to all when flavour matches nothing",
+			candidates: []string{"6.14.11-2-pve", "6.8.12-9-pve"},
+			flavour:    "amd64",
+			want:       "6.14.11-2-pve",
+		},
+		{
+			name:       "unknown running flavour considers everything",
+			candidates: []string{"5.15.0-91-generic", "5.15.0-100-generic"},
+			flavour:    "",
+			want:       "5.15.0-100-generic",
+		},
+		{
+			name:       "ignores the other ubuntu line",
+			candidates: []string{"5.15.0-100-lowlatency", "5.15.0-91-generic"},
+			flavour:    "generic",
+			want:       "5.15.0-91-generic",
+		},
+		{"no candidates", nil, "amd64", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := selectLatestKernel(tt.candidates, tt.flavour); got != tt.want {
+				t.Errorf("selectLatestKernel(%q, %q) = %q, want %q", tt.candidates, tt.flavour, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKernelIsOutdated(t *testing.T) {
+	tests := []struct {
+		name    string
+		running string
+		latest  string
+		want    bool
+	}{
+		{"running is older", "6.12.96+deb13-amd64", "6.12.101+deb13-amd64", true},
+		// Issue #831: the flag must clear once the host has actually rebooted.
+		{"831 clears after reboot", "6.12.101+deb13-amd64", "6.12.101+deb13-amd64", false},
+		// Issue #647: same version across variants is not a pending reboot.
+		{"647 same version", "6.12.47+rpt-rpi-2712", "6.12.47+rpt-rpi-2712", false},
+		{"running is newer after rollback", "6.12.101+deb13-amd64", "6.12.96+deb13-amd64", false},
+		{"no latest known", "6.12.101+deb13-amd64", "", false},
+		{"no running known", "", "6.12.101+deb13-amd64", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := kernelIsOutdated(tt.running, tt.latest); got != tt.want {
+				t.Errorf("kernelIsOutdated(%q, %q) = %v, want %v", tt.running, tt.latest, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes five open issues about false or incorrect reboot notifications, all of which turned out to share a small number of root causes in `internal/system/reboot.go`. That file had not changed since v2.0.2 and had no test coverage at all.

Closes #946
Closes #814
Closes #647
Closes #553
Closes #772

## Three defects, not one

**1. Tokenising ignored `+`.** `parseKernelVersion` split on `.` and `-` only, so a Debian release became `["6" "12" "101+deb13" "amd64"]`. That token is not a number, so the comparison fell through to text, where `"101+deb13"` ranks below `"96+deb13"` because `'1' < '9'`. The newest kernel was therefore never selected.

This reproduces #946 exactly. With `6.12.90+deb13.1`, `6.12.96+deb13` and `6.12.101+deb13` installed, the old ordering picks `6.12.96`, matching the reporter's log up to 08:56. Once `apt autoremove` cleared 96, it picks `6.12.90+deb13.1`, matching every line from 09:01 onward. The true latest never appeared at any point.

**2. The decision compared strings, not versions.** `CheckRebootRequired` used `runningKernel != latestKernel`, so any formatting difference reported a pending reboot and the flag never cleared once the host had rebooted.

**3. `/boot` was trusted even when it carried no version.** It is consulted first and returned whatever it found, which made the RPM and dpkg fallbacks unreachable. Arch installs an unversioned `vmlinuz-linux`, yielding the "version" `linux`, which can never equal `uname -r`, so every Arch host reported a pending reboot permanently.

## What changed

- Split on `+`, and rank a numeric component above a label at the same position, so `deb13.1` sorts above `deb13`
- Narrow candidates to the running kernel's line before comparing. A Raspberry Pi carries both the 2712 and v8 builds and neither is an upgrade of the other, so a Pi 5 host is now only compared against 2712 kernels
- Discard `/boot` entries with no version, and add `/lib/modules` as a last resort since its directory names are always real kernel releases. This is what unblocks Arch
- Decide by version comparison, so a reboot is reported only when the running kernel is genuinely older
- Drop `PendingFileRenameOperations` from the Windows check, kept as a separate commit so it can be reverted alone

## Grouping kernels by line

Review of the first pass found that taking the final component as the kernel line was wrong in two ways, both confirmed false negatives:

- A release with no label, such as a self-built `6.12.4`, took its patch number as the line, so an installed `6.13.9` was filtered out and a real pending reboot went unreported
- Arch keeps `linux`, `linux-zen` and `linux-rt` side by side and all end in pkgrel `1`, so the filter could not separate them and the zen build was reported as an upgrade of linux, permanently. Debian has the same shape with its cloud and realtime kernels

The line is now the labelled components with revision numbers dropped, so `arch` and `zen` separate while `deb13` and `deb13.1` stay together, and `el9_4` and `el9_5` stay together so a RHEL point release upgrade is still seen.

## Testing

`reboot.go` had no tests. This adds coverage across Debian, Ubuntu (including GA to HWE), RHEL, SUSE, Alpine, Proxmox, Arch and Raspberry Pi, with a case tied to each issue number.

Grouping is asserted in both directions, because a wrong grouping either hides a real reboot or invents one. The issue-specific assertions were checked against the pre-fix implementation and genuinely fail on `main`.

`make check` passes clean: fmt, vet, golangci-lint and tests.

## Behaviour change worth noting in the release

Hosts currently showing a false "needs reboot" will flip to "no reboot required" after upgrading. That is the intended outcome, but across a fleet it will look like reboot alerts disappearing.

On Windows, a third-party installer that only sets `PendingFileRenameOperations` will no longer report a pending reboot. Windows Update `RebootRequired` and Component Based Servicing remain, which are the two authoritative signals.

## Credit

@egrueda in #818 and @jbcr in #834 each diagnosed the `+` tokenising defect independently and correctly. Their test cases are carried over here and both PRs are credited in the commit message. Thank you both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)