### PR TITLE
Record last_login on local sign-in

### DIFF
--- a/server-source-code/internal/db/querier.go
+++ b/server-source-code/internal/db/querier.go
@@ -583,6 +583,7 @@ type Querier interface {
 	UpdateJobHistoryCompleted(ctx context.Context, jobID string) error
 	UpdateJobHistoryDelayed(ctx context.Context, jobID string) error
 	UpdateJobHistoryFailed(ctx context.Context, arg UpdateJobHistoryFailedParams) error
+	UpdateLastLogin(ctx context.Context, arg UpdateLastLoginParams) error
 	UpdateNotificationDestination(ctx context.Context, arg UpdateNotificationDestinationParams) (NotificationDestination, error)
 	UpdateNotificationRoute(ctx context.Context, arg UpdateNotificationRouteParams) (NotificationRoute, error)
 	UpdatePassword(ctx context.Context, arg UpdatePasswordParams) error

--- a/server-source-code/internal/db/users.sql.go
+++ b/server-source-code/internal/db/users.sql.go
@@ -668,6 +668,20 @@ func (q *Queries) SetNewsletterSubscribed(ctx context.Context, id string) error 
 	return err
 }
 
+const updateLastLogin = `-- name: UpdateLastLogin :exec
+UPDATE users SET last_login = $1 WHERE id = $2
+`
+
+type UpdateLastLoginParams struct {
+	LastLogin pgtype.Timestamp `json:"last_login"`
+	ID        string           `json:"id"`
+}
+
+func (q *Queries) UpdateLastLogin(ctx context.Context, arg UpdateLastLoginParams) error {
+	_, err := q.db.Exec(ctx, updateLastLogin, arg.LastLogin, arg.ID)
+	return err
+}
+
 const updatePassword = `-- name: UpdatePassword :exec
 UPDATE users SET password_hash = $1, updated_at = NOW() WHERE id = $2
 `

--- a/server-source-code/internal/handler/auth.go
+++ b/server-source-code/internal/handler/auth.go
@@ -497,6 +497,11 @@ func setAuthCookiesWithRemember(w http.ResponseWriter, r *http.Request, accessTo
 func (h *AuthHandler) completeLogin(w http.ResponseWriter, r *http.Request, user *models.User, rememberMe bool) {
 	expiresIn := h.getJwtExpiresInSeconds(r.Context())
 
+	// Losing a timestamp is not a reason to fail an otherwise valid sign-in.
+	if err := h.users.UpdateLastLogin(r.Context(), user.ID, time.Now()); err != nil && h.log != nil {
+		h.log.Error("failed to record last login", "user_id", user.ID, "error", err)
+	}
+
 	refreshExpSec := int64(7 * 24 * 3600)
 	if rememberMe {
 		refreshExpSec = 30 * 24 * 3600

--- a/server-source-code/internal/handler/last_login_test.go
+++ b/server-source-code/internal/handler/last_login_test.go
@@ -1,0 +1,87 @@
+package handler
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+// #730: last_login was written only by the OIDC and Discord profile updaters,
+// so anyone signing in with a username and password left the column NULL and
+// the Users table showed "Never" forever. The dashboard's recent-logins widget
+// reads the same column and was silently empty on password-only installs.
+//
+// The defect was an omitted call rather than a wrong one, so the regression
+// worth guarding is that completeLogin stops recording it. Both local sign-in
+// paths, plain and post-2FA, funnel through completeLogin; the OIDC path uses
+// CompleteOidcLogin and records it separately.
+func TestCompleteLoginRecordsLastLogin(t *testing.T) {
+	t.Parallel()
+
+	const file = "auth.go"
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, file, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", file, err)
+	}
+
+	var fn *ast.FuncDecl
+	ast.Inspect(f, func(n ast.Node) bool {
+		d, ok := n.(*ast.FuncDecl)
+		if ok && d.Name.Name == "completeLogin" {
+			fn = d
+			return false
+		}
+		return true
+	})
+	if fn == nil {
+		t.Fatal("completeLogin not found in auth.go; if it was renamed, move this guard with it")
+	}
+
+	var found bool
+	ast.Inspect(fn, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel.Name != "UpdateLastLogin" {
+			return true
+		}
+		found = true
+		return false
+	})
+
+	if !found {
+		t.Error("completeLogin does not call UpdateLastLogin: local sign-ins will show Last Login as Never")
+	}
+}
+
+// The two local sign-in paths must keep funnelling through completeLogin. If a
+// third is added that does not, it reintroduces the same gap for that path.
+func TestLocalLoginPathsGoThroughCompleteLogin(t *testing.T) {
+	t.Parallel()
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "auth.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse auth.go: %v", err)
+	}
+
+	calls := 0
+	ast.Inspect(f, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "completeLogin" {
+			calls++
+		}
+		return true
+	})
+
+	if calls < 2 {
+		t.Errorf("found %d calls to completeLogin, want at least 2 (plain sign-in and post-2FA)", calls)
+	}
+}

