### PR TITLE
fix(dashboard): label the silent-hosts segment for what it counts

### DIFF
--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -106,10 +106,11 @@ ChartJS.register(
 	Title,
 );
 
-// Hosts-page filter shared by the errored-hosts card and the "Errored" segment
-// of the update-status chart. The server-side `inactive` filter resolves to the
-// same "active host, silent past 2x the update interval" set the card counts,
-// so the count and the resulting list always agree.
+// Hosts-page filter for the not-reporting card. The server-side `inactive`
+// filter resolves to the same "active host, silent past 2x the update interval"
+// set the card counts, so the count and the resulting list always agree. The
+// update-status chart reaches the same list through the `filter` its segment
+// carries, rather than through this constant.
 const ERRORED_HOSTS_FILTER = "inactive";
 
 // Drag-to-resize handle on the right edge of a card in edit mode
@@ -340,23 +341,13 @@ const Dashboard = () => {
 		if (elements.length > 0 && stats?.charts?.updateStatusDistribution) {
 			const elementIndex = elements[0].index;
 			const statusItem = stats.charts.updateStatusDistribution[elementIndex];
-			if (!statusItem?.name) return;
 
-			const statusName = statusItem.name;
-			// Map status names to filter parameters
-			let filter = "";
-			if (statusName.toLowerCase().includes("needs updates")) {
-				filter = "needsUpdates";
-			} else if (statusName.toLowerCase().includes("up to date")) {
-				filter = "upToDate";
-			} else if (statusName.toLowerCase().includes("errored")) {
-				filter = ERRORED_HOSTS_FILTER;
-			} else if (statusName.toLowerCase().includes("stale")) {
-				filter = "stale";
-			}
-
-			if (filter) {
-				navigate(`/hosts?filter=${filter}`, { replace: true });
+			// The segment carries the filter it links to. Deriving it from the
+			// display label instead breaks silently the moment a segment is
+			// renamed: no branch matches, no filter is applied, and the click
+			// lands on an unfiltered host list that looks like it worked.
+			if (statusItem?.filter) {
+				navigate(`/hosts?filter=${statusItem.filter}`, { replace: true });
 			}
 		}
 	};
@@ -2310,7 +2301,7 @@ const Dashboard = () => {
 				backgroundColor: [
 					"#10B981", // Green - Up to date
 					"#F59E0B", // Yellow - Needs updates
-					"#EF4444", // Red - Errored
+					"#EF4444", // Red - Not reporting
 				],
 				borderWidth: 0,
 			},

--- a/server-source-code/internal/store/dashboard.go
+++ b/server-source-code/internal/store/dashboard.go
@@ -30,6 +30,30 @@ func (s *DashboardStore) withWorkMem(ctx context.Context, fn func(q *db.Queries)
 	return withWorkMemTx(ctx, s.db, fn)
 }
 
+// updateStatusSegments builds the update-status chart's segments.
+//
+// Every segment carries the Hosts-page filter it links to, so the dashboard
+// never maps a display label back to a filter. That keeps renaming a segment a
+// display-only change: deriving the filter from the label breaks silently the
+// moment the wording moves, because no branch matches and the click lands on an
+// unfiltered host list.
+//
+// The third segment reads "Not reporting" rather than "Errored" because that is
+// what it counts — hosts silent past the reporting threshold. GetDashboardStats
+// inlines that predicate as (status = 'active' AND last_update < $1) OR
+// status = 'inactive', mirroring the effective_status = 'inactive' column
+// GetHostsWithCounts filters on so the count and the list it links to agree.
+// Whether the last job succeeded does not enter into it, so a host that patched
+// cleanly and then stopped checking in belongs here, while one whose run failed
+// but is still reporting does not.
+func updateStatusSegments(upToDate, needsUpdates, notReporting int) []map[string]interface{} {
+	return []map[string]interface{}{
+		{"name": "Up to date", "filter": "upToDate", "count": upToDate},
+		{"name": "Needs updates", "filter": "needsUpdates", "count": needsUpdates},
+		{"name": "Not reporting", "filter": "inactive", "count": notReporting},
+	}
+}
+
 // GetStats returns dashboard statistics matching Node backend structure for frontend compatibility.
 func (s *DashboardStore) GetStats(ctx context.Context) (map[string]interface{}, error) {
 	now := time.Now()
@@ -109,11 +133,7 @@ func (s *DashboardStore) GetStats(ctx context.Context) (map[string]interface{}, 
 		}
 	}
 
-	updateStatusDistribution := []map[string]interface{}{
-		{"name": "Up to date", "count": upToDateHosts},
-		{"name": "Needs updates", "count": hostsNeedingUpdates},
-		{"name": "Errored", "count": erroredHosts},
-	}
+	updateStatusDistribution := updateStatusSegments(upToDateHosts, hostsNeedingUpdates, erroredHosts)
 
 	regularUpdates := totalOutdatedPackages - securityUpdates
 	if regularUpdates < 0 {

--- a/server-source-code/internal/store/dashboard_segments_test.go
+++ b/server-source-code/internal/store/dashboard_segments_test.go
@@ -1,0 +1,61 @@
+package store
+
+import "testing"
+
+// The update-status chart navigates by the filter its segment carries. A
+// segment without one is not a cosmetic problem: the click falls through and
+// lands on an unfiltered host list, which reads as having worked. These tests
+// pin that contract so a fourth segment cannot be added without a filter, and
+// so the three filters stay the ones the Hosts page actually understands.
+func TestUpdateStatusSegments_EverySegmentCarriesAFilter(t *testing.T) {
+	t.Parallel()
+
+	for _, seg := range updateStatusSegments(1, 2, 3) {
+		name, ok := seg["name"].(string)
+		if !ok || name == "" {
+			t.Fatalf("segment %v has no display name", seg)
+		}
+		filter, ok := seg["filter"].(string)
+		if !ok || filter == "" {
+			t.Fatalf("segment %q carries no Hosts-page filter", name)
+		}
+	}
+}
+
+func TestUpdateStatusSegments_FiltersMatchTheHostsPage(t *testing.T) {
+	t.Parallel()
+
+	// "inactive" is the filter the not-reporting card already links to, and the
+	// one whose server-side effective_status predicate the chart's own count is
+	// computed from. The two must stay in step or the count and the list it
+	// links to disagree.
+	want := []struct{ name, filter string }{
+		{"Up to date", "upToDate"},
+		{"Needs updates", "needsUpdates"},
+		{"Not reporting", "inactive"},
+	}
+
+	got := updateStatusSegments(0, 0, 0)
+	if len(got) != len(want) {
+		t.Fatalf("expected %d segments, got %d", len(want), len(got))
+	}
+	for i, w := range want {
+		if got[i]["name"] != w.name {
+			t.Errorf("segment %d: expected name %q, got %v", i, w.name, got[i]["name"])
+		}
+		if got[i]["filter"] != w.filter {
+			t.Errorf("segment %d (%s): expected filter %q, got %v", i, w.name, w.filter, got[i]["filter"])
+		}
+	}
+}
+
+func TestUpdateStatusSegments_CountsLandOnTheRightSegment(t *testing.T) {
+	t.Parallel()
+
+	got := updateStatusSegments(7, 11, 13)
+	for i, want := range []int{7, 11, 13} {
+		if got[i]["count"] != want {
+			t.Errorf("segment %d (%v): expected count %d, got %v", i, got[i]["name"], want, got[i]["count"])
+		}
+	}
+}


### PR DESCRIPTION
Closes #929.

The Update Status chart's third segment was labelled **Errored** while counting
hosts that have gone quiet past the reporting threshold. The card sitting beside
it already describes that same set accurately — *"{n} hosts haven't reported in
{interval}+"* — so the two widgets disagreed about what the same number means.
Whether a host's last job succeeded never enters into the count, which is why a
host that patched cleanly and then stopped checking in showed up as errored.

The segment now reads **Not reporting**.

## Renaming it needed the click-through fixed first

`handleUpdateStatusChartClick` derived the Hosts-page filter from the display
label:

```js
if (statusName.toLowerCase().includes("needs updates")) {
    filter = "needsUpdates";
} else if (statusName.toLowerCase().includes("up to date")) {
    ...
} else if (statusName.toLowerCase().includes("errored")) {
```

Move the wording and no branch matches, no filter is applied, and the click
lands on an unfiltered host list that looks like it worked — the same failure
mode that was just closed for this widget. So each segment now carries the
filter it links to, and the label becomes display-only.

## What this PR does

1. **`fix(dashboard)`** — `updateStatusSegments()` in `internal/store/dashboard.go`
   builds the segments, each with an explicit `filter` key.
2. **`fix(dashboard)`** — `handleUpdateStatusChartClick` navigates by
   `statusItem.filter` instead of matching the label.
3. **`fix(dashboard)`** — the third segment is renamed to "Not reporting".
4. The handler's `stale` branch goes with it: the chart has only ever had three
   segments and none of them was named `stale`, so that branch was unreachable.

Deliberately **not** changed: the `cards.erroredHosts` JSON field, the count
itself, and the SQL behind it. This changes what the segment is called and how
the click resolves, not what it counts — renaming the API field would be a
breaking change and is a separate decision.

## Tests

`internal/store/dashboard_segments_test.go` pins the contract the frontend now
depends on: every segment carries a non-empty filter, the three filters are the
ones the Hosts page understands, and the counts land on the right segment. A
segment without a filter is not a cosmetic problem — the click falls through and
shows an unfiltered list, which reads as having worked.

Verified by mutation: dropping the `"filter"` key from the third segment fails
two of the three new tests.

`gofmt -l`, `go vet ./internal/...`, `golangci-lint run ./internal/...`
(0 issues) and `go test ./internal/...` are clean. `biome check
frontend/src/pages/Dashboard.jsx` is clean and `npm run test:run` passes
12 files / 177 tests, 3 skipped.

Checked before touching the label: it had exactly one behavioural consumer
(the `includes("errored")` branch), the chart colours are index-based, and the
legend renders from `item.name` — so nothing else keyed on the old string.

## Three things left deliberately, for you to judge

- `ERRORED_HOSTS_FILTER` keeps its name, pairing with the `cards.erroredHosts`
  field above rather than with the new label. Renaming it alone would leave the
  vocabulary split differently rather than fix it; happy to take it further if
  you want the field renamed too.
- `"inactive"` now appears both in the Go segment and in that frontend constant.
  Before this change the constant was the only copy. Converging them — the card
  taking its filter from the API as the chart now does — felt like scope this
  issue does not cover, but say the word.
- `handlePackagePriorityChartClick`, directly below, still matches on
  `priorityItem?.name`. It is the same fragile pattern, out of scope here since
  `packageUpdateDistribution` carries no `filter` key to switch to. Glad to open
  a follow-up if you would like it done the same way.

## AI Disclosure

- **Used AI:** yes
- **Model(s):** Claude Opus 5 (1M context)
- **Harness / tool:** Claude Code CLI
- **Scope:** code, tests, commit message and this PR description
- **Human review completed:** yes — reviewed by me line by line. The single
  behavioural consumer of the old label, the unreachable `stale` branch, the
  index-based colours, and the mutation run were each checked against the code
  rather than taken from the model's description; a first draft of the doc
  comment named `effective_status` as if it were a column in
  `GetDashboardStats`, which it is not — that query inlines the predicate, and
  the comment was corrected before this PR was opened.
