### PR TITLE
Stop the agent WebSocket reconnect loop from stalling silently

### DIFF
--- a/agent-source-code/cmd/patchmon-agent/commands/serve.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/serve.go
@@ -1340,6 +1340,131 @@ func (cs *complianceScheduler) loop() {
 	}
 }
 
+const (
+	wsPingPeriod = 30 * time.Second
+	wsWriteWait  = 5 * time.Second
+)
+
+// Overridable so tests can exercise the timeout paths without real waits.
+var (
+	wsHandshakeTimeout = 45 * time.Second
+	wsPongWait         = 90 * time.Second
+	wsDispatchWait     = 5 * time.Second
+)
+
+// newWSDialer builds the dialer used for the agent WebSocket.
+//
+// The fields are copied from DefaultDialer rather than starting from a zero
+// Dialer: gorilla only puts a deadline on the socket when HandshakeTimeout is
+// non-zero, so a zero value leaves the TLS handshake and the read of the 101
+// response completely unbounded. A peer that completes the TCP handshake and
+// then stalls (a reverse proxy mid-restart, a backend with no healthy upstream)
+// parks wsLoop forever with the socket ESTABLISHED and nothing logged. A nil
+// Proxy would also ignore the HTTPS_PROXY the HTTP client honours.
+func newWSDialer(skipSSLVerify bool) *websocket.Dialer {
+	d := *websocket.DefaultDialer
+	d.HandshakeTimeout = wsHandshakeTimeout
+	if skipSSLVerify {
+		// Operator-gated insecure TLS for lab/air-gapped deployments with
+		// self-signed certs. This exposes the agent to man-in-the-middle
+		// attacks on command delivery.
+		d.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+	}
+	return &d
+}
+
+// wsControlWriter is the subset of *websocket.Conn that runWSPingLoop needs.
+type wsControlWriter interface {
+	WriteControl(messageType int, data []byte, deadline time.Time) error
+	Close() error
+}
+
+// runWSPingLoop proves liveness to the server and, via the pong it elicits,
+// is the only thing that re-arms the agent's read deadline.
+//
+// A failed WriteControl does not mean the socket is gone: gorilla returns a
+// plain timeout when another writer still holds the write mutex at the
+// deadline, which happens under a proxy burst or TCP backpressure. Returning on
+// that error left a live connection with nothing pinging it and nothing
+// watching it, so the connection has to be closed to hand over to wsLoop.
+func runWSPingLoop(conn wsControlWriter, interval time.Duration, done <-chan struct{}) {
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-done:
+			return
+		case <-t.C:
+			if err := conn.WriteControl(websocket.PingMessage, nil, time.Now().Add(wsWriteWait)); err != nil {
+				logger.WithError(err).Warn("WebSocket ping failed; closing connection to force reconnect")
+				_ = conn.Close()
+				return
+			}
+		}
+	}
+}
+
+// configureWSDeadlines arms the read deadline and keeps it armed on any frame
+// from the server, not only on pongs. Data proves the link just as well, and
+// dropping a busy connection because a pong was late produces a redial the
+// server then has to reconcile against the one it already holds.
+func configureWSDeadlines(conn *websocket.Conn) {
+	extend := func() error {
+		return conn.SetReadDeadline(time.Now().Add(wsPongWait))
+	}
+	_ = extend()
+	conn.SetPongHandler(func(string) error { return extend() })
+	// Gorilla's default ping handler gives the pong reply a 1s write deadline
+	// and discards a timeout without a word, so a busy agent goes silent and
+	// the server's own pong wait expires on a healthy connection. Take longer
+	// and say something. A timeout is contention on the write mutex rather
+	// than a dead socket, so it is tolerated; anything else is returned, which
+	// fails the read and hands over to wsLoop.
+	conn.SetPingHandler(func(appData string) error {
+		_ = extend()
+		err := conn.WriteControl(websocket.PongMessage, []byte(appData), time.Now().Add(wsWriteWait))
+		if err == nil || errors.Is(err, websocket.ErrCloseSent) {
+			return nil
+		}
+		var netErr net.Error
+		if errors.As(err, &netErr) && netErr.Timeout() {
+			logger.WithError(err).Warn("Failed to send WebSocket pong")
+			return nil
+		}
+		return err
+	})
+}
+
+// readWSMessage reads one frame and re-arms the read deadline, so that any
+// traffic from the server counts as proof of life. See configureWSDeadlines.
+func readWSMessage(conn *websocket.Conn) ([]byte, error) {
+	_, data, err := conn.ReadMessage()
+	if err != nil {
+		return nil, err
+	}
+	_ = conn.SetReadDeadline(time.Now().Add(wsPongWait))
+	return data, nil
+}
+
+// dispatchWSMessage hands a decoded message to the service loop.
+//
+// It must never block indefinitely. While the read loop is parked on this send
+// it is not inside ReadMessage, and a Go read deadline only produces an error
+// on an attempted read, so an unbounded send disables the connection watchdog
+// for as long as the service loop is busy. The service loop runs check-ins and
+// reports inline, and proxy input frames fill the buffer in milliseconds.
+func dispatchWSMessage(out chan<- wsMsg, m wsMsg) {
+	timer := time.NewTimer(wsDispatchWait)
+	defer timer.Stop()
+	select {
+	case out <- m:
+	case <-timer.C:
+		logger.WithField("type", logutil.Sanitize(m.kind)).Warn("Service loop busy; dropping WebSocket message")
+	}
+}
+
 func wsLoop(out chan<- wsMsg, dockerEvents <-chan interface{}) {
 	backoff := time.Second
 	for {
@@ -1389,18 +1514,11 @@ func connectOnce(out chan<- wsMsg, dockerEvents <-chan interface{}, backoff *tim
 	header.Set("X-API-ID", apiID)
 	header.Set("X-API-KEY", apiKey)
 
-	// SECURITY: Configure WebSocket dialer for insecure connections if needed
-	// WARNING: This exposes the agent to man-in-the-middle attacks!
-	dialer := websocket.DefaultDialer
-	if cfgManager.GetConfig().SkipSSLVerify || client.IsSkipSSLVerifyEnvSet() {
+	skipSSLVerify := cfgManager.GetConfig().SkipSSLVerify || client.IsSkipSSLVerifyEnvSet()
+	if skipSSLVerify {
 		logger.Warn("TLS verification disabled for WebSocket")
-		// Operator-gated insecure TLS for lab/air-gapped deployments with self-signed certs.
-		dialer = &websocket.Dialer{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true,
-			},
-		}
 	}
+	dialer := newWSDialer(skipSSLVerify)
 
 	conn, _, err := dialer.Dial(wsURL, header)
 	if err != nil {
@@ -1422,27 +1540,9 @@ func connectOnce(out chan<- wsMsg, dockerEvents <-chan interface{}, backoff *tim
 		}
 	}()
 
-	// ping loop - now with cancellation support
-	go func() {
-		t := time.NewTicker(30 * time.Second)
-		defer t.Stop()
-		for {
-			select {
-			case <-done:
-				return
-			case <-t.C:
-				if err := conn.WriteControl(websocket.PingMessage, nil, time.Now().Add(5*time.Second)); err != nil {
-					return // Connection closed, exit goroutine
-				}
-			}
-		}
-	}()
+	go runWSPingLoop(conn, wsPingPeriod, done)
 
-	// Set read deadlines and extend them on pong frames to avoid idle timeouts
-	_ = conn.SetReadDeadline(time.Now().Add(90 * time.Second))
-	conn.SetPongHandler(func(string) error {
-		return conn.SetReadDeadline(time.Now().Add(90 * time.Second))
-	})
+	configureWSDeadlines(conn)
 
 	// SECURITY: Limit WebSocket message size to prevent DoS attacks (64KB max)
 	conn.SetReadLimit(64 * 1024)
@@ -1543,7 +1643,7 @@ func connectOnce(out chan<- wsMsg, dockerEvents <-chan interface{}, backoff *tim
 	}()
 
 	for {
-		_, data, err := conn.ReadMessage()
+		data, err := readWSMessage(conn)
 		if err != nil {
 			return connected, err
 		}
@@ -1592,19 +1692,19 @@ func connectOnce(out chan<- wsMsg, dockerEvents <-chan interface{}, backoff *tim
 		switch payload.Type {
 		case "settings_update":
 			logger.WithField("interval", payload.UpdateInterval).Info("settings_update received")
-			out <- wsMsg{kind: "settings_update", interval: payload.UpdateInterval, complianceScanInterval: payload.ComplianceScanInterval, packageCacheRefreshMode: payload.PackageCacheRefreshMode, packageCacheRefreshMaxAge: payload.PackageCacheRefreshMaxAge}
+			dispatchWSMessage(out, wsMsg{kind: "settings_update", interval: payload.UpdateInterval, complianceScanInterval: payload.ComplianceScanInterval, packageCacheRefreshMode: payload.PackageCacheRefreshMode, packageCacheRefreshMaxAge: payload.PackageCacheRefreshMaxAge})
 		case "report_now":
 			logger.Info("report_now received")
-			out <- wsMsg{kind: "report_now"}
+			dispatchWSMessage(out, wsMsg{kind: "report_now"})
 		case "update_agent":
 			logger.Info("update_agent received")
-			out <- wsMsg{kind: "update_agent"}
+			dispatchWSMessage(out, wsMsg{kind: "update_agent"})
 		case "refresh_integration_status":
 			logger.Info("refresh_integration_status received")
-			out <- wsMsg{kind: "refresh_integration_status"}
+			dispatchWSMessage(out, wsMsg{kind: "refresh_integration_status"})
 		case "docker_inventory_refresh":
 			logger.Info("docker_inventory_refresh received")
-			out <- wsMsg{kind: "docker_inventory_refresh"}
+			dispatchWSMessage(out, wsMsg{kind: "docker_inventory_refresh"})
 		case "run_patch":
 			if payload.PatchRunID == "" {
 				logger.Warn("run_patch missing patch_run_id")
@@ -1648,13 +1748,13 @@ func connectOnce(out chan<- wsMsg, dockerEvents <-chan interface{}, backoff *tim
 				"package_names": packageNames,
 				"dry_run":       payload.DryRun,
 			})).Info("run_patch received")
-			out <- wsMsg{
+			dispatchWSMessage(out, wsMsg{
 				kind:         "run_patch",
 				patchRunID:   payload.PatchRunID,
 				patchType:    patchType,
 				packageNames: packageNames,
 				dryRun:       payload.DryRun,
-			}
+			})
 		case "compliance_scan":
 			// Validate profile ID to prevent command injection
 			if err := validateProfileID(payload.ProfileID); err != nil {
@@ -1670,7 +1770,7 @@ func connectOnce(out chan<- wsMsg, dockerEvents <-chan interface{}, backoff *tim
 				"profile_id":         payload.ProfileID,
 				"enable_remediation": payload.EnableRemediation,
 			})).Info("compliance_scan received")
-			out <- wsMsg{
+			dispatchWSMessage(out, wsMsg{
 				kind:                 "compliance_scan",
 				profileType:          profileType,
 				profileID:            payload.ProfileID,
@@ -1678,24 +1778,24 @@ func connectOnce(out chan<- wsMsg, dockerEvents <-chan interface{}, backoff *tim
 				fetchRemoteResources: payload.FetchRemoteResources,
 				openscapEnabled:      payload.OpenSCAPEnabled,
 				dockerBenchEnabled:   payload.DockerBenchEnabled,
-			}
+			})
 		case "compliance_scan_cancel":
 			logger.Info("compliance_scan_cancel received")
-			out <- wsMsg{kind: "compliance_scan_cancel"}
+			dispatchWSMessage(out, wsMsg{kind: "compliance_scan_cancel"})
 		case "patch_run_stop":
 			if payload.PatchRunID == "" {
 				logger.Warn("patch_run_stop missing patch_run_id")
 				continue
 			}
 			logger.WithField("patch_run_id", logutil.Sanitize(payload.PatchRunID)).Info("patch_run_stop received")
-			out <- wsMsg{kind: "patch_run_stop", patchRunID: payload.PatchRunID}
+			dispatchWSMessage(out, wsMsg{kind: "patch_run_stop", patchRunID: payload.PatchRunID})
 		case "upgrade_ssg":
 			logger.WithField("version", payload.Version).Info("upgrade_ssg received from WebSocket")
-			out <- wsMsg{kind: "upgrade_ssg", version: payload.Version}
+			dispatchWSMessage(out, wsMsg{kind: "upgrade_ssg", version: payload.Version})
 			logger.Info("upgrade_ssg sent to message channel")
 		case "install_scanner":
 			logger.Info("install_scanner received from WebSocket")
-			out <- wsMsg{kind: "install_scanner"}
+			dispatchWSMessage(out, wsMsg{kind: "install_scanner"})
 		case "remediate_rule":
 			// Validate rule ID to prevent command injection
 			if err := validateRuleID(payload.RuleID); err != nil {
@@ -1703,7 +1803,7 @@ func connectOnce(out chan<- wsMsg, dockerEvents <-chan interface{}, backoff *tim
 				continue
 			}
 			logger.WithField("rule_id", logutil.Sanitize(payload.RuleID)).Info("remediate_rule received")
-			out <- wsMsg{kind: "remediate_rule", ruleID: payload.RuleID}
+			dispatchWSMessage(out, wsMsg{kind: "remediate_rule", ruleID: payload.RuleID})
 		case "docker_image_scan":
 			// Validate Docker image and container names to prevent command injection
 			if err := validateDockerImageName(payload.ImageName); err != nil {
@@ -1719,15 +1819,15 @@ func connectOnce(out chan<- wsMsg, dockerEvents <-chan interface{}, backoff *tim
 				"container_name":  payload.ContainerName,
 				"scan_all_images": payload.ScanAllImages,
 			})).Info("docker_image_scan received")
-			out <- wsMsg{
+			dispatchWSMessage(out, wsMsg{
 				kind:          "docker_image_scan",
 				imageName:     payload.ImageName,
 				containerName: payload.ContainerName,
 				scanAllImages: payload.ScanAllImages,
-			}
+			})
 		case "apply_config":
 			logger.Info("apply_config received")
-			out <- wsMsg{kind: "apply_config", applyConfig: payload.Config}
+			dispatchWSMessage(out, wsMsg{kind: "apply_config", applyConfig: payload.Config})
 		case "ssh_proxy":
 			// Validate SSH proxy is enabled in config
 			if !cfgManager.IsIntegrationEnabled("ssh-proxy-enabled") {
@@ -1781,7 +1881,7 @@ func connectOnce(out chan<- wsMsg, dockerEvents <-chan interface{}, backoff *tim
 				"port":       payload.Port,
 				"username":   payload.Username,
 			})).Info("ssh_proxy received")
-			out <- wsMsg{
+			dispatchWSMessage(out, wsMsg{
 				kind:               "ssh_proxy",
 				sshProxySessionID:  payload.SessionID,
 				sshProxyHost:       payload.Host,
@@ -1793,37 +1893,37 @@ func connectOnce(out chan<- wsMsg, dockerEvents <-chan interface{}, backoff *tim
 				sshProxyTerminal:   payload.Terminal,
 				sshProxyCols:       payload.Cols,
 				sshProxyRows:       payload.Rows,
-			}
+			})
 		case "ssh_proxy_input":
 			if payload.SessionID == "" {
 				logger.Warn("ssh_proxy_input missing session_id")
 				continue
 			}
-			out <- wsMsg{
+			dispatchWSMessage(out, wsMsg{
 				kind:              "ssh_proxy_input",
 				sshProxySessionID: payload.SessionID,
 				sshProxyData:      payload.Data,
-			}
+			})
 		case "ssh_proxy_resize":
 			if payload.SessionID == "" {
 				logger.Warn("ssh_proxy_resize missing session_id")
 				continue
 			}
-			out <- wsMsg{
+			dispatchWSMessage(out, wsMsg{
 				kind:              "ssh_proxy_resize",
 				sshProxySessionID: payload.SessionID,
 				sshProxyCols:      payload.Cols,
 				sshProxyRows:      payload.Rows,
-			}
+			})
 		case "ssh_proxy_disconnect":
 			if payload.SessionID == "" {
 				logger.Warn("ssh_proxy_disconnect missing session_id")
 				continue
 			}
-			out <- wsMsg{
+			dispatchWSMessage(out, wsMsg{
 				kind:              "ssh_proxy_disconnect",
 				sshProxySessionID: payload.SessionID,
-			}
+			})
 		case "rdp_proxy":
 			if !cfgManager.IsIntegrationEnabled("rdp-proxy-enabled") {
 				logger.Warn("RDP proxy requested but not enabled in config.yml")
@@ -1869,31 +1969,31 @@ func connectOnce(out chan<- wsMsg, dockerEvents <-chan interface{}, backoff *tim
 				"host":       rdpHost,
 				"port":       port,
 			})).Info("rdp_proxy received")
-			out <- wsMsg{
+			dispatchWSMessage(out, wsMsg{
 				kind:              "rdp_proxy",
 				rdpProxySessionID: payload.SessionID,
 				rdpProxyHost:      rdpHost,
 				rdpProxyPort:      port,
-			}
+			})
 		case "rdp_proxy_input":
 			if payload.SessionID == "" {
 				logger.Warn("rdp_proxy_input missing session_id")
 				continue
 			}
-			out <- wsMsg{
+			dispatchWSMessage(out, wsMsg{
 				kind:              "rdp_proxy_input",
 				rdpProxySessionID: payload.SessionID,
 				rdpProxyData:      payload.Data,
-			}
+			})
 		case "rdp_proxy_disconnect":
 			if payload.SessionID == "" {
 				logger.Warn("rdp_proxy_disconnect missing session_id")
 				continue
 			}
-			out <- wsMsg{
+			dispatchWSMessage(out, wsMsg{
 				kind:              "rdp_proxy_disconnect",
 				rdpProxySessionID: payload.SessionID,
-			}
+			})
 		default:
 			if payload.Type != "" && payload.Type != "connected" {
 				logger.WithField("type", logutil.Sanitize(payload.Type)).Warn("Unknown WebSocket message type")

--- a/agent-source-code/cmd/patchmon-agent/commands/serve_ws_test.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/serve_ws_test.go
@@ -1,0 +1,435 @@
+package commands
+
+import (
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/sirupsen/logrus"
+)
+
+// The WebSocket helpers log through the package logger, which is normally
+// created by initialiseAgent and is nil under test.
+func TestMain(m *testing.M) {
+	logger = logrus.New()
+	logger.SetOutput(io.Discard)
+	os.Exit(m.Run())
+}
+
+// TestNewWSDialer guards the dialer defaults. A zero-value gorilla Dialer sets
+// no deadline on the socket at all, so a peer that accepts TCP and then stalls
+// parks the whole reconnect loop indefinitely.
+func TestNewWSDialer(t *testing.T) {
+	tests := []struct {
+		name              string
+		skipSSLVerify     bool
+		wantInsecureTLS   bool
+		wantTLSConfigured bool
+	}{
+		{
+			name:              "verified TLS keeps the shared defaults",
+			skipSSLVerify:     false,
+			wantInsecureTLS:   false,
+			wantTLSConfigured: false,
+		},
+		{
+			name:              "skip_ssl_verify keeps the defaults and disables verification",
+			skipSSLVerify:     true,
+			wantInsecureTLS:   true,
+			wantTLSConfigured: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d := newWSDialer(tc.skipSSLVerify)
+
+			if d.HandshakeTimeout == 0 {
+				t.Error("HandshakeTimeout is zero: Dial would have no deadline and could block forever")
+			}
+			if d.HandshakeTimeout != wsHandshakeTimeout {
+				t.Errorf("HandshakeTimeout = %v, want %v", d.HandshakeTimeout, wsHandshakeTimeout)
+			}
+			if d.Proxy == nil {
+				t.Error("Proxy is nil: the agent would ignore HTTPS_PROXY on the WebSocket only")
+			}
+			if got := d.TLSClientConfig != nil; got != tc.wantTLSConfigured {
+				t.Errorf("TLSClientConfig set = %v, want %v", got, tc.wantTLSConfigured)
+			}
+			if tc.wantInsecureTLS && !d.TLSClientConfig.InsecureSkipVerify {
+				t.Error("InsecureSkipVerify = false, want true")
+			}
+			if d == websocket.DefaultDialer {
+				t.Error("dialer aliases websocket.DefaultDialer; mutating it would leak into every other caller")
+			}
+		})
+	}
+}
+
+// TestNewWSDialerBoundsStalledHandshake dials a listener that completes the TCP
+// handshake and then says nothing, which is what a reverse proxy mid-restart or
+// a backend with no healthy upstream looks like. Dial must give up.
+func TestNewWSDialerBoundsStalledHandshake(t *testing.T) {
+	tests := []struct {
+		name          string
+		skipSSLVerify bool
+	}{
+		{name: "verified TLS", skipSSLVerify: false},
+		{name: "skip_ssl_verify", skipSSLVerify: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			restore := wsHandshakeTimeout
+			wsHandshakeTimeout = 300 * time.Millisecond
+			defer func() { wsHandshakeTimeout = restore }()
+
+			addr := startBlackHoleListener(t)
+			dialer := newWSDialer(tc.skipSSLVerify)
+
+			done := make(chan error, 1)
+			go func() {
+				conn, _, err := dialer.Dial("ws://"+addr+"/api/v1/agents/ws", nil)
+				if conn != nil {
+					_ = conn.Close()
+				}
+				done <- err
+			}()
+
+			select {
+			case err := <-done:
+				if err == nil {
+					t.Fatal("Dial succeeded against a black-hole listener, want an error")
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("Dial did not return: the reconnect loop is parked with the socket established")
+			}
+		})
+	}
+}
+
+// TestRunWSPingLoop covers the liveness pinger. Pongs are the only thing that
+// re-arm the read deadline, so a pinger that stops without tearing the
+// connection down leaves a live socket that nothing is watching.
+func TestRunWSPingLoop(t *testing.T) {
+	tests := []struct {
+		name        string
+		writeErr    error
+		stopEarly   bool
+		wantClosed  bool
+		wantMinPing int
+	}{
+		{
+			name:        "healthy connection keeps pinging",
+			writeErr:    nil,
+			wantClosed:  false,
+			wantMinPing: 2,
+		},
+		{
+			name:        "transient write timeout tears the connection down",
+			writeErr:    errors.New("websocket: write timeout"),
+			wantClosed:  true,
+			wantMinPing: 1,
+		},
+		{
+			name:        "fatal write error tears the connection down",
+			writeErr:    net.ErrClosed,
+			wantClosed:  true,
+			wantMinPing: 1,
+		},
+		{
+			name:        "cancellation stops the loop without closing",
+			writeErr:    nil,
+			stopEarly:   true,
+			wantClosed:  false,
+			wantMinPing: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := &fakeControlConn{err: tc.writeErr}
+			done := make(chan struct{})
+			returned := make(chan struct{})
+
+			go func() {
+				runWSPingLoop(conn, 10*time.Millisecond, done)
+				close(returned)
+			}()
+
+			if tc.stopEarly {
+				close(done)
+			} else if tc.writeErr == nil {
+				time.Sleep(60 * time.Millisecond)
+				close(done)
+			}
+
+			select {
+			case <-returned:
+			case <-time.After(2 * time.Second):
+				close(done)
+				t.Fatal("ping loop did not return")
+			}
+
+			if got := conn.closeCount(); (got > 0) != tc.wantClosed {
+				t.Errorf("connection closed = %v, want %v", got > 0, tc.wantClosed)
+			}
+			if got := conn.pingCount(); got < tc.wantMinPing {
+				t.Errorf("pings = %d, want at least %d", got, tc.wantMinPing)
+			}
+		})
+	}
+}
+
+// TestWSReadDeadlineStaysArmed drives a real WebSocket pair. The agent's read
+// deadline used to be re-armed only by a pong, so a connection carrying plenty
+// of server traffic was still torn down whenever a pong was late.
+func TestWSReadDeadlineStaysArmed(t *testing.T) {
+	tests := []struct {
+		name    string
+		serve   func(conn *websocket.Conn, stop <-chan struct{})
+		wantErr bool
+	}{
+		{
+			name: "data frames keep the deadline armed",
+			serve: func(conn *websocket.Conn, stop <-chan struct{}) {
+				sendUntilStop(conn, stop, websocket.TextMessage)
+			},
+			wantErr: false,
+		},
+		{
+			name: "server pings keep the deadline armed",
+			serve: func(conn *websocket.Conn, stop <-chan struct{}) {
+				sendUntilStop(conn, stop, websocket.PingMessage)
+			},
+			wantErr: false,
+		},
+		{
+			name: "silence still fires the watchdog",
+			serve: func(_ *websocket.Conn, stop <-chan struct{}) {
+				<-stop
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			restore := wsPongWait
+			wsPongWait = 250 * time.Millisecond
+			defer func() { wsPongWait = restore }()
+
+			client := newWSTestClient(t, tc.serve)
+			configureWSDeadlines(client)
+
+			errCh := make(chan error, 1)
+			readerDone := make(chan struct{})
+			go func() {
+				defer close(readerDone)
+				for {
+					if _, err := readWSMessage(client); err != nil {
+						errCh <- err
+						return
+					}
+				}
+			}()
+
+			// Long enough that a deadline armed once at connect time has
+			// certainly expired.
+			var gotErr error
+			select {
+			case gotErr = <-errCh:
+			case <-time.After(3 * wsPongWait):
+			}
+
+			_ = client.Close()
+			<-readerDone
+
+			if tc.wantErr && gotErr == nil {
+				t.Error("read never failed: a silent connection is not being watched")
+			}
+			if !tc.wantErr && gotErr != nil {
+				t.Errorf("read failed on a connection the server was actively feeding: %v", gotErr)
+			}
+		})
+	}
+}
+
+// TestDispatchWSMessage covers the hand-off from the read loop to the service
+// loop. A blocking send parks the reader outside ReadMessage, and a Go read
+// deadline only produces an error on an attempted read, so while the reader is
+// parked the connection watchdog does not exist.
+func TestDispatchWSMessage(t *testing.T) {
+	tests := []struct {
+		name          string
+		prefill       int
+		wantDelivered bool
+	}{
+		{
+			name:          "free slot delivers immediately",
+			prefill:       0,
+			wantDelivered: true,
+		},
+		{
+			name:          "busy service loop drops rather than blocking the reader",
+			prefill:       1,
+			wantDelivered: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			restore := wsDispatchWait
+			wsDispatchWait = 50 * time.Millisecond
+			defer func() { wsDispatchWait = restore }()
+
+			out := make(chan wsMsg, 1)
+			for i := 0; i < tc.prefill; i++ {
+				out <- wsMsg{kind: "prefill"}
+			}
+
+			returned := make(chan struct{})
+			go func() {
+				dispatchWSMessage(out, wsMsg{kind: "report_now"})
+				close(returned)
+			}()
+
+			select {
+			case <-returned:
+			case <-time.After(2 * time.Second):
+				t.Fatal("dispatch blocked: the read loop is parked and the connection is unwatched")
+			}
+
+			delivered := false
+			for len(out) > 0 {
+				if (<-out).kind == "report_now" {
+					delivered = true
+				}
+			}
+			if delivered != tc.wantDelivered {
+				t.Errorf("delivered = %v, want %v", delivered, tc.wantDelivered)
+			}
+		})
+	}
+}
+
+type fakeControlConn struct {
+	mu     sync.Mutex
+	pings  int
+	closes int
+	err    error
+}
+
+func (f *fakeControlConn) WriteControl(_ int, _ []byte, _ time.Time) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.pings++
+	return f.err
+}
+
+func (f *fakeControlConn) Close() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.closes++
+	return nil
+}
+
+func (f *fakeControlConn) pingCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.pings
+}
+
+func (f *fakeControlConn) closeCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.closes
+}
+
+// startBlackHoleListener accepts connections and then never writes a byte.
+func startBlackHoleListener(t *testing.T) string {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	stop := make(chan struct{})
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				<-stop
+				_ = conn.Close()
+			}()
+		}
+	}()
+	t.Cleanup(func() {
+		close(stop)
+		_ = ln.Close()
+	})
+	return ln.Addr().String()
+}
+
+// newWSTestClient returns a client connection to a test server running serve.
+func newWSTestClient(t *testing.T, serve func(conn *websocket.Conn, stop <-chan struct{})) *websocket.Conn {
+	t.Helper()
+
+	upgrader := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	stop := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		serve(conn, stop)
+		<-stop
+	}))
+
+	client, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(srv.URL, "http"), nil)
+	if err != nil {
+		srv.Close()
+		t.Fatalf("dial test server: %v", err)
+	}
+	t.Cleanup(func() {
+		close(stop)
+		_ = client.Close()
+		srv.Close()
+	})
+	return client
+}
+
+// sendUntilStop emits one frame of the given type every 40ms. Nothing it sends
+// is a pong, so only a deadline that is re-armed on data or on a ping survives.
+func sendUntilStop(conn *websocket.Conn, stop <-chan struct{}, messageType int) {
+	ticker := time.NewTicker(40 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-stop:
+			return
+		case <-ticker.C:
+			var err error
+			if messageType == websocket.PingMessage {
+				err = conn.WriteControl(websocket.PingMessage, nil, time.Now().Add(time.Second))
+			} else {
+				err = conn.WriteMessage(messageType, []byte(`{"type":"connected"}`))
+			}
+			if err != nil {
+				return
+			}
+		}
+	}
+}


