### PR TITLE
Reject dnf banner lines that parse as packages on RHEL

### DIFF
--- a/agent-source-code/internal/packages/dnf.go
+++ b/agent-source-code/internal/packages/dnf.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"slices"
+	"strconv"
 	"strings"
 
 	"patchmon-agent/pkg/models"
@@ -41,6 +42,23 @@ var rpmArchSuffixes = map[string]bool{
 	"s390x":   true,
 	"riscv64": true,
 	"src":     true,
+}
+
+// An RPM EVR is "[epoch:]version-release": it always starts with a digit
+// (epoch or version) and always carries a release separated by a hyphen.
+// Both conditions together are enough to tell a version column apart from
+// an English word.
+func looksLikeRPMVersion(s string) bool {
+	s = strings.TrimPrefix(s, "*") // yum marks obsoleting packages with a leading *
+	if i := strings.Index(s, ":"); i > 0 {
+		if _, err := strconv.Atoi(s[:i]); err == nil {
+			s = s[i+1:]
+		}
+	}
+	if s == "" || s[0] < '0' || s[0] > '9' {
+		return false
+	}
+	return strings.Contains(s, "-")
 }
 
 // Both parsers must agree: CombinePackageData keys its upgradable set on
@@ -352,6 +370,14 @@ func (m *DNFManager) parseUpgradablePackages(output string, packageManager strin
 			continue
 		}
 
+		// A real row is "name.arch  epoch:version-release  repo". Banner lines
+		// such as "Updating Subscription Management repositories." also have
+		// three or more fields, so the column has to be validated by shape or
+		// they are ingested as packages.
+		if !looksLikeRPMVersion(fields[1]) {
+			continue
+		}
+
 		packageName := stripRPMArchSuffix(fields[0])
 		availableVersion := fields[1]
 
@@ -446,7 +472,7 @@ func (m *DNFManager) parseInstalledPackages(output string) map[string]models.Pac
 		parts := strings.Fields(trimmed)
 
 		// Normal single-line format: "name.arch  version  repo"
-		if len(parts) >= 3 {
+		if len(parts) >= 3 && looksLikeRPMVersion(parts[1]) {
 			packageName := stripRPMArchSuffix(parts[0])
 			version := parts[1]
 			installedPackages[packageName] = models.Package{

--- a/agent-source-code/internal/packages/dnf_checkupdate_test.go
+++ b/agent-source-code/internal/packages/dnf_checkupdate_test.go
@@ -1,0 +1,79 @@
+package packages
+
+import (
+	"io"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestLooksLikeRPMVersion(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		{"5.0.1-1.el10", true},
+		{"1:3.2.4-4.fc42", true},
+		{"9.9p1-11.fc42", true},
+		{"20250101-3.el9", true},
+		{"*1.2.3-4.el9", true}, // yum marks obsoleting packages with a leading *
+
+		{"Subscription", false}, // #415: the banner line's second column
+		{"Management", false},
+		{"repositories.", false},
+		{"available", false},
+		{"5.0.1", false}, // no release component
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		if got := looksLikeRPMVersion(tt.in); got != tt.want {
+			t.Errorf("looksLikeRPMVersion(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}
+
+// #415: on RHEL hosts registered with subscription-manager, check-update
+// prints a banner line that survives the field-count guard and was ingested
+// as a package called "Updating" at version "Subscription".
+func TestParseUpgradablePackages_IgnoresSubscriptionManagerBanner(t *testing.T) {
+	log := logrus.New()
+	log.SetOutput(io.Discard)
+	m := &DNFManager{logger: log}
+
+	output := `Updating Subscription Management repositories.
+Last metadata expiration check: 0:42:20 ago on Mon 05 Jan 2026 11:52:38 AM CET.
+
+docker-compose-plugin.x86_64      5.0.1-1.el10     docker-ce-stable
+openssl-libs.x86_64               1:3.2.4-4.fc42   updates
+`
+
+	// The banner appears in "list installed" output too, and that is what made
+	// the phantom survive: the installed parser recorded Updating=Subscription,
+	// which then satisfied the non-empty currentVersion guard below.
+	installedOutput := `Updating Subscription Management repositories.
+Installed Packages
+docker-compose-plugin.x86_64      5.0.0-1.el10     @docker-ce-stable
+openssl-libs.x86_64               1:3.2.3-1.fc42   @updates
+`
+	installed := m.parseInstalledPackages(installedOutput)
+	if _, ok := installed["Updating"]; ok {
+		t.Error(`parseInstalledPackages ingested the banner as a package named "Updating"`)
+	}
+
+	got := m.parseUpgradablePackages(output, "dnf", installed, map[string]bool{})
+
+	names := make([]string, 0, len(got))
+	for _, p := range got {
+		names = append(names, p.Name)
+	}
+
+	if len(got) != 2 {
+		t.Fatalf("parsed %d packages %v, want 2 (banner must not become a package)", len(got), names)
+	}
+	for _, n := range names {
+		if n == "Updating" {
+			t.Errorf("banner line was ingested as a package: %v", names)
+		}
+	}
+}


### PR DESCRIPTION
On a host registered with subscription-manager, dnf prints "Updating Subscription Management repositories." That line has four fields, so it cleared the field count guard and was ingested as a package called `Updating` sitting at version `Subscription`.

@gruch4 pointed at the check-update parser, which is where it shows up, but fixing only that one would not have been enough. The same banner appears in `dnf list installed` too, so the installed parser recorded `Updating=Subscription`, and that entry then satisfied the non-empty current version guard in the check-update parser. The two were propping each other up, which is why the existing guard never caught it.

Both parsers now validate the version column by shape instead of blacklisting three known banner strings by substring, so any future banner gets rejected on its own merits. Confirmed the test fails without the change and passes with it.

Thanks @gruch4 and @wannesrams for the report and for confirming it on AlmaLinux too.

Fixes #415