### PR TITLE
Read the newest completed task for the automations Last Run column

### DIFF
--- a/server-source-code/internal/handler/automation.go
+++ b/server-source-code/internal/handler/automation.go
@@ -86,6 +86,69 @@ func (h *AutomationHandler) getQueueStats(queueName string) QueueStats {
 	}
 }
 
+// completedPageSize bounds the single page read to find the newest completion.
+const completedPageSize = 100
+
+// latestCompletedTask returns the most recently completed task on a queue, or
+// nil if there are none.
+//
+// Asynq keeps completed tasks in a sorted set scored by retention expiry and
+// ListCompletedTasks returns them in ascending score order, so the first page
+// holds the OLDEST retained completion, not the newest. Reading page one made
+// "Last Run" freeze at whatever completed first and stay there until retention
+// evicted it, while the total-runs counter kept climbing.
+func (h *AutomationHandler) latestCompletedTask(queueName string) *asynq.TaskInfo {
+	info, err := h.inspector.GetQueueInfo(queueName)
+	if err != nil || info.Completed == 0 {
+		return nil
+	}
+
+	lastPage := lastCompletedPage(info.Completed, completedPageSize)
+	tasks, err := h.inspector.ListCompletedTasks(queueName,
+		asynq.PageSize(completedPageSize), asynq.Page(lastPage))
+	if err != nil {
+		return nil
+	}
+	if len(tasks) == 0 && lastPage > 1 {
+		// The set shrank between the count and the read; fall back to page one
+		// rather than reporting "never run".
+		tasks, err = h.inspector.ListCompletedTasks(queueName, asynq.PageSize(completedPageSize))
+		if err != nil {
+			return nil
+		}
+	}
+	if len(tasks) == 0 {
+		return nil
+	}
+
+	return newestByCompletedAt(tasks)
+}
+
+// lastCompletedPage returns the 1-based page holding the highest-scored
+// entries for a set of the given size.
+func lastCompletedPage(completed, pageSize int) int {
+	if completed <= 0 || pageSize <= 0 {
+		return 1
+	}
+	return (completed + pageSize - 1) / pageSize
+}
+
+// newestByCompletedAt picks the latest completion from a page. The set is
+// scored by expiry rather than completion time, so tasks carrying different
+// retentions can interleave and position alone is not enough.
+func newestByCompletedAt(tasks []*asynq.TaskInfo) *asynq.TaskInfo {
+	var newest *asynq.TaskInfo
+	for _, t := range tasks {
+		if t == nil {
+			continue
+		}
+		if newest == nil || t.CompletedAt.After(newest.CompletedAt) {
+			newest = t
+		}
+	}
+	return newest
+}
+
 // getQueueLastRunInfo returns lastRun, lastRunTs, and status from Asynq/Redis for a queue.
 // Checks completed, active, retry, and archived tasks to reflect exact queue state.
 func (h *AutomationHandler) getQueueLastRunInfo(queueName string) (lastRun string, lastRunTs int64, status string) {
@@ -93,9 +156,8 @@ func (h *AutomationHandler) getQueueLastRunInfo(queueName string) (lastRun strin
 		return "Never", 0, "Never run"
 	}
 
-	// 1. Completed tasks (most recent first) - only present when Retention is set
-	if tasks, err := h.inspector.ListCompletedTasks(queueName, asynq.PageSize(1)); err == nil && len(tasks) > 0 {
-		t := tasks[0]
+	// 1. Completed tasks - only present when Retention is set
+	if t := h.latestCompletedTask(queueName); t != nil {
 		lastRunTs = t.CompletedAt.UnixMilli()
 		lastRun = t.CompletedAt.Format("1/2/2006, 3:04:05 PM")
 		if t.LastErr != "" {

--- a/server-source-code/internal/handler/automation_lastrun_test.go
+++ b/server-source-code/internal/handler/automation_lastrun_test.go
@@ -1,0 +1,72 @@
+package handler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hibiken/asynq"
+)
+
+// #698: asynq returns completed tasks oldest first, so reading page one made
+// "Last Run" freeze at the first retained completion while the total-runs
+// counter kept climbing. The newest completion lives on the final page.
+func TestLastCompletedPage(t *testing.T) {
+	tests := []struct {
+		name      string
+		completed int
+		pageSize  int
+		want      int
+	}{
+		{"empty", 0, 100, 1},
+		{"single task", 1, 100, 1},
+		{"exactly one full page", 100, 100, 1},
+		{"one past a full page", 101, 100, 2},
+		{"several pages", 752, 100, 8},
+		{"exact multiple", 300, 100, 3},
+		{"guards zero page size", 50, 0, 1},
+		{"guards negative count", -5, 100, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := lastCompletedPage(tt.completed, tt.pageSize); got != tt.want {
+				t.Errorf("lastCompletedPage(%d, %d) = %d, want %d",
+					tt.completed, tt.pageSize, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNewestByCompletedAt(t *testing.T) {
+	base := time.Date(2026, 8, 8, 12, 0, 0, 0, time.UTC)
+	mk := func(offset time.Duration) *asynq.TaskInfo {
+		return &asynq.TaskInfo{CompletedAt: base.Add(offset)}
+	}
+
+	t.Run("picks the latest regardless of position", func(t *testing.T) {
+		// Retention differences mean expiry order need not match completion
+		// order, so the newest is not reliably last.
+		tasks := []*asynq.TaskInfo{
+			mk(10 * time.Minute),
+			mk(45 * time.Minute),
+			mk(5 * time.Minute),
+		}
+		got := newestByCompletedAt(tasks)
+		if got == nil || !got.CompletedAt.Equal(base.Add(45*time.Minute)) {
+			t.Errorf("got %v, want %v", got, base.Add(45*time.Minute))
+		}
+	})
+
+	t.Run("empty page yields nil", func(t *testing.T) {
+		if got := newestByCompletedAt(nil); got != nil {
+			t.Errorf("got %v, want nil", got)
+		}
+	})
+
+	t.Run("skips nil entries", func(t *testing.T) {
+		got := newestByCompletedAt([]*asynq.TaskInfo{nil, mk(time.Minute), nil})
+		if got == nil || !got.CompletedAt.Equal(base.Add(time.Minute)) {
+			t.Errorf("got %v, want %v", got, base.Add(time.Minute))
+		}
+	})
+}


### PR DESCRIPTION
Asynq keeps completed tasks in a sorted set scored by retention expiry and returns them oldest first. We were calling `ListCompletedTasks` with `PageSize(1)` and taking the first result, so the Last Run column showed the oldest retained completion and sat there until retention evicted it. Meanwhile Total Task Runs kept climbing, which is exactly what @dlmorgan999 described.

The comment on that call said "most recent first", so it read as correct at a glance. That is really what hid it.

Now walks to the final page and picks the newest `CompletedAt` explicitly, since tasks with different retentions can interleave and position alone is not enough to trust.

Thanks @dlmorgan999 for the report, and @FyWolf and @henningsieh for confirming it after upgrading.

Fixes #698