### PR DESCRIPTION
Worth reading the first bit before the diff, because the headline symptom in the issue is **not** an agent-side socket defect.

@ingoriediger's evidence (last log line `WebSocket connected`, then 16 hours of silence, hourly HTTP reports succeeding throughout, socket still ESTABLISHED) is only consistent with the WebSocket being genuinely healthy end to end while the server had forgotten it. The agent has nothing to detect in that state. That is the server-side teardown race, already fixed in the v2.0.3 line by the identity-aware `Registry.UnregisterConn`. @Power2All reached the same conclusion in the thread and is right about it.

What this PR fixes is four separate agent-side mechanisms that either cause a permanent hang or stop the agent noticing a connection it should have redialled. None of them logged anything, which is why the reports have no error to go on.

**The dial was unbounded.** With `skip_ssl_verify` set the agent built a zero-value `websocket.Dialer`, and gorilla only puts a deadline on the socket when `HandshakeTimeout` is non-zero. A peer that accepts TCP and then stalls, which is what a reverse proxy mid-restart looks like, parked the loop forever. That one matches the reported symptom exactly. Using a copy of `DefaultDialer` also restores `Proxy: ProxyFromEnvironment`, which that branch silently dropped, so those agents were ignoring `HTTPS_PROXY` on the WebSocket while the HTTP client honoured it.

**The pinger exited on a non-fatal error.** `WriteControl` returns a plain timeout when it cannot get gorilla's write mutex in time, which says nothing about the socket and happens under an SSH or RDP burst. The old code treated it as "connection closed" and returned.

**The read deadline was re-armed only by pongs**, never by data or by a server ping, so a busy connection got torn down whenever a pong was late. Each spurious redial is one the server then has to reconcile, which is what fed the original race.

**The read-to-service hand-off was an unbounded channel send.** Least obvious of the four: a read deadline only fires on an attempted read, so while the reader is parked on that send the 90 second watchdog does not exist.

Tests are table-driven and I verified each one fails with its specific change reverted and passes with it restored. `make check` clean, `go test -race` clean.

One thing left open: the agent still has no way to learn that the server registry no longer holds it, because in that state its socket really is healthy. Closing that needs a server signal, cheapest being a `wsConnected` flag on the `/hosts/ping` response that the agent acts on. Server-side change, so out of scope here, and the v2.0.3 fix already removes the known route into that state. Happy to raise a follow-up if you want belt and braces.

Fixes #773