### PR TITLE
Resolve SMTP transport security identically on all three send paths

### DIFF
--- a/server-source-code/internal/queue/email_tls_mode_test.go
+++ b/server-source-code/internal/queue/email_tls_mode_test.go
@@ -1,0 +1,110 @@
+package queue
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/PatchMon/PatchMon/server-source-code/internal/mailer"
+)
+
+// The stored config is JSON, so an absent "use_tls" key must stay absent all
+// the way through to ResolveMode. Decoding it into a plain bool turns "not
+// configured" into an explicit false, which ResolveMode reads as "the operator
+// chose no encryption" and returns TLSModeNone, skipping the port heuristic.
+//
+// The test-email handler decodes into *bool and therefore got the heuristic,
+// while both send workers decoded into bool and did not. A destination could
+// pass "send test email" over STARTTLS and then deliver real alerts in the
+// clear.
+func TestEmailConfig_AbsentUseTLSStaysNil(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want mailer.TLSMode
+		port int
+	}{
+		{
+			name: "absent key on 587 falls through to the port heuristic",
+			raw:  `{"smtp_host":"mail.example.com","smtp_port":587,"from":"a@b.c","to":"d@e.f"}`,
+			port: 587,
+			want: mailer.TLSModeStartTLS,
+		},
+		{
+			name: "absent key on 465 falls through to the port heuristic",
+			raw:  `{"smtp_host":"mail.example.com","smtp_port":465,"from":"a@b.c","to":"d@e.f"}`,
+			port: 465,
+			want: mailer.TLSModeTLS,
+		},
+		{
+			name: "explicit false is still honoured as a deliberate choice",
+			raw:  `{"smtp_host":"mail.example.com","smtp_port":587,"from":"a@b.c","to":"d@e.f","use_tls":false}`,
+			port: 587,
+			want: mailer.TLSModeNone,
+		},
+		{
+			name: "explicit true maps to auto",
+			raw:  `{"smtp_host":"mail.example.com","smtp_port":25,"from":"a@b.c","to":"d@e.f","use_tls":true}`,
+			port: 25,
+			want: mailer.TLSModeAuto,
+		},
+		{
+			name: "an explicit mode wins over everything",
+			raw:  `{"smtp_host":"mail.example.com","smtp_port":587,"from":"a@b.c","to":"d@e.f","use_tls":false,"tls_mode":"tls"}`,
+			port: 587,
+			want: mailer.TLSModeTLS,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var alert emailConfig
+			if err := json.Unmarshal([]byte(tt.raw), &alert); err != nil {
+				t.Fatalf("emailConfig: %v", err)
+			}
+			if got := mailer.ResolveMode(alert.TLSMode, alert.UseTLS, tt.port); got != tt.want {
+				t.Errorf("emailConfig resolved %q, want %q", got, tt.want)
+			}
+
+			var report scheduledEmailConfig
+			if err := json.Unmarshal([]byte(tt.raw), &report); err != nil {
+				t.Fatalf("scheduledEmailConfig: %v", err)
+			}
+			if got := mailer.ResolveMode(report.TLSMode, report.UseTLS, tt.port); got != tt.want {
+				t.Errorf("scheduledEmailConfig resolved %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// All three call sites must agree. The two workers previously disagreed with
+// the test-email path for exactly the configs an operator is most likely to
+// have: saved through the current UI, which writes tls_mode and no use_tls.
+func TestEmailConfig_SendPathsAgreeWithTestPath(t *testing.T) {
+	const savedByCurrentUI = `{"smtp_host":"mail.example.com","smtp_port":587,"from":"a@b.c","to":"d@e.f"}`
+
+	// The handler's shape: *bool, absent stays nil.
+	var handlerSide struct {
+		UseTLS  *bool  `json:"use_tls"`
+		TLSMode string `json:"tls_mode"`
+	}
+	if err := json.Unmarshal([]byte(savedByCurrentUI), &handlerSide); err != nil {
+		t.Fatal(err)
+	}
+	want := mailer.ResolveMode(handlerSide.TLSMode, handlerSide.UseTLS, 587)
+
+	var alert emailConfig
+	if err := json.Unmarshal([]byte(savedByCurrentUI), &alert); err != nil {
+		t.Fatal(err)
+	}
+	var report scheduledEmailConfig
+	if err := json.Unmarshal([]byte(savedByCurrentUI), &report); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := mailer.ResolveMode(alert.TLSMode, alert.UseTLS, 587); got != want {
+		t.Errorf("alert worker resolved %q but the test-email path resolves %q", got, want)
+	}
+	if got := mailer.ResolveMode(report.TLSMode, report.UseTLS, 587); got != want {
+		t.Errorf("scheduled report worker resolved %q but the test-email path resolves %q", got, want)
+	}
+}

--- a/server-source-code/internal/queue/notification_worker.go
+++ b/server-source-code/internal/queue/notification_worker.go
@@ -631,7 +631,7 @@ type emailConfig struct {
 	// UseTLS is the legacy boolean preserved for backward compatibility on rows
 	// written before TLSMode existed. New code should set TLSMode and let
 	// mailer.ResolveMode pick the effective policy.
-	UseTLS  bool   `json:"use_tls"`
+	UseTLS  *bool  `json:"use_tls"`
 	TLSMode string `json:"tls_mode"`
 }
 
@@ -790,7 +790,7 @@ func (h *NotificationDeliverHandler) sendEmail(ctx context.Context, plain string
 	subject := fmt.Sprintf("[%s] %s", strings.ToUpper(p.Severity), p.Title)
 	htmlBody := buildEmailHTML(p)
 
-	mode := mailer.ResolveMode(cfg.TLSMode, &cfg.UseTLS, cfg.SMTPPort)
+	mode := mailer.ResolveMode(cfg.TLSMode, cfg.UseTLS, cfg.SMTPPort)
 	mc := mailer.Config{
 		Host:     cfg.SMTPHost,
 		Port:     cfg.SMTPPort,

--- a/server-source-code/internal/queue/scheduled_report_worker.go
+++ b/server-source-code/internal/queue/scheduled_report_worker.go
@@ -362,7 +362,7 @@ type scheduledEmailConfig struct {
 	// UseTLS is the legacy boolean preserved for backward compatibility on rows
 	// written before TLSMode existed. New code should set TLSMode and let
 	// mailer.ResolveMode pick the effective policy.
-	UseTLS  bool   `json:"use_tls"`
+	UseTLS  *bool  `json:"use_tls"`
 	TLSMode string `json:"tls_mode"`
 }
 
@@ -378,7 +378,7 @@ func sendScheduledEmail(ctx context.Context, log *slog.Logger, plain, subject, h
 		cfg.SMTPPort = 587
 	}
 
-	mode := mailer.ResolveMode(cfg.TLSMode, &cfg.UseTLS, cfg.SMTPPort)
+	mode := mailer.ResolveMode(cfg.TLSMode, cfg.UseTLS, cfg.SMTPPort)
 	mc := mailer.Config{
 		Host:     cfg.SMTPHost,
 		Port:     cfg.SMTPPort,


### PR DESCRIPTION
Found while double-checking that #870 really was fixed. It is, but this is a separate defect sitting next to it, and it is the more dangerous of the two.

`mailer.ResolveMode` only falls through to the port heuristic (587 to STARTTLS, 465 to implicit TLS) when the legacy `use_tls` value is nil. The three callers disagreed about whether it could ever be nil:

```
handler/notifications.go        UseTLS *bool   absent stays nil    -> port heuristic
queue/notification_worker.go    UseTLS bool    absent becomes false -> none
queue/scheduled_report_worker.go  UseTLS bool  absent becomes false -> none
```

The stored config is JSON, and a destination saved through the current UI writes `tls_mode` with no `use_tls` key at all, so this is the common shape rather than an edge case. Decoding into a plain bool turns "not configured" into an explicit "the operator chose no encryption".

The practical effect: **Send Test Email could succeed over STARTTLS while the same destination delivered real alerts in the clear.** That is the worst way for it to fail, because the test button is precisely what you use to convince yourself the configuration is right.

Both workers now carry the nil-able pointer through so all three sites agree. An explicit `false` is still honoured as a deliberate choice, and an explicit `tls_mode` still wins over everything.

Tests cover both worker config shapes across absent, explicit true, explicit false and explicit mode, plus one that asserts the two send paths agree with the test path for the exact config the current UI writes. Verified they fail without the change: both workers return `none` on 587 and 465 where they should return `starttls` and `tls`.

No migration needed, since nothing is stored differently. Existing rows that do carry an explicit `use_tls: false` keep behaving as they do today.