### PR TITLE
Auto-assign Bug type on new issues, patch dependency advisories

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: "Bug Report"
 description: Report a bug or unexpected behavior
-title: "[Bug]: "
 labels: ["bug"]
+type: Bug
 body:
   - type: markdown
     attributes:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,7 +38,7 @@
 		"react-icons": "^5.6.0",
 		"react-is": "18.3.1",
 		"react-markdown": "9.0.1",
-		"react-router-dom": "6.30.3",
+		"react-router-dom": "6.30.4",
 		"recharts": "2.15.0"
 	},
 	"devDependencies": {

--- a/frontend/src/__tests__/contexts/ConfirmContext.test.jsx
+++ b/frontend/src/__tests__/contexts/ConfirmContext.test.jsx
@@ -152,6 +152,10 @@ describe("ConfirmContext", () => {
 
 	it("throws when used outside a provider", () => {
 		const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+		// React re-throws through a DOM error event, which jsdom reports to its
+		// own console unless the event is cancelled.
+		const swallow = (event) => event.preventDefault();
+		window.addEventListener("error", swallow);
 		const Bare = () => {
 			useConfirm();
 			return null;
@@ -159,6 +163,7 @@ describe("ConfirmContext", () => {
 		expect(() => render(<Bare />)).toThrow(
 			"useConfirm must be used within a ConfirmProvider",
 		);
+		window.removeEventListener("error", swallow);
 		spy.mockRestore();
 	});
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
 				"react-icons": "^5.6.0",
 				"react-is": "18.3.1",
 				"react-markdown": "9.0.1",
-				"react-router-dom": "6.30.3",
+				"react-router-dom": "6.30.4",
 				"recharts": "2.15.0"
 			},
 			"devDependencies": {
@@ -1298,9 +1298,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@remix-run/router": {
-			"version": "1.23.2",
-			"resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-			"integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+			"version": "1.23.3",
+			"resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz",
+			"integrity": "sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=14.0.0"
@@ -5268,9 +5268,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.16",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-			"integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+			"version": "3.3.18",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+			"integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
 			"dev": true,
 			"funding": [
 				{
@@ -5897,12 +5897,12 @@
 			}
 		},
 		"node_modules/react-router": {
-			"version": "6.30.3",
-			"resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-			"integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+			"version": "6.30.4",
+			"resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz",
+			"integrity": "sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==",
 			"license": "MIT",
 			"dependencies": {
-				"@remix-run/router": "1.23.2"
+				"@remix-run/router": "1.23.3"
 			},
 			"engines": {
 				"node": ">=14.0.0"
@@ -5912,13 +5912,13 @@
 			}
 		},
 		"node_modules/react-router-dom": {
-			"version": "6.30.3",
-			"resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-			"integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+			"version": "6.30.4",
+			"resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz",
+			"integrity": "sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@remix-run/router": "1.23.2",
-				"react-router": "6.30.3"
+				"@remix-run/router": "1.23.3",
+				"react-router": "6.30.4"
 			},
 			"engines": {
 				"node": ">=14.0.0"


### PR DESCRIPTION
Three small, unrelated changes that were grouped because the pre-commit `vuln-check` hook blocks a commit until the dependency advisories are cleared.

## Issue template

New bug reports now carry the organisation `Bug` issue type at creation, alongside the existing `bug` label, so they arrive typed without manual triage.

Dropped the `[Bug]: ` title prefix. It is redundant now that `blank_issues_enabled: false` means the bug form is the only way to open an issue, and the type is set automatically. The prefix has also been stripped from the 82 open issues that carried it.

## Dependency advisories

- `nanoid` 3.3.16 to 3.3.18, clearing the **high** severity advisory ([GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8)) that was blocking commits. Transitive via `postcss`, so no manifest change was needed.
- `react-router-dom` 6.30.3 to 6.30.4, which pulls `@remix-run/router` 1.23.3.

Worth noting: `npm audit` advises that the router fix requires `react-router-dom@7.18.2` and a breaking major migration. That is wrong. 6.30.4 exists and carries the patched router, so this is a patch bump.

Two moderate advisories against `react-router` itself do remain, covering all of 6.x, and those genuinely need the v7 migration. Left for their own branch. The hook does not block on moderate.

## Test output hygiene

The `ConfirmContext` negative test asserts that `useConfirm()` throws outside a provider. It passes, but printed a full uncaught-exception stack trace on every run. The existing `console.error` spy never suppressed it because the output does not come from `console`: React re-throws during render via a DOM error event, and jsdom reports that to its own virtual console. Cancelling the event suppresses it.

No behaviour change, and the test was already passing.

## Verification

- `npm audit --audit-level=high` exits 0
- `govulncheck` clean on both server and agent
- Frontend: 177 passed, 3 skipped
- Biome clean
- All six pre-commit hooks green