### PR TITLE
Stability batch: Redis ACL, dnf makecache, apt only-upgrade, dev Dockerfile

### DIFF
--- a/agent-source-code/cmd/patchmon-agent/commands/serve.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/serve.go
@@ -2259,7 +2259,10 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 				stepErr = err
 			}
 		default:
-			if err, abort := runStep(false, upgradeBin+" makecache", upgradeBin+" makecache failed: %w", upgradeBin, "makecache", "-q"); abort {
+			// -y/--assumeyes accepts new GPG key imports non-interactively.
+			// Without it, dnf prompts "Is this ok [y/N]:" for keys like the
+			// PostgreSQL pgdg repo and the patch run hangs/fails.
+			if err, abort := runStep(false, upgradeBin+" makecache", upgradeBin+" makecache failed: %w", upgradeBin, "makecache", "-q", "-y"); abort {
 				stepErr = err
 			}
 		}

--- a/agent-source-code/cmd/patchmon-agent/commands/serve.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/serve.go
@@ -2329,13 +2329,13 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 			switch pkgManager {
 			case "apt":
 				if dryRun {
-					args := append([]string{"-s", "install"}, packageNames...)
-					if err, abort := runStep(false, "apt-get -s install", "apt-get -s install failed: %w", "apt-get", args...); abort {
+					args := append([]string{"-s", "--only-upgrade", "install"}, packageNames...)
+					if err, abort := runStep(false, "apt-get -s --only-upgrade install", "apt-get -s --only-upgrade install failed: %w", "apt-get", args...); abort {
 						stepErr = err
 					}
 				} else {
-					args := append([]string{"install", "-y"}, packageNames...)
-					if err, abort := runStep(false, "apt-get install", "apt-get install failed: %w", "apt-get", args...); abort {
+					args := append([]string{"--only-upgrade", "install", "-y"}, packageNames...)
+					if err, abort := runStep(false, "apt-get --only-upgrade install", "apt-get --only-upgrade install failed: %w", "apt-get", args...); abort {
 						stepErr = err
 					}
 				}

--- a/docker/server.Dockerfile
+++ b/docker/server.Dockerfile
@@ -1,7 +1,7 @@
 # Development stage - run with go run, source can be volume-mounted for live reload
 FROM golang:1.26-alpine AS development
 
-RUN apk add --no-cache git ca-certificates tzdata curl node npm
+RUN apk add --no-cache git ca-certificates tzdata curl nodejs npm
 
 WORKDIR /app
 
@@ -14,7 +14,7 @@ WORKDIR /app/frontend
 COPY frontend/package*.json ./
 RUN npm install --ignore-scripts --legacy-peer-deps 2>/dev/null || true
 COPY frontend/ ./
-RUN npm run build 2>/dev/null || mkdir -p dist && echo '<!DOCTYPE html><html><body>Build frontend first</body></html>' > dist/index.html
+RUN npm run build 2>/dev/null || (mkdir -p dist && echo '<!DOCTYPE html><html><body>Build frontend first</body></html>' > dist/index.html)
 
 WORKDIR /app/server
 COPY server-source-code/ ./

--- a/docker/server.Dockerfile
+++ b/docker/server.Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /app/frontend
 COPY frontend/package*.json ./
 RUN npm install --ignore-scripts --legacy-peer-deps 2>/dev/null || true
 COPY frontend/ ./
-RUN npm run build 2>/dev/null || (mkdir -p dist && echo '<!DOCTYPE html><html><body>Build frontend first</body></html>' > dist/index.html)
+RUN npm run build
 
 WORKDIR /app/server
 COPY server-source-code/ ./

--- a/server-source-code/internal/queue/client.go
+++ b/server-source-code/internal/queue/client.go
@@ -30,7 +30,7 @@ func RedisOpts() asynq.RedisClientOpt {
 	return asynq.RedisClientOpt{
 		Addr:      fmt.Sprintf("%s:%d", host, port),
 		Password:  password,
-		Username:     username,
+		Username:  username,
 		DB:        db,
 		TLSConfig: patchmonredis.TLSConfigFromEnv(),
 	}

--- a/server-source-code/internal/queue/client.go
+++ b/server-source-code/internal/queue/client.go
@@ -25,10 +25,12 @@ func RedisOpts() asynq.RedisClientOpt {
 	port := getEnvInt("REDIS_PORT", defaultRedisPort)
 	db := getEnvInt("REDIS_DB", defaultRedisDB)
 	password := os.Getenv("REDIS_PASSWORD")
+	username := os.Getenv("REDIS_USER")
 
 	return asynq.RedisClientOpt{
 		Addr:      fmt.Sprintf("%s:%d", host, port),
 		Password:  password,
+		Username:     username,
 		DB:        db,
 		TLSConfig: patchmonredis.TLSConfigFromEnv(),
 	}

--- a/server-source-code/internal/queue/client.go
+++ b/server-source-code/internal/queue/client.go
@@ -29,8 +29,8 @@ func RedisOpts() asynq.RedisClientOpt {
 
 	return asynq.RedisClientOpt{
 		Addr:      fmt.Sprintf("%s:%d", host, port),
-		Password:  password,
 		Username:  username,
+		Password:  password,
 		DB:        db,
 		TLSConfig: patchmonredis.TLSConfigFromEnv(),
 	}

--- a/server-source-code/internal/queue/client_test.go
+++ b/server-source-code/internal/queue/client_test.go
@@ -1,0 +1,45 @@
+package queue
+
+import "testing"
+
+// The asynq options are built separately from internal/redis.NewClient, so the
+// two can drift. #745: REDIS_USER was honoured by the Redis client but dropped
+// from the asynq options, leaving every background task failing WRONGPASS on a
+// non-default ACL user while the rest of the server connected fine.
+func TestRedisOpts_CarriesEveryCredentialFromEnv(t *testing.T) {
+	t.Setenv("REDIS_HOST", "redis.internal")
+	t.Setenv("REDIS_PORT", "6380")
+	t.Setenv("REDIS_DB", "3")
+	t.Setenv("REDIS_USER", "patchmon")
+	t.Setenv("REDIS_PASSWORD", "s3cret")
+
+	opts := RedisOpts()
+
+	if opts.Addr != "redis.internal:6380" {
+		t.Errorf("Addr = %q, want redis.internal:6380", opts.Addr)
+	}
+	if opts.Username != "patchmon" {
+		t.Errorf("Username = %q, want patchmon", opts.Username)
+	}
+	if opts.Password != "s3cret" {
+		t.Errorf("Password = %q, want s3cret", opts.Password)
+	}
+	if opts.DB != 3 {
+		t.Errorf("DB = %d, want 3", opts.DB)
+	}
+}
+
+func TestRedisOpts_UnsetUserStaysEmpty(t *testing.T) {
+	t.Setenv("REDIS_HOST", "")
+	t.Setenv("REDIS_USER", "")
+	t.Setenv("REDIS_PASSWORD", "")
+
+	opts := RedisOpts()
+
+	if opts.Username != "" {
+		t.Errorf("Username = %q, want empty so Redis applies the default ACL user", opts.Username)
+	}
+	if opts.Addr != "localhost:6379" {
+		t.Errorf("Addr = %q, want localhost:6379", opts.Addr)
+	}
+}


### PR DESCRIPTION
Integration branch for five community fixes. Every contributor commit is cherry-picked with its original authorship intact, so the history credits them properly.

The reason these are not merged as their own PRs: they all predate the `Test (server)` / `Build (server)` / `Biome (frontend)` checks, so those checks have never run on them and the ruleset will not let them through. Rebuilding them on current `main` gets them properly tested rather than merged on trust.

**@jinnatar (#785)** `REDIS_USER` was read by `config.go`, used by `internal/redis/client.go` and shown in settings, but never set on the asynq options. Everything except the queues authenticated fine, which is why it looked like a queue fault. I have added regression tests on top so the two connection paths cannot drift apart again.

**@fpenezic (#854)** `dnf makecache -y`, so a GPG key import prompt with nothing on stdin cannot hang the whole patch run. pgdg is the usual trigger.

**@balu212 (#883)** `apt --only-upgrade`, so a stale package list cannot cause an install of something that was never present. Also means a package removed between report and patch run is skipped rather than reinstalled, which is the safer default.

**@egrueda (#819)** `node` is not an Alpine package, it is `nodejs`, so that stage could never build. Also fixed the shell precedence, since `A || B && C` parses as `(A || B) && C` and the placeholder was overwriting successful builds.

**@tobyw7 (#843)** proposed deleting the placeholder fallback outright rather than parenthesising it, and they are right. A dev stage that quietly serves "Build frontend first" instead of failing is why #840 took months to pin down. Applied as the follow-up commit.

Both module checks pass, `make check` clean on server and agent.

Closes #785
Closes #854
Closes #883
Closes #819
Closes #843