### PR TITLE
Read the apt security pocket from the origin list, not the whole line

### DIFF
--- a/agent-source-code/internal/packages/apt.go
+++ b/agent-source-code/internal/packages/apt.go
@@ -386,7 +386,10 @@ func (m *APTManager) isCacheStale(maxAgeMinutes int) bool {
 // trailing architecture field is bracketed too, so scanning for "the first
 // [...] field" picks up [amd64] on those lines and reports it as the installed
 // version. Some lines also end in a bare [], which a scan happily absorbs.
-var aptInstRe = regexp.MustCompile(`^Inst\s+(\S+)\s+(?:\[([^\]]*)\]\s+)?\(([^\s)]+)`)
+// The trailing group is the origin list, which is the only part that may be
+// searched for the security pocket: the package name is on the same line and
+// 43 packages in Debian main contain "security" in their name.
+var aptInstRe = regexp.MustCompile(`^Inst\s+(\S+)\s+(?:\[([^\]]*)\]\s+)?\(([^\s)]+)([^)]*)`)
 
 // parseAPTUpgrade parses apt/apt-get upgrade simulation output
 func (m *APTManager) parseAPTUpgrade(output string) []models.Package {
@@ -407,6 +410,7 @@ func (m *APTManager) parseAPTUpgrade(output string) []models.Package {
 			continue
 		}
 		packageName, currentVersion, availableVersion := match[1], match[2], match[3]
+		origins := match[4]
 
 		// No current version means apt is installing this package rather than
 		// upgrading it, so there is nothing on the host to be out of date.
@@ -421,7 +425,7 @@ func (m *APTManager) parseAPTUpgrade(output string) []models.Package {
 			CurrentVersion:   currentVersion,
 			AvailableVersion: availableVersion,
 			NeedsUpdate:      true,
-			IsSecurityUpdate: strings.Contains(strings.ToLower(line), "security"),
+			IsSecurityUpdate: strings.Contains(strings.ToLower(origins), "security"),
 		})
 	}
 

--- a/agent-source-code/internal/packages/apt_security_origin_test.go
+++ b/agent-source-code/internal/packages/apt_security_origin_test.go
@@ -1,0 +1,68 @@
+package packages
+
+import (
+	"io"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+// The security pocket must be read from the origin list only. The package name
+// sits on the same line, and Debian main ships packages whose names contain
+// "security" (libapache2-mod-security2, modsecurity-crs, debian-security-support
+// and around 40 others), which a whole-line match flags as security updates.
+func TestParseAPTUpgrade_SecurityIsReadFromOriginNotPackageName(t *testing.T) {
+	log := logrus.New()
+	log.SetOutput(io.Discard)
+	m := &APTManager{logger: log}
+
+	output := `Inst libssl1.1 [1.1.1w-0+deb11u7] (1.1.1w-0+deb11u8 Debian-Security:11/oldoldstable [armhf])
+Inst libapache2-mod-security2 [2.9.3-3] (2.9.3-4 Raspbian:11/oldoldstable [armhf])
+Inst modsecurity-crs [3.3.2-1] (3.3.3-1 Debian:11/oldoldstable [all])
+Inst debian-security-support [1:11+2021.03.15] (1:11+2022.02.02 Debian:11/oldoldstable [all])
+Inst curl [7.74.0-1.3+deb11u11] (7.74.0-1.3+deb11u14 Debian-Security:11/oldoldstable [armhf])
+`
+
+	got := m.parseAPTUpgrade(output)
+
+	want := map[string]bool{
+		"libssl1.1":                true,
+		"libapache2-mod-security2": false,
+		"modsecurity-crs":          false,
+		"debian-security-support":  false,
+		"curl":                     true,
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("parsed %d packages, want %d", len(got), len(want))
+	}
+	for _, p := range got {
+		expected, ok := want[p.Name]
+		if !ok {
+			t.Errorf("unexpected package %q", p.Name)
+			continue
+		}
+		if p.IsSecurityUpdate != expected {
+			t.Errorf("%s: IsSecurityUpdate = %v, want %v", p.Name, p.IsSecurityUpdate, expected)
+		}
+	}
+}
+
+// Raspbian publishes no security suite at all, so nothing on a Raspberry Pi OS
+// host can be classified. Recorded so the behaviour is deliberate rather than
+// accidental: see #782.
+func TestParseAPTUpgrade_RaspbianHasNoSecurityOrigin(t *testing.T) {
+	log := logrus.New()
+	log.SetOutput(io.Discard)
+	m := &APTManager{logger: log}
+
+	output := `Inst openssl [1.1.1w-0+deb11u7] (1.1.1w-0+deb11u8 Raspbian:11/oldoldstable [armhf])
+Inst libpng16-16 [1.6.37-3] (1.6.37-3+deb11u4 Raspbian:11/oldoldstable [armhf])
+`
+
+	for _, p := range m.parseAPTUpgrade(output) {
+		if p.IsSecurityUpdate {
+			t.Errorf("%s flagged as a security update, but Raspbian carries no security origin", p.Name)
+		}
+	}
+}


### PR DESCRIPTION
Came out of digging into #782. It does not close that one, but it is a real bug on its own.

The classifier tested the whole `Inst` line for the substring "security". The package name is on that line, so anything named like a security tool got flagged as a security update. Debian main has around 43 of them: `libapache2-mod-security2`, `modsecurity-crs`, `debian-security-support`, `checksecurity` and so on.

The regex already parses the line, so it now captures the origin list separately and only that gets searched. The flag reflects which archive the candidate comes from rather than what the package is called.

On why this does not close #782: Raspbian publishes no security suite for any codename, so there is no origin for a parser to match and a Pi still reports zero. What to do about an archive that has no security channel at all is a product decision, so I have left #782 open.

Refs #782