### PR TITLE
Use dnf/yum upgrade rather than install for selected packages

### DIFF
--- a/agent-source-code/cmd/patchmon-agent/commands/serve.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/serve.go
@@ -2363,14 +2363,16 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 					}
 				}
 			default: // dnf, yum
+				// "install" on an already-installed package is a no-op on
+				// dnf/yum, unlike apt-get install which upgrades it.
 				if dryRun {
-					args := append([]string{"install", "--assumeno"}, packageNames...)
-					if err, abort := runStep(true, upgradeBin+" install --assumeno", upgradeBin+" install --assumeno failed: %w", upgradeBin, args...); abort {
+					args := append([]string{"upgrade", "--assumeno"}, packageNames...)
+					if err, abort := runStep(true, upgradeBin+" upgrade --assumeno", upgradeBin+" upgrade --assumeno failed: %w", upgradeBin, args...); abort {
 						stepErr = err
 					}
 				} else {
-					args := append([]string{"install", "-y"}, packageNames...)
-					if err, abort := runStep(false, upgradeBin+" install", upgradeBin+" install failed: %w", upgradeBin, args...); abort {
+					args := append([]string{"upgrade", "-y"}, packageNames...)
+					if err, abort := runStep(false, upgradeBin+" upgrade", upgradeBin+" upgrade failed: %w", upgradeBin, args...); abort {
 						stepErr = err
 					}
 				}


### PR DESCRIPTION
Approving specific packages on a RHEL family host ran `dnf install <pkg>`, which does nothing when the package is already there. dnf reported "Package ... is already installed" and the run came back successful with everything still on its old version.

Swapped to `upgrade` for the dnf and yum branch only. The apt branch above it deliberately keeps `install`, because `apt-get install` does upgrade an installed package, and FreeBSD and pacman are untouched.

Thanks to @jcaino and @TMS-Namespace for pinning down the right verb in the thread.

Fixes #741