--- a/server-source-code/internal/sqlc/queries/users.sql
+++ b/server-source-code/internal/sqlc/queries/users.sql
@@ -64,6 +64,9 @@ DELETE FROM users WHERE id = $1;
 -- name: UpdatePassword :exec
 UPDATE users SET password_hash = $1, updated_at = NOW() WHERE id = $2;
 
+-- name: UpdateLastLogin :exec
+UPDATE users SET last_login = $1 WHERE id = $2;
+
 -- name: CreateUser :exec
 INSERT INTO users (
     id, username, email, password_hash, role, is_active, created_at, updated_at,

--- a/server-source-code/internal/store/query_guards_test.go
+++ b/server-source-code/internal/store/query_guards_test.go
@@ -116,3 +116,19 @@ func TestUpdateHostMetrics_RebootReasonIsPairedWithNeedsReboot(t *testing.T) {
 		}
 	}
 }
+
+// #730: local sign-ins never wrote users.last_login, so the Users table showed
+// "Never" and the dashboard's recent-logins widget was empty on password-only
+// installs. The query must set the column and be scoped to a single user.
+func TestUpdateLastLoginWritesTheColumnScopedToOneUser(t *testing.T) {
+	t.Parallel()
+
+	stmt := extractStatement(t, readQueryFile(t, "../sqlc/queries/users.sql"), "UpdateLastLogin")
+
+	if !strings.Contains(stmt, "last_login") {
+		t.Error("UpdateLastLogin does not assign last_login")
+	}
+	if !strings.Contains(stmt, "WHERE id =") {
+		t.Error("UpdateLastLogin is not scoped by id; it would stamp every user")
+	}
+}

--- a/server-source-code/internal/store/users.go
+++ b/server-source-code/internal/store/users.go
@@ -257,6 +257,18 @@ func (s *UsersStore) UpdatePassword(ctx context.Context, userID, hash string) er
 	return d.Queries.UpdatePassword(ctx, db.UpdatePasswordParams{PasswordHash: &hash, ID: userID})
 }
 
+// UpdateLastLogin records the time of a successful sign-in.
+//
+// The OIDC and Discord paths set this as part of their profile sync, so this
+// exists for local sign-ins, which had no write path at all.
+func (s *UsersStore) UpdateLastLogin(ctx context.Context, userID string, at time.Time) error {
+	d := s.db.DB(ctx)
+	return d.Queries.UpdateLastLogin(ctx, db.UpdateLastLoginParams{
+		LastLogin: pgtime.From(at),
+		ID:        userID,
+	})
+}
+
 // Delete deletes a user.
 func (s *UsersStore) Delete(ctx context.Context, id string) error {
 	d := s.db.DB(ctx)


### PR DESCRIPTION
Thanks @tobyw7 for reporting this, and for testing it on two separate installs, which was the detail that made it obvious it was code rather than deployment.

`users.last_login` was only ever written by the OIDC and Discord profile updaters. `UsersStore` had no method for it otherwise, and the auth handler never touched the column at all, so signing in with a username and password left it NULL and User Management showed "Never" indefinitely.

Worth noting it was broader than the report. `GetRecentUsers` reads the same column with `WHERE last_login IS NOT NULL`, so the dashboard recent-logins widget was silently empty on any password-only install. Nobody raised that because an empty widget does not look broken.

The write goes in `completeLogin`, which both local paths funnel through, plain sign-in and post-2FA. OIDC uses `CompleteOidcLogin` and already records it, so nothing is written twice. A failed write is logged and the sign-in continues, since losing a timestamp is not a reason to refuse a valid login.

The defect was an omitted call rather than a wrong one, so the tests guard the omission: one asserts `completeLogin` still calls `UpdateLastLogin`, one asserts both local paths still go through `completeLogin` so a third path cannot quietly reintroduce the gap, and one asserts the query writes the column and is scoped by id. Verified the first fails without the change.

Fixes #730