### PR TITLE
Recognise security advisories by shape, not by vendor prefix

### DIFF
--- a/agent-source-code/internal/packages/dnf.go
+++ b/agent-source-code/internal/packages/dnf.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -12,6 +13,10 @@ import (
 
 	"github.com/sirupsen/logrus"
 )
+
+// Vendor advisory identifiers all share the shape PREFIX-YEAR:SEQUENCE, for
+// example RHSA-2025:1234, ALSA-2025:11140, RLSA-2025:5678, ELSA-2025-1234.
+var advisoryIDRe = regexp.MustCompile(`^[A-Z]{2,10}-\d{4}[:-]\d+`)
 
 // DNFManager handles dnf/yum package information collection
 type DNFManager struct {
@@ -275,16 +280,11 @@ func (m *DNFManager) getSecurityPackages(packageManager string) map[string]bool 
 			continue
 		}
 
-		// Skip lines that don't start with advisory IDs
-		// Common advisory ID prefixes: RHSA (Red Hat), ALSA (AlmaLinux), ELSA (Oracle/Enterprise Linux), CESA (CentOS)
-		// This filters out header lines like "expiration"
+		// Match the advisory ID by shape rather than by a list of known
+		// vendor prefixes, so a new distribution does not silently report
+		// zero security updates. Filters out header lines like "expiration".
 		advisoryID := fields[0]
-		isAdvisory := strings.HasPrefix(advisoryID, "RHSA") ||
-			strings.HasPrefix(advisoryID, "ALSA") ||
-			strings.HasPrefix(advisoryID, "ELSA") ||
-			strings.HasPrefix(advisoryID, "CESA")
-
-		if !isAdvisory {
+		if !advisoryIDRe.MatchString(advisoryID) {
 			continue
 		}
 

--- a/agent-source-code/internal/packages/dnf_advisory_test.go
+++ b/agent-source-code/internal/packages/dnf_advisory_test.go
@@ -1,0 +1,38 @@
+package packages
+
+import "testing"
+
+// #867: the advisory filter was a fixed list of vendor prefixes, so Rocky's
+// RLSA-* notices were discarded and a host with 188 security errata reported
+// zero. Matching on shape instead means a new distribution does not silently
+// under-report.
+func TestAdvisoryIDRe(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		want bool
+	}{
+		{"rocky", "RLSA-2025:5678", true},
+		{"redhat", "RHSA-2025:1234", true},
+		{"alma", "ALSA-2025:11140", true},
+		{"centos", "CESA-2025:0001", true},
+		{"oracle dash separator", "ELSA-2025-1234", true},
+		{"fedora style", "FEDORA-2025:9999", true},
+
+		{"summary header", "Updates", false},
+		{"metadata header", "Last", false},
+		{"expiration header", "expiration", false},
+		{"lowercase prefix", "rhsa-2025:1234", false},
+		{"package name", "glib2-2.68.4-16.el9_6.2.x86_64", false},
+		{"no year", "RHSA-25:1234", false},
+		{"empty", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := advisoryIDRe.MatchString(tt.id); got != tt.want {
+				t.Errorf("advisoryIDRe.MatchString(%q) = %v, want %v", tt.id, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The security classifier matched a fixed list of advisory prefixes: RHSA, ALSA, ELSA and CESA. Rocky issues `RLSA-*` identifiers, which were not on that list, so every Rocky security notice was dropped. A host reporting 188 security errata from `dnf updateinfo summary` showed zero in PatchMon.

Rather than adding RLSA and waiting for the next rebuild to hit the same wall, this matches the shape all of them share, `PREFIX-YEAR:SEQUENCE`. Covers the existing four, Rocky, and anything added later.

Tests cover each vendor plus the header lines the old prefix check was there to filter out.

Fixes #867