### PR TITLE
fix: Windows text encoding across reports, collectors, and install scripts

### DIFF
--- a/agent-source-code/internal/packages/packages.go
+++ b/agent-source-code/internal/packages/packages.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"strings"
 
+	"patchmon-agent/internal/textsan"
 	"patchmon-agent/pkg/models"
 
 	"github.com/sirupsen/logrus"
@@ -55,22 +56,32 @@ func (m *Manager) GetPackages() ([]models.Package, error) {
 
 	m.logger.WithField("package_manager", packageManager).Debug("Detected package manager")
 
+	var (
+		pkgs []models.Package
+		err  error
+	)
 	switch packageManager {
 	case "windows":
-		return m.winManager.GetPackages(), nil
+		pkgs = m.winManager.GetPackages()
 	case "apt":
-		return m.aptManager.GetPackages()
+		pkgs, err = m.aptManager.GetPackages()
 	case "dnf", "yum":
-		return m.dnfManager.GetPackages()
+		pkgs, err = m.dnfManager.GetPackages()
 	case "apk":
-		return m.apkManager.GetPackages()
+		pkgs, err = m.apkManager.GetPackages()
 	case "pacman":
-		return m.pacmanManager.GetPackages()
+		pkgs, err = m.pacmanManager.GetPackages()
 	case "pkg":
-		return m.freebsdManager.GetPackages()
+		pkgs, err = m.freebsdManager.GetPackages()
 	default:
 		return nil, fmt.Errorf("unsupported package manager: %s", packageManager)
 	}
+	if err != nil {
+		return nil, err
+	}
+	// Cleaning here, at the single collection choke point, keeps the canonical
+	// hash and the report payload consistent — both are derived downstream.
+	return textsan.CleanPackages(pkgs), nil
 }
 
 // DetectPackageManager detects which package manager is available on the system.

--- a/agent-source-code/internal/packages/windows.go
+++ b/agent-source-code/internal/packages/windows.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"patchmon-agent/internal/logutil"
+	"patchmon-agent/internal/winexec"
 	"patchmon-agent/pkg/models"
 
 	"github.com/sirupsen/logrus"
@@ -217,7 +218,7 @@ foreach ($path in $paths) {
 if ($result.Count -gt 5000) { $result = $result[0..4999] }
 $result | ConvertTo-Json -Compress -Depth 3
 `
-	cmd, cancel := boundedCommand(networkCollectorTimeout, "powershell", "-NoProfile", "-NonInteractive", "-Command", psScript)
+	cmd, cancel := boundedCommand(networkCollectorTimeout, "powershell", "-NoProfile", "-NonInteractive", "-Command", winexec.Script(psScript))
 	defer cancel()
 	output, err := cmd.Output()
 	if err != nil {
@@ -225,7 +226,7 @@ $result | ConvertTo-Json -Compress -Depth 3
 		return nil
 	}
 
-	outputStr := strings.TrimSpace(string(output))
+	outputStr := strings.TrimSpace(string(winexec.TrimBOM(output)))
 	if outputStr == "" || outputStr == "null" || outputStr == "[]" {
 		return nil
 	}
@@ -294,7 +295,6 @@ func (m *WindowsManager) getPackagesFromWinget() []models.Package {
 	psScript := `
 $ErrorActionPreference = "SilentlyContinue"
 $env:TERM = 'dumb'
-[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 
 # Resolve winget.exe path — handle SYSTEM/Session 0 where it's not on PATH
 $wingetPath = $null
@@ -323,7 +323,7 @@ if (-not $wingetPath) {
 $out = & $wingetPath list --accept-source-agreements --disable-interactivity 2>&1
 if ($out) { $out | Out-String }
 `
-	cmd, cancel := boundedCommand(networkCollectorTimeout, "powershell", "-NoProfile", "-NonInteractive", "-Command", psScript)
+	cmd, cancel := boundedCommand(networkCollectorTimeout, "powershell", "-NoProfile", "-NonInteractive", "-Command", winexec.Script(psScript))
 	defer cancel()
 	output, err := cmd.Output()
 	if err != nil {
@@ -510,7 +510,6 @@ func (m *WindowsManager) getWingetUpgradeAvailable() map[string]string {
 	psScript := `
 $ErrorActionPreference = "SilentlyContinue"
 $env:TERM = 'dumb'
-[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 
 # Resolve winget.exe path (same logic as main list)
 $wingetPath = $null
@@ -535,7 +534,7 @@ if (-not $wingetPath) { exit 0 }
 $out = & $wingetPath list --upgrade-available --accept-source-agreements --disable-interactivity 2>&1
 if ($out) { $out | Out-String }
 `
-	cmd, cancel := boundedCommand(networkCollectorTimeout, "powershell", "-NoProfile", "-NonInteractive", "-Command", psScript)
+	cmd, cancel := boundedCommand(networkCollectorTimeout, "powershell", "-NoProfile", "-NonInteractive", "-Command", winexec.Script(psScript))
 	defer cancel()
 	output, err := cmd.Output()
 	if err != nil {
@@ -562,13 +561,18 @@ if ($out) { $out | Out-String }
 
 func stripEllipsis(s string) string {
 	s = strings.TrimSpace(s)
-	// Winget truncates with U+2026 HORIZONTAL ELLIPSIS; also handle mis-encoded ÔÇª
+	// Winget truncates with U+2026 HORIZONTAL ELLIPSIS.
 	const ellipsis = "\u2026"
 	if strings.HasSuffix(s, ellipsis) {
 		return strings.TrimSuffix(s, ellipsis)
 	}
-	if strings.HasSuffix(s, "\u00d4\u00c2\u00c9") { // ÔÇª in UTF-8
-		return strings.TrimSuffix(s, "\u00d4\u00c2\u00c9")
+	// The same character written as UTF-8 (E2 80 A6) and read back through a
+	// single-byte code page lands as ÔÇª under CP850 or â€¦ under CP1252.
+	// The constant here used to spell ÔÂÉ, so it never matched anything.
+	for _, mangled := range []string{"\u00d4\u00c7\u00aa", "\u00e2\u20ac\u00a6"} {
+		if strings.HasSuffix(s, mangled) {
+			return strings.TrimSuffix(s, mangled)
+		}
 	}
 	return s
 }
@@ -586,7 +590,7 @@ $server = (Get-ItemProperty -Path $wuKey -Name WUServer -ErrorAction SilentlyCon
 $useWU = (Get-ItemProperty -Path "$wuKey\AU" -Name UseWUServer -ErrorAction SilentlyContinue).UseWUServer
 if ($server -and $useWU -eq 1) { "WSUS_ACTIVE" } else { "WSUS_INACTIVE" }
 `
-	cmd, cancel := boundedCommand(networkCollectorTimeout, "powershell", "-NoProfile", "-NonInteractive", "-Command", psScript)
+	cmd, cancel := boundedCommand(networkCollectorTimeout, "powershell", "-NoProfile", "-NonInteractive", "-Command", winexec.Script(psScript))
 	defer cancel()
 	output, err := cmd.Output()
 	if err != nil {
@@ -718,7 +722,7 @@ if ($comFailed) {
 
 $result | ConvertTo-Json -Compress -Depth 4
 `
-	cmd, cancel := boundedCommand(networkCollectorTimeout, "powershell", "-NoProfile", "-NonInteractive", "-Command", psScript)
+	cmd, cancel := boundedCommand(networkCollectorTimeout, "powershell", "-NoProfile", "-NonInteractive", "-Command", winexec.Script(psScript))
 	defer cancel()
 	output, err := cmd.Output()
 	if err != nil {
@@ -726,7 +730,7 @@ $result | ConvertTo-Json -Compress -Depth 4
 		return nil
 	}
 
-	outputStr := strings.TrimSpace(string(output))
+	outputStr := strings.TrimSpace(string(winexec.TrimBOM(output)))
 	// Check for COM error message (e.g. E_ACCESSDENIED in Session 0)
 	if strings.Contains(outputStr, "WUA_COM_ERROR:") {
 		idx := strings.Index(outputStr, "WUA_COM_ERROR:")

--- a/agent-source-code/internal/packages/windows_patch.go
+++ b/agent-source-code/internal/packages/windows_patch.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+
+	"patchmon-agent/internal/winexec"
 )
 
 // WindowsPatcher executes Windows patching operations via PowerShell.
@@ -72,7 +74,7 @@ try {
 }
 `, guid)
 
-	cmd := exec.CommandContext(ctx, "powershell", "-NoProfile", "-NonInteractive", "-Command", psScript)
+	cmd := exec.CommandContext(ctx, "powershell", "-NoProfile", "-NonInteractive", "-Command", winexec.Script(psScript))
 	out, err := cmd.CombinedOutput()
 	output := strings.TrimSpace(string(out))
 	if err != nil {
@@ -128,13 +130,12 @@ func (p *WindowsPatcher) WinGetUpgradeAll(ctx context.Context, dryRun bool) (str
 	}
 	psScript := fmt.Sprintf(`
 $ErrorActionPreference = "SilentlyContinue"
-[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 $env:TERM = 'dumb'
 %s
 %s
 `, wingetResolveBlock, action)
 
-	cmd := exec.CommandContext(ctx, "powershell", "-NoProfile", "-NonInteractive", "-Command", psScript)
+	cmd := exec.CommandContext(ctx, "powershell", "-NoProfile", "-NonInteractive", "-Command", winexec.Script(psScript))
 	out, err := cmd.CombinedOutput()
 	output := strings.TrimSpace(string(out))
 	if err != nil {
@@ -160,13 +161,12 @@ Write-Output $out
 	}
 	psScript := fmt.Sprintf(`
 $ErrorActionPreference = "SilentlyContinue"
-[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 $env:TERM = 'dumb'
 %s
 %s
 `, wingetResolveBlock, action)
 
-	cmd := exec.CommandContext(ctx, "powershell", "-NoProfile", "-NonInteractive", "-Command", psScript)
+	cmd := exec.CommandContext(ctx, "powershell", "-NoProfile", "-NonInteractive", "-Command", winexec.Script(psScript))
 	out, err := cmd.CombinedOutput()
 	output := strings.TrimSpace(string(out))
 	if err != nil {
@@ -182,7 +182,7 @@ func RebootRequired() bool {
 $key = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired'
 if (Test-Path $key) { Write-Output 'true' } else { Write-Output 'false' }
 `
-	cmd, cancel := boundedCommand(collectorTimeout, "powershell", "-NoProfile", "-NonInteractive", "-Command", psScript)
+	cmd, cancel := boundedCommand(collectorTimeout, "powershell", "-NoProfile", "-NonInteractive", "-Command", winexec.Script(psScript))
 	defer cancel()
 	out, err := cmd.Output()
 	if err != nil {

--- a/agent-source-code/internal/packages/windows_test.go
+++ b/agent-source-code/internal/packages/windows_test.go
@@ -1,0 +1,27 @@
+package packages
+
+import "testing"
+
+// TestStripEllipsis covers winget's column truncation marker in each of the
+// forms it reaches the agent in. The mis-encoded variants appear when the
+// PowerShell console encoding is a single-byte code page rather than UTF-8.
+func TestStripEllipsis(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"untruncated", "Microsoft Windows Desktop Runtime", "Microsoft Windows Desktop Runtime"},
+		{"utf8 ellipsis", "Microsoft Windows Desktop Runtime - 8.0\u2026", "Microsoft Windows Desktop Runtime - 8.0"},
+		{"cp850 mangled", "Microsoft Visual C++ 2015-2022 Redistri\u00d4\u00c7\u00aa", "Microsoft Visual C++ 2015-2022 Redistri"},
+		{"cp1252 mangled", "Microsoft Visual C++ 2015-2022 Redistri\u00e2\u20ac\u00a6", "Microsoft Visual C++ 2015-2022 Redistri"},
+		{"surrounding space trimmed", "  vim\u2026  ", "vim"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := stripEllipsis(tc.in); got != tc.want {
+				t.Fatalf("stripEllipsis(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/agent-source-code/internal/repositories/repositories.go
+++ b/agent-source-code/internal/repositories/repositories.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"strings"
 
+	"patchmon-agent/internal/textsan"
 	"patchmon-agent/pkg/models"
 
 	"github.com/sirupsen/logrus"
@@ -41,24 +42,31 @@ func (m *Manager) GetRepositories() ([]models.Repository, error) {
 
 	m.logger.WithField("package_manager", packageManager).Debug("Detected package manager")
 
+	var (
+		repos []models.Repository
+		err   error
+	)
 	switch packageManager {
 	case "windows":
-		return m.winManager.GetRepositories()
+		repos, err = m.winManager.GetRepositories()
 	case "apt":
-		return m.aptManager.GetRepositories()
+		repos, err = m.aptManager.GetRepositories()
 	case "dnf", "yum":
-		repos := m.dnfManager.GetRepositories()
-		return repos, nil
+		repos = m.dnfManager.GetRepositories()
 	case "apk":
-		return m.apkManager.GetRepositories()
+		repos, err = m.apkManager.GetRepositories()
 	case "pacman":
-		return m.pacmanManager.GetRepositories()
+		repos, err = m.pacmanManager.GetRepositories()
 	case "pkg":
-		return m.freebsdManager.GetRepositories()
+		repos, err = m.freebsdManager.GetRepositories()
 	default:
 		m.logger.WithField("package_manager", packageManager).Warn("Unsupported package manager")
 		return []models.Repository{}, nil
 	}
+	if err != nil {
+		return nil, err
+	}
+	return textsan.CleanRepositories(repos), nil
 }
 
 // detectPackageManager detects which package manager is available on the system

--- a/agent-source-code/internal/repositories/windows.go
+++ b/agent-source-code/internal/repositories/windows.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"patchmon-agent/internal/constants"
+	"patchmon-agent/internal/winexec"
 	"patchmon-agent/pkg/models"
 
 	"github.com/sirupsen/logrus"
@@ -52,7 +53,7 @@ $sources += @{ Name = "Microsoft Update"; URL = "https://update.microsoft.com"; 
 $sources | ConvertTo-Json -Compress
 `
 
-	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", psScript)
+	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", winexec.Script(psScript))
 	output, err := cmd.Output()
 	if err != nil {
 		m.logger.WithError(err).Warn("Failed to query Windows Update sources (may require admin privileges)")
@@ -67,7 +68,7 @@ $sources | ConvertTo-Json -Compress
 		}}, nil
 	}
 
-	sourcesJSON := strings.TrimSpace(string(output))
+	sourcesJSON := strings.TrimSpace(string(winexec.TrimBOM(output)))
 	if sourcesJSON == "" || sourcesJSON == "[]" {
 		return []models.Repository{{
 			Name:         "Microsoft Update",
@@ -78,6 +79,12 @@ $sources | ConvertTo-Json -Compress
 			IsEnabled:    true,
 			IsSecure:     true,
 		}}, nil
+	}
+
+	// ConvertTo-Json emits a bare object, not an array, when the pipeline
+	// carries exactly one item — which is every host without WSUS configured.
+	if !strings.HasPrefix(sourcesJSON, "[") {
+		sourcesJSON = "[" + sourcesJSON + "]"
 	}
 
 	var sources []windowsUpdateSource

--- a/agent-source-code/internal/system/reboot.go
+++ b/agent-source-code/internal/system/reboot.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"patchmon-agent/internal/logutil"
+	"patchmon-agent/internal/winexec"
 )
 
 // CheckRebootRequired checks if the system requires a reboot
@@ -96,7 +97,7 @@ if ($reasons.Count -gt 0) {
   Write-Output "REBOOT_NOT_REQUIRED"
 }
 `
-	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", psScript)
+	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", winexec.Script(psScript))
 	output, err := cmd.Output()
 	if err != nil {
 		d.logger.WithError(err).Debug("Windows reboot check failed")

--- a/agent-source-code/internal/textsan/textsan.go
+++ b/agent-source-code/internal/textsan/textsan.go
@@ -1,0 +1,68 @@
+// Package textsan normalises text collected from the host before the agent
+// hashes it, logs it, or ships it to the server.
+package textsan
+
+import (
+	"strings"
+	"unicode/utf8"
+
+	"patchmon-agent/pkg/models"
+)
+
+// Clean removes NUL and repairs invalid UTF-8.
+//
+// PostgreSQL can store neither: the server binds package data as jsonb, which
+// rejects the \u0000 escape outright, so one padded registry value (several
+// Windows installers pad DisplayVersion with trailing NULs) used to fail the
+// host's entire report. The server sanitises defensively as well, for agents
+// older than this; cleaning here keeps `patchmon-agent report --json` honest
+// and stops the bad bytes entering the canonical hash.
+//
+// Both branches are scans that allocate nothing for clean input.
+func Clean(s string) string {
+	if s == "" {
+		return s
+	}
+	if strings.IndexByte(s, 0) >= 0 {
+		s = strings.ReplaceAll(s, "\x00", "")
+	}
+	if !utf8.ValidString(s) {
+		s = strings.ToValidUTF8(s, "�")
+	}
+	return s
+}
+
+// CleanPackages cleans every string field in place and returns the slice for
+// convenient chaining at a return statement.
+func CleanPackages(pkgs []models.Package) []models.Package {
+	for i := range pkgs {
+		p := &pkgs[i]
+		p.Name = Clean(p.Name)
+		p.Description = Clean(p.Description)
+		p.Category = Clean(p.Category)
+		p.CurrentVersion = Clean(p.CurrentVersion)
+		p.AvailableVersion = Clean(p.AvailableVersion)
+		p.SourceRepository = Clean(p.SourceRepository)
+		p.WUAGuid = Clean(p.WUAGuid)
+		p.WUAKb = Clean(p.WUAKb)
+		p.WUASeverity = Clean(p.WUASeverity)
+		p.WUASupportURL = Clean(p.WUASupportURL)
+		for j := range p.WUACategories {
+			p.WUACategories[j] = Clean(p.WUACategories[j])
+		}
+	}
+	return pkgs
+}
+
+// CleanRepositories cleans every string field in place and returns the slice.
+func CleanRepositories(repos []models.Repository) []models.Repository {
+	for i := range repos {
+		r := &repos[i]
+		r.Name = Clean(r.Name)
+		r.URL = Clean(r.URL)
+		r.Distribution = Clean(r.Distribution)
+		r.Components = Clean(r.Components)
+		r.RepoType = Clean(r.RepoType)
+	}
+	return repos
+}

--- a/agent-source-code/internal/textsan/textsan_test.go
+++ b/agent-source-code/internal/textsan/textsan_test.go
@@ -1,0 +1,62 @@
+package textsan
+
+import (
+	"testing"
+
+	"patchmon-agent/pkg/models"
+)
+
+func TestClean(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"clean ascii", "Mesh Agent", "Mesh Agent"},
+		{"accents preserved", "Mise à jour de la sélection", "Mise à jour de la sélection"},
+		{"trailing nuls", "2026-02-16 01:43:44.000+01:00\x00\x00", "2026-02-16 01:43:44.000+01:00"},
+		{"embedded nul", "Microsoft\x00", "Microsoft"},
+		{"invalid utf8 repaired", "caf\xe9", "caf�"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Clean(tc.in); got != tc.want {
+				t.Fatalf("Clean(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCleanPackages(t *testing.T) {
+	pkgs := CleanPackages([]models.Package{{
+		Name:             "Mesh Agent\x00",
+		Description:      "3,3 MB",
+		CurrentVersion:   "2026-02-16 01:43:44.000+01:00\x00\x00",
+		AvailableVersion: "1.2.3\x00",
+		WUACategories:    []string{"Security Updates\x00"},
+	}})
+	p := pkgs[0]
+	if p.Name != "Mesh Agent" {
+		t.Fatalf("name = %q", p.Name)
+	}
+	if p.CurrentVersion != "2026-02-16 01:43:44.000+01:00" {
+		t.Fatalf("current version = %q", p.CurrentVersion)
+	}
+	if p.AvailableVersion != "1.2.3" {
+		t.Fatalf("available version = %q", p.AvailableVersion)
+	}
+	if p.WUACategories[0] != "Security Updates" {
+		t.Fatalf("wua category = %q", p.WUACategories[0])
+	}
+}
+
+func TestCleanRepositories(t *testing.T) {
+	repos := CleanRepositories([]models.Repository{{
+		Name: "Microsoft Update\x00",
+		URL:  "https://update.microsoft.com\x00",
+	}})
+	if repos[0].Name != "Microsoft Update" || repos[0].URL != "https://update.microsoft.com" {
+		t.Fatalf("repository not cleaned: %+v", repos[0])
+	}
+}

--- a/agent-source-code/internal/winexec/powershell.go
+++ b/agent-source-code/internal/winexec/powershell.go
@@ -1,0 +1,41 @@
+// Package winexec centralises how the agent shells out to Windows PowerShell.
+package winexec
+
+import "bytes"
+
+// utf8Preamble forces stdout to UTF-8 for the rest of the script.
+//
+// Windows PowerShell 5.1 encodes redirected stdout using
+// [Console]::OutputEncoding, which defaults to the console's OEM code page
+// (CP850 in much of western Europe, CP866 in Russia). Anything outside ASCII
+// then reaches the agent as bytes that are not valid UTF-8, and Go's JSON
+// decoder rewrites each one as U+FFFD, so package names arrive as "Mise � jour".
+//
+// The BOM-less UTF8Encoding matters. [System.Text.Encoding]::UTF8, which the
+// winget collectors used before, is an encoding whose GetPreamble() returns
+// three bytes; UTF8Encoding($false) returns none. Whether the host actually
+// writes that preamble to a redirected stream varies by runtime, so the
+// collectors that parse the output as JSON take the BOM-less encoding and go
+// through TrimBOM as well.
+//
+// The assignment is wrapped because the agent runs as a service in Session 0,
+// where no console is attached. Setting the encoding on a redirected stdout is
+// safe there, but a host configuration that makes it throw must degrade to
+// mojibake rather than losing the collector entirely.
+const utf8Preamble = "try { [Console]::OutputEncoding = New-Object System.Text.UTF8Encoding $false } catch {}\n"
+
+var bom = []byte{0xEF, 0xBB, 0xBF}
+
+// Script prepends the UTF-8 preamble to a PowerShell script body. Every
+// PowerShell invocation in the agent must go through this, whether or not the
+// script currently emits non-ASCII: Windows Update titles, publisher names and
+// install paths are all localised.
+func Script(body string) string {
+	return utf8Preamble + body
+}
+
+// TrimBOM drops a leading byte-order mark. PowerShell can still emit one
+// depending on host configuration, and it is not valid JSON.
+func TrimBOM(b []byte) []byte {
+	return bytes.TrimPrefix(b, bom)
+}

--- a/agent-source-code/internal/winexec/powershell_test.go
+++ b/agent-source-code/internal/winexec/powershell_test.go
@@ -1,0 +1,38 @@
+package winexec
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestScriptSetsBomlessUTF8Output(t *testing.T) {
+	got := Script("Get-Service\n")
+	if !strings.HasPrefix(got, "try { [Console]::OutputEncoding") {
+		t.Fatalf("preamble must come first, got: %q", got)
+	}
+	// [System.Text.Encoding]::UTF8 writes a BOM, which breaks json.Unmarshal
+	// on the collectors that parse ConvertTo-Json output.
+	if strings.Contains(got, "[System.Text.Encoding]::UTF8") {
+		t.Fatal("preamble uses the BOM-emitting encoding")
+	}
+	if !strings.Contains(got, "UTF8Encoding $false") {
+		t.Fatalf("preamble does not disable the BOM: %q", got)
+	}
+	if !strings.HasSuffix(got, "Get-Service\n") {
+		t.Fatalf("script body not preserved: %q", got)
+	}
+}
+
+func TestTrimBOM(t *testing.T) {
+	withBOM := append([]byte{0xEF, 0xBB, 0xBF}, []byte(`[{"Name":"vim"}]`)...)
+	if got := string(TrimBOM(withBOM)); got != `[{"Name":"vim"}]` {
+		t.Fatalf("BOM not trimmed: %q", got)
+	}
+	clean := []byte(`[{"Name":"vim"}]`)
+	if got := string(TrimBOM(clean)); got != string(clean) {
+		t.Fatalf("clean input altered: %q", got)
+	}
+	if got := TrimBOM(nil); len(got) != 0 {
+		t.Fatalf("nil input produced %q", got)
+	}
+}

--- a/docs/patchmon-operator-guide.md
+++ b/docs/patchmon-operator-guide.md
@@ -2832,7 +2832,7 @@ curl -s "https://patchmon.example.com/api/v1/hosts/install?os=freebsd" \
 **Windows one-liner** (elevated PowerShell, single line):
 
 ```powershell
-$r = Invoke-WebRequest -Uri "https://patchmon.example.com/api/v1/hosts/install?os=windows" -Headers @{"X-API-ID"="patchmon_a1b2c3d4"; "X-API-KEY"="<64-char-key>"} -UseBasicParsing; $r.Content | Set-Content "$env:TEMP\patchmon-install.ps1" -Encoding UTF8; & "$env:TEMP\patchmon-install.ps1"
+Invoke-WebRequest -Uri "https://patchmon.example.com/api/v1/hosts/install?os=windows" -Headers @{"X-API-ID"="patchmon_a1b2c3d4"; "X-API-KEY"="<64-char-key>"} -UseBasicParsing -OutFile "$env:TEMP\patchmon-install.ps1"; & "$env:TEMP\patchmon-install.ps1"
 ```
 
 Click **Copy command**. The wizard advances to **Step 5: Connection** automatically.
@@ -4002,10 +4002,11 @@ curl -s https://patchmon.example.com/api/v1/hosts/remove | sudo sh
 
 ```powershell
 $ProgressPreference = 'SilentlyContinue'
-irm https://patchmon.example.com/api/v1/hosts/remove?os=windows | iex
+Invoke-WebRequest https://patchmon.example.com/api/v1/hosts/remove?os=windows -UseBasicParsing -OutFile "$env:TEMP\patchmon-remove.ps1"
+powershell.exe -ExecutionPolicy Bypass -File "$env:TEMP\patchmon-remove.ps1"
 ```
 
-(Or download first, inspect, then run: `irm ... -OutFile remove.ps1; .\remove.ps1`.)
+`-OutFile` writes the script to disk byte for byte. Piping the response through `iex` makes Windows PowerShell 5.1 decode it as text first, which is a common source of parser errors.
 
 The Linux/FreeBSD script handles everything:
 - Stops the service (systemd, OpenRC, or crontab)
@@ -4392,7 +4393,8 @@ curl -s https://patchmon.example.com/api/v1/hosts/remove | sudo REMOVE_BACKUPS=1
 
 ```powershell
 $ProgressPreference = 'SilentlyContinue'
-irm https://patchmon.example.com/api/v1/hosts/remove?os=windows | iex
+Invoke-WebRequest https://patchmon.example.com/api/v1/hosts/remove?os=windows -UseBasicParsing -OutFile "$env:TEMP\patchmon-remove.ps1"
+powershell.exe -ExecutionPolicy Bypass -File "$env:TEMP\patchmon-remove.ps1"
 ```
 
 Or download first, inspect, then run:

--- a/frontend/src/components/AddHostWizard.jsx
+++ b/frontend/src/components/AddHostWizard.jsx
@@ -110,7 +110,11 @@ const AddHostWizard = ({ isOpen, onClose, onSuccess }) => {
 			const curlInsecure = includeSslBypass ? " -k" : "";
 			return `${sslBlock}curl.exe${curlInsecure} -s -H "X-API-ID: ${createdHost?.api_id}" -H "X-API-KEY: ${plaintextApiKey}" -o "$env:TEMP\\patchmon-install.ps1" "${installUrl}"; if ($LASTEXITCODE -eq 0) { & "$env:TEMP\\patchmon-install.ps1" } else { Write-Error "curl failed with exit code $LASTEXITCODE" }`;
 		}
-		return `${sslBlock}$r = Invoke-WebRequest -Uri "${installUrl}" -Headers @{"X-API-ID"="${createdHost?.api_id}"; "X-API-KEY"="${plaintextApiKey}"} -UseBasicParsing; $r.Content | Set-Content "$env:TEMP\\patchmon-install.ps1" -Encoding UTF8; & "$env:TEMP\\patchmon-install.ps1"`;
+		// -OutFile writes the response bytes straight to disk. Reading
+		// $r.Content instead makes Windows PowerShell 5.1 decode the body
+		// through the Windows ANSI code page, which corrupts every non-ASCII
+		// character in the script.
+		return `${sslBlock}Invoke-WebRequest -Uri "${installUrl}" -Headers @{"X-API-ID"="${createdHost?.api_id}"; "X-API-KEY"="${plaintextApiKey}"} -UseBasicParsing -OutFile "$env:TEMP\\patchmon-install.ps1"; & "$env:TEMP\\patchmon-install.ps1"`;
 	};
 
 	const getShellCommand = (force) => {

--- a/frontend/src/components/settings/AgentUpdatesTab.jsx
+++ b/frontend/src/components/settings/AgentUpdatesTab.jsx
@@ -85,6 +85,12 @@ const AgentUpdatesTab = () => {
 	});
 	const serverUrl = serverUrlData?.server_url || window.location.origin;
 
+	// Built once and used for both the displayed text and the copy button. JSX
+	// collapses a multi-line literal to whitespace-separated words, which used
+	// to put a space inside the URL of the command shown on screen.
+	const windowsRemoveCommand = (extraArgs = "") =>
+		`Invoke-WebRequest -Uri "${serverUrl}/api/v1/hosts/remove?os=windows" -UseBasicParsing -OutFile "$env:TEMP\\patchmon-remove.ps1"; powershell.exe -ExecutionPolicy Bypass -File "$env:TEMP\\patchmon-remove.ps1"${extraArgs}`;
+
 	// Update form data when settings are loaded
 	useEffect(() => {
 		if (settings) {
@@ -694,19 +700,13 @@ const AgentUpdatesTab = () => {
 											</div>
 											<div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2">
 												<div className="bg-red-100 dark:bg-red-800 rounded p-2 font-mono text-xs flex-1 break-all overflow-x-auto">
-													$script = Invoke-WebRequest -Uri "{serverUrl}
-													/api/v1/hosts/remove?os=windows " -UseBasicParsing;
-													$script.Content | Out-File -FilePath
-													"$env:TEMP\patchmon-remove.ps1" -Encoding utf8;
-													powershell.exe -ExecutionPolicy Bypass -File
-													"$env:TEMP\patchmon-remove.ps1"
+													{windowsRemoveCommand()}
 												</div>
 												<button
 													type="button"
 													onClick={async () => {
 														try {
-															const cmd = `$script = Invoke-WebRequest -Uri "${serverUrl}/api/v1/hosts/remove?os=windows" -UseBasicParsing; $script.Content | Out-File -FilePath "$env:TEMP\\patchmon-remove.ps1" -Encoding utf8; powershell.exe -ExecutionPolicy Bypass -File "$env:TEMP\\patchmon-remove.ps1"`;
-															await copyToClipboard(cmd);
+															await copyToClipboard(windowsRemoveCommand());
 															showToast(
 																"Standard removal command copied!",
 																"success",
@@ -730,19 +730,15 @@ const AgentUpdatesTab = () => {
 											</div>
 											<div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2">
 												<div className="bg-red-100 dark:bg-red-800 rounded p-2 font-mono text-xs flex-1 break-all overflow-x-auto">
-													$script = Invoke-WebRequest -Uri "{serverUrl}
-													/api/v1/hosts/remove?os=windows " -UseBasicParsing;
-													$script.Content | Out-File -FilePath
-													"$env:TEMP\patchmon-remove.ps1" -Encoding utf8;
-													powershell.exe -ExecutionPolicy Bypass -File
-													"$env:TEMP\patchmon-remove.ps1" -RemoveAll -Force
+													{windowsRemoveCommand(" -RemoveAll -Force")}
 												</div>
 												<button
 													type="button"
 													onClick={async () => {
 														try {
-															const cmd = `$script = Invoke-WebRequest -Uri "${serverUrl}/api/v1/hosts/remove?os=windows" -UseBasicParsing; $script.Content | Out-File -FilePath "$env:TEMP\\patchmon-remove.ps1" -Encoding utf8; powershell.exe -ExecutionPolicy Bypass -File "$env:TEMP\\patchmon-remove.ps1" -RemoveAll -Force`;
-															await copyToClipboard(cmd);
+															await copyToClipboard(
+																windowsRemoveCommand(" -RemoveAll -Force"),
+															);
 															showToast(
 																"Complete removal command copied!",
 																"success",

--- a/frontend/src/pages/hostdetail/CredentialsModal.jsx
+++ b/frontend/src/pages/hostdetail/CredentialsModal.jsx
@@ -114,7 +114,11 @@ const CredentialsModal = ({ host, isOpen, onClose, plaintextApiKey }) => {
 			const curlInsecure = windowsIgnoreSsl ? " -k" : "";
 			return `${sslBlock}curl.exe${curlInsecure} -s -H "X-API-ID: ${effectiveApiId}" -H "X-API-KEY: ${effectiveApiKey}" -o "$env:TEMP\\patchmon-install.ps1" "${installUrl}"; if ($LASTEXITCODE -eq 0) { & "$env:TEMP\\patchmon-install.ps1" } else { Write-Error "curl failed with exit code $LASTEXITCODE" }`;
 		}
-		return `${sslBlock}$r = Invoke-WebRequest -Uri "${installUrl}" -Headers @{"X-API-ID"="${effectiveApiId}"; "X-API-KEY"="${effectiveApiKey}"} -UseBasicParsing; $r.Content | Set-Content "$env:TEMP\\patchmon-install.ps1" -Encoding UTF8; & "$env:TEMP\\patchmon-install.ps1"`;
+		// -OutFile writes the response bytes straight to disk. Reading
+		// $r.Content instead makes Windows PowerShell 5.1 decode the body
+		// through the Windows ANSI code page, which corrupts every non-ASCII
+		// character in the script.
+		return `${sslBlock}Invoke-WebRequest -Uri "${installUrl}" -Headers @{"X-API-ID"="${effectiveApiId}"; "X-API-KEY"="${effectiveApiKey}"} -UseBasicParsing -OutFile "$env:TEMP\\patchmon-install.ps1"; & "$env:TEMP\\patchmon-install.ps1"`;
 	};
 
 	const getLinuxInstallCommand = () =>

--- a/server-source-code/internal/agents/patchmon_install_windows.ps1
+++ b/server-source-code/internal/agents/patchmon_install_windows.ps1
@@ -265,28 +265,28 @@ if ($serviceStarted) {
 }
 Write-Host ""
 Write-Host "Installation Summary:" -ForegroundColor Green
-Write-Host "   • Configuration directory: $ConfigPath" -ForegroundColor Gray
-Write-Host "   • Agent binary installed: $InstallPath\patchmon-agent.exe" -ForegroundColor Gray
-Write-Host "   • Architecture: $arch" -ForegroundColor Gray
+Write-Host "   - Configuration directory: $ConfigPath" -ForegroundColor Gray
+Write-Host "   - Agent binary installed: $InstallPath\patchmon-agent.exe" -ForegroundColor Gray
+Write-Host "   - Architecture: $arch" -ForegroundColor Gray
 $svc = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
 if ($svc -and $svc.Status -eq "Running") {
-    Write-Host "   • Windows Service: configured and running" -ForegroundColor Gray
+    Write-Host "   - Windows Service: configured and running" -ForegroundColor Gray
 } elseif ($svc) {
-    Write-Host "   • Windows Service: configured (Status: $($svc.Status))" -ForegroundColor Gray
+    Write-Host "   - Windows Service: configured (Status: $($svc.Status))" -ForegroundColor Gray
 } else {
-    Write-Host "   • Windows Service: not configured (run manually: patchmon-agent.exe serve)" -ForegroundColor Gray
+    Write-Host "   - Windows Service: not configured (run manually: patchmon-agent.exe serve)" -ForegroundColor Gray
 }
-Write-Host "   • API credentials configured and tested" -ForegroundColor Gray
-Write-Host "   • Logs: $ConfigPath\patchmon-agent.log" -ForegroundColor Gray
+Write-Host "   - API credentials configured and tested" -ForegroundColor Gray
+Write-Host "   - Logs: $ConfigPath\patchmon-agent.log" -ForegroundColor Gray
 
 Write-Host ""
 Write-Host "Management Commands:" -ForegroundColor Cyan
-Write-Host "   • Test connection: patchmon-agent ping" -ForegroundColor Gray
-Write-Host "   • Manual report: patchmon-agent report" -ForegroundColor Gray
-Write-Host "   • Check status: patchmon-agent diagnostics" -ForegroundColor Gray
-Write-Host "   • Service status: Get-Service -Name $serviceName" -ForegroundColor Gray
-Write-Host "   • Service logs: Get-Content `"$ConfigPath\patchmon-agent.log`" -Tail 50 -Wait" -ForegroundColor Gray
-Write-Host "   • Restart service: Restart-Service -Name $serviceName" -ForegroundColor Gray
+Write-Host "   - Test connection: patchmon-agent ping" -ForegroundColor Gray
+Write-Host "   - Manual report: patchmon-agent report" -ForegroundColor Gray
+Write-Host "   - Check status: patchmon-agent diagnostics" -ForegroundColor Gray
+Write-Host "   - Service status: Get-Service -Name $serviceName" -ForegroundColor Gray
+Write-Host "   - Service logs: Get-Content `"$ConfigPath\patchmon-agent.log`" -Tail 50 -Wait" -ForegroundColor Gray
+Write-Host "   - Restart service: Restart-Service -Name $serviceName" -ForegroundColor Gray
 
 Write-Host ""
 if ($serviceStarted) {

--- a/server-source-code/internal/agents/patchmon_remove_windows.ps1
+++ b/server-source-code/internal/agents/patchmon_remove_windows.ps1
@@ -34,30 +34,30 @@ $serviceName = "PatchMonAgent"
 # Functions
 function Write-Info {
     param([string]$Message)
-    Write-Host "ℹ️  $Message" -ForegroundColor Cyan
+    Write-Host "[i] $Message" -ForegroundColor Cyan
 }
 
 function Write-Success {
     param([string]$Message)
-    Write-Host "✅ $Message" -ForegroundColor Green
+    Write-Host "[OK] $Message" -ForegroundColor Green
 }
 
 function Write-Warn {
     param([string]$Message)
-    Write-Host "⚠️  $Message" -ForegroundColor Yellow
+    Write-Host "[!] $Message" -ForegroundColor Yellow
 }
 
 function Write-Error-Msg {
     param([string]$Message)
-    Write-Host "❌ ERROR: $Message" -ForegroundColor Red
+    Write-Host "[X] ERROR: $Message" -ForegroundColor Red
 }
 
 Write-Host ""
-Write-Info "🗑️  Starting PatchMon Agent Removal..."
+Write-Info "Starting PatchMon Agent Removal..."
 Write-Host ""
 
 # Step 1: Stop and remove Windows Service
-Write-Info "🛑 Stopping PatchMon service..."
+Write-Info "Stopping PatchMon service..."
 $serviceStopped = $false
 
 try {
@@ -71,11 +71,11 @@ try {
             # Verify it stopped
             $service = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
             if ($service.Status -eq "Running") {
-                Write-Warn "⚠️  Service is STILL RUNNING after stop command! Attempting force stop..."
+                Write-Warn "Service is STILL RUNNING after stop command! Attempting force stop..."
                 & sc.exe stop $serviceName | Out-Null
                 Start-Sleep -Seconds 2
             } else {
-                Write-Success "✓ Service stopped successfully"
+                Write-Success "Service stopped successfully"
             }
             $serviceStopped = $true
         } else {
@@ -91,9 +91,9 @@ try {
         # Verify service was removed
         $service = Get-Service -Name $serviceName -ErrorAction SilentlyContinue
         if (-not $service) {
-            Write-Success "✓ Service removed successfully"
+            Write-Success "Service removed successfully"
         } else {
-            Write-Warn "⚠️  Service still exists after deletion attempt"
+            Write-Warn "Service still exists after deletion attempt"
         }
     } else {
         Write-Info "Windows Service not found"
@@ -103,7 +103,7 @@ try {
 }
 
 # Step 2: Stop any running agent processes
-Write-Info "🔄 Stopping any running PatchMon processes..."
+Write-Info "Stopping any running PatchMon processes..."
 $processes = Get-Process -Name "patchmon-agent" -ErrorAction SilentlyContinue
 if ($processes) {
     Write-Warn "Found $($processes.Count) running PatchMon process(es), stopping them..."
@@ -113,16 +113,16 @@ if ($processes) {
     # Verify they stopped
     $remaining = Get-Process -Name "patchmon-agent" -ErrorAction SilentlyContinue
     if ($remaining) {
-        Write-Warn "⚠️  Some processes are still running after stop command"
+        Write-Warn "Some processes are still running after stop command"
     } else {
-        Write-Success "✓ All processes stopped"
+        Write-Success "All processes stopped"
     }
 } else {
     Write-Info "No running PatchMon processes found"
 }
 
 # Step 3: Remove agent binary
-Write-Info "📄 Removing agent binaries..."
+Write-Info "Removing agent binaries..."
 $binaryRemoved = $false
 
 $binaryPath = Join-Path $InstallPath "patchmon-agent.exe"
@@ -135,7 +135,7 @@ if (Test-Path $binaryPath) {
             Start-Sleep -Seconds 3
         }
         Remove-Item -Path $binaryPath -Force -ErrorAction Stop
-        Write-Success "✓ Binary removed"
+        Write-Success "Binary removed"
         $binaryRemoved = $true
     } catch {
         Write-Warn "Failed to remove binary: $_"
@@ -160,14 +160,14 @@ if ($binaryRemoved) {
 }
 
 # Step 4: Remove from PATH
-Write-Info "🗑️  Removing PatchMon from system PATH..."
+Write-Info "Removing PatchMon from system PATH..."
 try {
     $currentPath = [Environment]::GetEnvironmentVariable("Path", [EnvironmentVariableTarget]::Machine)
     if ($currentPath -like "*$InstallPath*") {
         Write-Warn "Removing PatchMon from system PATH..."
         $newPath = ($currentPath -split ';' | Where-Object { $_ -ne $InstallPath }) -join ';'
         [Environment]::SetEnvironmentVariable("Path", $newPath, [EnvironmentVariableTarget]::Machine)
-        Write-Success "✓ Removed from PATH"
+        Write-Success "Removed from PATH"
     } else {
         Write-Info "PatchMon not found in system PATH"
     }
@@ -176,14 +176,14 @@ try {
 }
 
 # Step 5: Remove installation directory (if empty or RemoveAll)
-Write-Info "📁 Checking installation directory..."
+Write-Info "Checking installation directory..."
 if (Test-Path $InstallPath) {
     $items = Get-ChildItem -Path $InstallPath -ErrorAction SilentlyContinue
     if ($items.Count -eq 0 -or $RemoveAll) {
         Write-Warn "Removing installation directory: $InstallPath"
         try {
             Remove-Item -Path $InstallPath -Recurse -Force -ErrorAction Stop
-            Write-Success "✓ Installation directory removed"
+            Write-Success "Installation directory removed"
         } catch {
             Write-Warn "Failed to remove installation directory: $_"
             Write-Warn "You may need to manually delete: $InstallPath"
@@ -197,12 +197,12 @@ if (Test-Path $InstallPath) {
 
 # Step 6: Remove configuration files (optional)
 if ($RemoveConfig) {
-    Write-Info "📋 Removing configuration files..."
+    Write-Info "Removing configuration files..."
     if (Test-Path $ConfigPath) {
         Write-Warn "Removing configuration directory: $ConfigPath"
         try {
             Remove-Item -Path $ConfigPath -Recurse -Force -ErrorAction Stop
-            Write-Success "✓ Configuration directory removed"
+            Write-Success "Configuration directory removed"
         } catch {
             Write-Warn "Failed to remove configuration directory: $_"
             Write-Warn "You may need to manually delete: $ConfigPath"
@@ -211,7 +211,7 @@ if ($RemoveConfig) {
         Write-Info "Configuration directory not found"
     }
 } else {
-    Write-Info "📋 Configuration files preserved (use -RemoveConfig to remove)"
+    Write-Info "Configuration files preserved (use -RemoveConfig to remove)"
     if (Test-Path $ConfigPath) {
         Write-Host "   Location: $ConfigPath" -ForegroundColor Gray
     }
@@ -219,13 +219,13 @@ if ($RemoveConfig) {
 
 # Step 7: Remove log files (optional)
 if ($RemoveLogs) {
-    Write-Info "📝 Removing log files..."
+    Write-Info "Removing log files..."
     $logPath = Join-Path $ConfigPath "patchmon-agent.log"
     if (Test-Path $logPath) {
         Write-Warn "Removing log file: $logPath"
         try {
             Remove-Item -Path $logPath -Force -ErrorAction Stop
-            Write-Success "✓ Log file removed"
+            Write-Success "Log file removed"
         } catch {
             Write-Warn "Failed to remove log file: $_"
         }
@@ -240,12 +240,12 @@ if ($RemoveLogs) {
         $logBackups | Remove-Item -Force -ErrorAction SilentlyContinue
     }
 } else {
-    Write-Info "📝 Log files preserved (use -RemoveLogs to remove)"
+    Write-Info "Log files preserved (use -RemoveLogs to remove)"
 }
 
 # Step 8: Clean up backup files in config directory (if RemoveConfig or RemoveAll)
 if ($RemoveConfig -or $RemoveAll) {
-    Write-Info "🧹 Checking for backup files..."
+    Write-Info "Checking for backup files..."
     $backupFiles = @()
 
     if (Test-Path $ConfigPath) {
@@ -255,7 +255,7 @@ if ($RemoveConfig -or $RemoveAll) {
     if ($backupFiles.Count -gt 0) {
         Write-Warn "Removing $($backupFiles.Count) backup file(s)..."
         $backupFiles | Remove-Item -Force -ErrorAction SilentlyContinue
-        Write-Success "✓ Backup files removed"
+        Write-Success "Backup files removed"
     } else {
         Write-Info "No backup files found"
     }
@@ -266,18 +266,18 @@ Write-Host ""
 Write-Success "Removal process complete!"
 Write-Host ""
 Write-Info "Summary of actions taken:"
-Write-Host "  • Windows Service: Stopped and removed" -ForegroundColor Gray
-Write-Host "  • Agent binaries: Removed" -ForegroundColor Gray
-Write-Host "  • System PATH: Updated" -ForegroundColor Gray
+Write-Host "  - Windows Service: Stopped and removed" -ForegroundColor Gray
+Write-Host "  - Agent binaries: Removed" -ForegroundColor Gray
+Write-Host "  - System PATH: Updated" -ForegroundColor Gray
 if ($RemoveConfig) {
-    Write-Host "  • Configuration files: Removed" -ForegroundColor Gray
+    Write-Host "  - Configuration files: Removed" -ForegroundColor Gray
 } else {
-    Write-Host "  • Configuration files: Preserved" -ForegroundColor Gray
+    Write-Host "  - Configuration files: Preserved" -ForegroundColor Gray
 }
 if ($RemoveLogs) {
-    Write-Host "  • Log files: Removed" -ForegroundColor Gray
+    Write-Host "  - Log files: Removed" -ForegroundColor Gray
 } else {
-    Write-Host "  • Log files: Preserved" -ForegroundColor Gray
+    Write-Host "  - Log files: Preserved" -ForegroundColor Gray
 }
 
 if (-not $RemoveAll) {

--- a/server-source-code/internal/agents/scripts_test.go
+++ b/server-source-code/internal/agents/scripts_test.go
@@ -1,0 +1,43 @@
+package agents
+
+import (
+	"testing"
+)
+
+// TestWindowsScriptsAreASCII guards the fix for the removal script that would
+// not parse under Windows PowerShell 5.1.
+//
+// When PS 5.1 decodes these scripts through the Windows ANSI code page (which
+// Invoke-WebRequest does for a response whose Content-Type carries no charset),
+// CP1252 maps 0x91-0x94 to the curly quotes ' ' " ", and the PowerShell
+// tokenizer accepts those as string delimiters. The stop sign emoji is
+// F0 9F 9B 91, so its last byte became a quote that opened a string mid-line
+// and cascaded into "Unexpected token '}'" and "The string is missing the
+// terminator" errors several lines later.
+//
+// Serving these as charset=utf-8 and downloading with -OutFile both avoid the
+// bad decode, but keeping the scripts ASCII means an operator running a command
+// they pasted a year ago is safe too. Do not add emoji back.
+func TestWindowsScriptsAreASCII(t *testing.T) {
+	scripts := map[string][]byte{
+		"patchmon_install_windows.ps1": PatchmonWindowsInstallScript,
+		"patchmon_remove_windows.ps1":  PatchmonWindowsRemoveScript,
+	}
+	for name, body := range scripts {
+		t.Run(name, func(t *testing.T) {
+			if len(body) == 0 {
+				t.Fatal("script is empty, embed failed")
+			}
+			line := 1
+			for i, b := range body {
+				if b == '\n' {
+					line++
+				}
+				if b > 127 {
+					t.Fatalf("non-ASCII byte 0x%02X at offset %d (line %d); "+
+						"PowerShell 5.1 mis-decodes these, see the doc comment", b, i, line)
+				}
+			}
+		})
+	}
+}

--- a/server-source-code/internal/handler/auto_enrollment.go
+++ b/server-source-code/internal/handler/auto_enrollment.go
@@ -700,7 +700,7 @@ func (h *AutoEnrollmentHandler) ServeScript(w http.ResponseWriter, r *http.Reque
 	out.WriteString(envBlock)
 	out.WriteString(scriptStr)
 
-	w.Header().Set("Content-Type", "text/plain")
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.Header().Set("Content-Disposition", "inline; filename=\""+scriptType+"_auto_enroll.sh\"")
 	// Prevent caching of URLs containing token credentials in query parameters.
 	w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate")

--- a/server-source-code/internal/handler/install.go
+++ b/server-source-code/internal/handler/install.go
@@ -170,7 +170,7 @@ func (h *InstallHandler) ServeInstall(w http.ResponseWriter, r *http.Request) {
 			script = append([]byte("#"), script[1:]...)
 		}
 		script = append([]byte(envBlock), script...)
-		w.Header().Set("Content-Type", "text/plain")
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		w.Header().Set("Content-Disposition", `inline; filename="patchmon_install_windows.ps1"`)
 		_, _ = w.Write(script)
 		return
@@ -233,7 +233,7 @@ fetch_credentials
 	}
 	script = append([]byte(envBlock), script...)
 
-	w.Header().Set("Content-Type", "text/plain")
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.Header().Set("Content-Disposition", `inline; filename="patchmon_install.sh"`)
 	_, _ = w.Write(script)
 }
@@ -254,7 +254,7 @@ func (h *InstallHandler) ServeRemove(w http.ResponseWriter, r *http.Request) {
 			JSON(w, http.StatusNotFound, map[string]string{"error": "Windows removal script not found"})
 			return
 		}
-		w.Header().Set("Content-Type", "text/plain")
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		w.Header().Set("Content-Disposition", `inline; filename="patchmon_remove_windows.ps1"`)
 		_, _ = w.Write(script)
 		return
@@ -274,7 +274,7 @@ func (h *InstallHandler) ServeRemove(w http.ResponseWriter, r *http.Request) {
 		script = append([]byte("#"), script[1:]...)
 	}
 	script = append(envPrefix, script...)
-	w.Header().Set("Content-Type", "text/plain")
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.Header().Set("Content-Disposition", `inline; filename="patchmon_remove.sh"`)
 	_, _ = w.Write(script)
 }

--- a/server-source-code/internal/store/report.go
+++ b/server-source-code/internal/store/report.go
@@ -345,6 +345,12 @@ func (s *ReportStore) ProcessReport(ctx context.Context, hostID string, payload 
 		}
 	}
 
+	// Strip NUL and invalid UTF-8 before anything touches a query parameter.
+	// Postgres cannot store either, and one bad byte from one Windows host
+	// aborts that host's whole report. See sanitizeReportPayload for why this
+	// sits here and not at the decode boundary.
+	sanitizeReportPayload(payload)
+
 	// Deterministic ordering eliminates cross-transaction lock-order
 	// inversion that caused 40P01 deadlocks. See sortReportInputs.
 	sortReportInputs(payload)

--- a/server-source-code/internal/store/report_sanitize.go
+++ b/server-source-code/internal/store/report_sanitize.go
@@ -1,0 +1,145 @@
+package store
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"unicode/utf8"
+)
+
+// nulEscape is the JSON encoding of U+0000. Because all four hex digits are
+// zero there is no case variance to match on.
+const nulEscape = `\u0000`
+
+// sanitizeText strips NUL and repairs invalid UTF-8 in an agent-supplied
+// string.
+//
+// PostgreSQL cannot store U+0000 in either target type this package writes to:
+// `jsonb` rejects the \u0000 escape with 22P05 (unsupported Unicode escape
+// sequence) and `text` rejects the raw byte with 22021. Windows hosts do send
+// it — several installers pad registry values such as DisplayVersion with
+// trailing NULs, which survive ConvertTo-Json, the agent, and json.Marshal
+// here, and then abort the whole report transaction.
+//
+// Both checks are scans with no allocation on the overwhelmingly common clean
+// input, so this is safe to run over every string in every report.
+func sanitizeText(s string) string {
+	if s == "" {
+		return s
+	}
+	if strings.IndexByte(s, 0) >= 0 {
+		s = strings.ReplaceAll(s, "\x00", "")
+	}
+	if !utf8.ValidString(s) {
+		s = strings.ToValidUTF8(s, "�")
+	}
+	return s
+}
+
+func sanitizeTextPtr(p *string) {
+	if p != nil {
+		*p = sanitizeText(*p)
+	}
+}
+
+func sanitizeTextSlice(ss []string) {
+	for i := range ss {
+		ss[i] = sanitizeText(ss[i])
+	}
+}
+
+// sanitizeRawJSON cleans a pre-encoded JSON blob that is bound straight to a
+// jsonb parameter. A raw 0x00 byte would already have failed json.Valid, so
+// the only reachable form is the \u0000 escape. Re-encoding is confined to
+// blobs that actually contain one: everything else is returned untouched.
+func sanitizeRawJSON(raw json.RawMessage) json.RawMessage {
+	if !bytes.Contains(raw, []byte(nulEscape)) {
+		return raw
+	}
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	var v any
+	if err := dec.Decode(&v); err != nil {
+		return raw
+	}
+	cleaned, err := json.Marshal(scrubJSONValue(v))
+	if err != nil {
+		return raw
+	}
+	return cleaned
+}
+
+func scrubJSONValue(v any) any {
+	switch t := v.(type) {
+	case string:
+		return sanitizeText(t)
+	case map[string]any:
+		out := make(map[string]any, len(t))
+		for k, val := range t {
+			out[sanitizeText(k)] = scrubJSONValue(val)
+		}
+		return out
+	case []any:
+		for i := range t {
+			t[i] = scrubJSONValue(t[i])
+		}
+		return t
+	default:
+		return v
+	}
+}
+
+// sanitizeReportPayload cleans every agent-supplied string in the payload,
+// in place.
+//
+// This must run AFTER the handler's canonical-hash drift check and BEFORE
+// sortReportInputs. The agent hashes the values it collected, so the server
+// has to hash the same bytes or every report from an affected host would be
+// rejected as a hash mismatch instead of stored. Running before the sort and
+// dedup matters too: stripping NUL can make two package names collide, and
+// dedupe-by-name downstream is what keeps that from reaching ON CONFLICT.
+func sanitizeReportPayload(p *ReportPayload) {
+	for i := range p.Packages {
+		pkg := &p.Packages[i]
+		pkg.Name = sanitizeText(pkg.Name)
+		pkg.Description = sanitizeText(pkg.Description)
+		pkg.Category = sanitizeText(pkg.Category)
+		pkg.CurrentVersion = sanitizeText(pkg.CurrentVersion)
+		sanitizeTextPtr(pkg.AvailableVersion)
+		pkg.SourceRepository = sanitizeText(pkg.SourceRepository)
+		pkg.WUAGuid = sanitizeText(pkg.WUAGuid)
+		pkg.WUAKb = sanitizeText(pkg.WUAKb)
+		pkg.WUASeverity = sanitizeText(pkg.WUASeverity)
+		pkg.WUASupportURL = sanitizeText(pkg.WUASupportURL)
+		sanitizeTextSlice(pkg.WUACategories)
+	}
+
+	for i := range p.Repositories {
+		repo := &p.Repositories[i]
+		repo.Name = sanitizeText(repo.Name)
+		repo.URL = sanitizeText(repo.URL)
+		repo.Distribution = sanitizeText(repo.Distribution)
+		repo.Components = sanitizeText(repo.Components)
+		repo.RepoType = sanitizeText(repo.RepoType)
+	}
+
+	p.OSType = sanitizeText(p.OSType)
+	p.OSVersion = sanitizeText(p.OSVersion)
+	p.Hostname = sanitizeText(p.Hostname)
+	p.IP = sanitizeText(p.IP)
+	p.Architecture = sanitizeText(p.Architecture)
+	p.AgentVersion = sanitizeText(p.AgentVersion)
+	p.MachineID = sanitizeText(p.MachineID)
+	p.KernelVersion = sanitizeText(p.KernelVersion)
+	p.InstalledKernelVersion = sanitizeText(p.InstalledKernelVersion)
+	p.SELinuxStatus = sanitizeText(p.SELinuxStatus)
+	p.SystemUptime = sanitizeText(p.SystemUptime)
+	p.CPUModel = sanitizeText(p.CPUModel)
+	p.GatewayIP = sanitizeText(p.GatewayIP)
+	p.RebootReason = sanitizeText(p.RebootReason)
+	p.PackageManager = sanitizeText(p.PackageManager)
+	sanitizeTextSlice(p.DNSServers)
+
+	p.DiskDetails = sanitizeRawJSON(p.DiskDetails)
+	p.NetworkInterfaces = sanitizeRawJSON(p.NetworkInterfaces)
+}

--- a/server-source-code/internal/store/report_sanitize_test.go
+++ b/server-source-code/internal/store/report_sanitize_test.go
@@ -1,0 +1,175 @@
+package store
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestSanitizeText covers the two things Postgres refuses to store: U+0000 in
+// any column, and byte sequences that are not valid UTF-8.
+func TestSanitizeText(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"clean ascii", "Mesh Agent", "Mesh Agent"},
+		{"clean non-ascii preserved", "Mise à jour de la sélection", "Mise à jour de la sélection"},
+		{"trailing nuls", "2026-02-16 01:43:44.000+01:00\x00\x00", "2026-02-16 01:43:44.000+01:00"},
+		{"embedded nul", "Microsoft\x00 Visual C++", "Microsoft Visual C++"},
+		{"only nuls", "\x00\x00", ""},
+		{"invalid utf8 repaired", "caf\xe9", "caf\uFFFD"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sanitizeText(tc.in); got != tc.want {
+				t.Fatalf("sanitizeText(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSanitizeReportPayload_StripsNulsEverywhere is the regression guard for
+// the 22P05 report failure: a single NUL anywhere in an agent payload used to
+// abort the whole transaction.
+func TestSanitizeReportPayload_StripsNulsEverywhere(t *testing.T) {
+	avail := "1.2.3\x00"
+	payload := &ReportPayload{
+		Packages: []ReportPackage{{
+			Name:             "Mesh Agent\x00",
+			Description:      "3,3 MB\x00",
+			Category:         "Application",
+			CurrentVersion:   "2026-02-16 01:43:44.000+01:00\x00\x00",
+			AvailableVersion: &avail,
+			SourceRepository: "local\x00",
+			WUAGuid:          "guid\x00",
+			WUAKb:            "KB123\x00",
+			WUASeverity:      "Critical\x00",
+			WUASupportURL:    "https://example.test\x00",
+			WUACategories:    []string{"Security Updates\x00"},
+		}},
+		Repositories: []ReportRepository{{
+			Name:         "Microsoft Update\x00",
+			URL:          "https://update.microsoft.com\x00",
+			Distribution: "d\x00",
+			Components:   "c\x00",
+			RepoType:     "wu\x00",
+		}},
+		OSType:                 "Windows\x00",
+		OSVersion:              "25H2\x00",
+		Hostname:               "host\x00",
+		IP:                     "10.0.0.1\x00",
+		Architecture:           "amd64\x00",
+		AgentVersion:           "2.0.2\x00",
+		MachineID:              "mid\x00",
+		KernelVersion:          "kv\x00",
+		InstalledKernelVersion: "ikv\x00",
+		SELinuxStatus:          "n/a\x00",
+		SystemUptime:           "1d\x00",
+		CPUModel:               "Intel\x00",
+		GatewayIP:              "10.0.0.254\x00",
+		RebootReason:           "patching\x00",
+		PackageManager:         "windows\x00",
+		DNSServers:             []string{"1.1.1.1\x00"},
+	}
+
+	sanitizeReportPayload(payload)
+
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	// The jsonb bind is what actually rejects the escape, so assert on the
+	// encoded form rather than field by field.
+	if strings.Contains(string(raw), `\u0000`) {
+		t.Fatalf("payload still encodes a NUL escape: %s", raw)
+	}
+	if payload.Packages[0].Name != "Mesh Agent" {
+		t.Fatalf("package name = %q", payload.Packages[0].Name)
+	}
+	if *payload.Packages[0].AvailableVersion != "1.2.3" {
+		t.Fatalf("available version = %q", *payload.Packages[0].AvailableVersion)
+	}
+	if payload.Packages[0].WUACategories[0] != "Security Updates" {
+		t.Fatalf("wua category = %q", payload.Packages[0].WUACategories[0])
+	}
+	if payload.DNSServers[0] != "1.1.1.1" {
+		t.Fatalf("dns server = %q", payload.DNSServers[0])
+	}
+}
+
+// TestSanitizeReportPayload_RunsBeforeDedup documents the ordering contract:
+// names that differ only by a NUL collapse to one name, and the dedup in
+// ProcessReport (which runs after this) is what stops that reaching
+// ON CONFLICT as a 21000 cardinality violation.
+func TestSanitizeReportPayload_RunsBeforeDedup(t *testing.T) {
+	payload := &ReportPayload{
+		Packages: []ReportPackage{
+			{Name: "vim"},
+			{Name: "vim\x00"},
+		},
+	}
+	sanitizeReportPayload(payload)
+	if payload.Packages[0].Name != payload.Packages[1].Name {
+		t.Fatalf("expected collapsed names, got %q and %q",
+			payload.Packages[0].Name, payload.Packages[1].Name)
+	}
+}
+
+func TestSanitizeRawJSON(t *testing.T) {
+	t.Run("clean blob passes through untouched", func(t *testing.T) {
+		in := json.RawMessage(`{"b":1,"a":"x","n":123456789012345}`)
+		got := sanitizeRawJSON(in)
+		if string(got) != string(in) {
+			t.Fatalf("clean blob was rewritten: %s", got)
+		}
+	})
+
+	t.Run("nul escape removed", func(t *testing.T) {
+		in := json.RawMessage(`{"name":"disk\u0000","size":42}`)
+		got := sanitizeRawJSON(in)
+		if strings.Contains(string(got), `\u0000`) {
+			t.Fatalf("nul escape survived: %s", got)
+		}
+		var out map[string]any
+		if err := json.Unmarshal(got, &out); err != nil {
+			t.Fatalf("result is not valid JSON: %v", err)
+		}
+		if out["name"] != "disk" {
+			t.Fatalf("name = %v", out["name"])
+		}
+	})
+
+	t.Run("large integers keep their exact form", func(t *testing.T) {
+		in := json.RawMessage(`{"a":"x\u0000","size":9007199254740993}`)
+		got := sanitizeRawJSON(in)
+		if !strings.Contains(string(got), "9007199254740993") {
+			t.Fatalf("integer precision lost: %s", got)
+		}
+	})
+
+	t.Run("escaped backslash is not mistaken for an escape", func(t *testing.T) {
+		in := json.RawMessage(`{"path":"C:\\u0000dir","x":"y\u0000"}`)
+		got := sanitizeRawJSON(in)
+		var out map[string]any
+		if err := json.Unmarshal(got, &out); err != nil {
+			t.Fatalf("result is not valid JSON: %v", err)
+		}
+		if out["path"] != `C:\u0000dir` {
+			t.Fatalf("literal backslash sequence was corrupted: %v", out["path"])
+		}
+		if out["x"] != "y" {
+			t.Fatalf("x = %v", out["x"])
+		}
+	})
+
+	t.Run("malformed blob is returned unchanged", func(t *testing.T) {
+		in := json.RawMessage(`{"a":"x\u0000"`)
+		if got := sanitizeRawJSON(in); !reflect.DeepEqual(got, in) {
+			t.Fatalf("malformed blob was rewritten: %s", got)
+		}
+	})
+}


### PR DESCRIPTION
Fixes three Windows text-encoding bugs. #824 and #941 share a root cause (the agent ships raw PowerShell output straight into the report); #769 is a separate bug in how the server delivers its PowerShell scripts.

Fixes #824
Fixes #941
Fixes #769

Every mechanism claimed below was checked against the PowerShell parser, the PowerShell host, or Microsoft's reference docs. Where a claim could not be verified, it says so.

---

## #824: `unsupported Unicode escape sequence (SQLSTATE 22P05)`

A NUL byte in a package string reaches a PostgreSQL `jsonb` parameter, and `jsonb` cannot represent U+0000.

Several installers pad registry values such as `DisplayVersion` with trailing NULs (the Mesh Agent example in the thread). Those survive `ConvertTo-Json`, the agent, and `json.Marshal` on the server, then hit the bulk-upsert `::jsonb` bind. The transaction aborts, the host gets a 500, and it never reports again. #689, #793 and #857 are the same bug.

Verified: `ConvertTo-Json` does emit the NUL as a `\u0000` escape rather than dropping it.

```
PS> @{V="1.0" + [char]0} | ConvertTo-Json -Compress
{"V":"1.0\u0000"}
```

**Fix:** `sanitizeReportPayload` in `internal/store/report_sanitize.go` strips NUL and repairs invalid UTF-8 across every agent-supplied string, including the `diskDetails` and `networkInterfaces` raw JSON blobs. This is the server-side layer, so it repairs every host already in the field without waiting for an agent rollout.

Two ordering constraints, both load-bearing and both documented at the call site:

- It runs **after** the handler's canonical-hash drift check. The agent hashes what it collected, so the server has to hash the same bytes. Sanitising earlier just converts the 500 into a 400 `packages hash mismatch`.
- It runs **before** `sortReportInputs` and the dedup in `ProcessReport`. Stripping NUL can make two package names collide, and dedupe-by-name is what stops that reaching `ON CONFLICT` as a 21000 cardinality violation.

`sanitizeRawJSON` only re-encodes blobs that actually contain the escape, and decodes with `UseNumber()` so numeric literals survive the round trip unchanged. The clean path is two scans with no allocation.

## #941: non-English characters render as replacement characters

Windows PowerShell 5.1 encodes redirected stdout using `[Console]::OutputEncoding`, which defaults to the console's OEM code page (CP850 in much of western Europe, CP866 in Russia). Go reads those bytes as UTF-8, `encoding/json` substitutes U+FFFD for each invalid one, and the result is stored as valid UTF-8 replacement characters.

The screenshot in the issue fits exactly: in `Mise ? jour de la s?lection ... 2267602?Ko (version?1.455.499.0)`, the damaged characters are `a-grave`, `e-acute` and two non-breaking spaces, each one byte, each one replacement character, on a row categorised as Windows Update.

Verified that `[Console]::OutputEncoding` really does control PowerShell's own redirected stdout, and that it takes effect for output written later in the same `-Command`:

```
$ pwsh -Command 'Write-Output "AB"' | od -t x1              ->  41 42 0a
$ pwsh -Command '[Console]::OutputEncoding = [Text.Encoding]::Unicode
                 Write-Output "AB"'  | od -t x1              ->  41 00 42 00 0a 00
$ pwsh -Command '[Console]::OutputEncoding = [Text.Encoding]::GetEncoding(28591)
                 Write-Output ([char]0xE9)' | od -t x1       ->  e9 0a          <- the #941 failure
$ pwsh -Command 'try { [Console]::OutputEncoding = New-Object System.Text.UTF8Encoding $false } catch {}
                 Write-Output ([char]0xE9)' | od -t x1       ->  c3 a9 0a       <- this PR, no BOM
```

Four of the eleven PowerShell invocations set the encoding by hand. The registry collector, the Windows Update collector, the WSUS check, the repository collector and the reboot check did not.

**Fix:** every invocation now goes through `winexec.Script`, which prefixes the BOM-less assignment shown above. Centralising it is the point: this is the second time the per-script version was forgotten. The assignment is wrapped in `try/catch` because the .NET docs list `IOException` on that setter, and the agent runs as a service in Session 0; a host where it throws should degrade to today's behaviour rather than lose the collector entirely. `winexec.TrimBOM` guards the JSON-parsing collectors against a preamble.

Two related bugs found in the same code:

- `stripEllipsis` had a fallback for winget's mis-encoded truncation marker, but the constant spelled U+00D4 U+00C2 U+00C9 instead of the CP850 form U+00D4 U+00C7 U+00AA, so it never matched. This is why the two Application rows in the issue screenshot are truncated at exactly 39 characters with trailing mojibake. Both the CP850 and CP1252 forms are now handled.
- The Windows repository collector unmarshalled into a slice, but `ConvertTo-Json` emits a bare object when the pipeline carries exactly one item, which is every host without WSUS configured. That is the `Failed to parse Windows Update sources JSON` warning visible in #824's logs, firing every cycle on every non-WSUS host.

`textsan.Clean` also strips NUL at the agent's collection choke points, before the canonical hash is computed, so the bad bytes stop leaving the host at all and `patchmon-agent report --json` is honest.

Existing corrupted rows self-heal on the next successful report after the agent update. The U+FFFD already stored cannot be recovered.

**Caveat, stated plainly:** the tests above ran on PowerShell 7 on Linux, because 5.1 is not available here. They establish the mechanism, not the exact 5.1 behaviour. This is the part of the PR that most wants a check on a real Windows host.

## #769: Windows removal script fails to parse

The issue diagnosed this as "UTF-8 without BOM", and my first pass at it named ISO-8859-1 and U+0085 NEL. Both are wrong. Reproducing it against the actual PowerShell parser gives the real answer.

Decoding the old removal script through **CP1252**, the Windows ANSI code page, and parsing it with `[System.Management.Automation.Language.Parser]::ParseFile` reproduces the reported errors exactly, down to the line and column:

| Reported in #769 | Reproduced |
|---|---|
| `:81 char:9 Unexpected token "}" in expression or statement.` | `line 81 char 9: Unexpected token '}' in expression or statement.` |
| `:168 char:93 The string is missing the terminator: '.` | `line 168 char 93: The string is missing the terminator: '.` |
| `The Try statement is missing its Catch or Finally block.` | `line 290 char 1: The Try statement is missing its Catch or Finally block.` |

The trigger is that CP1252 maps `0x91`-`0x94` onto the curly quotes `' ' " "`, and the PowerShell tokenizer accepts those as string delimiters. `🛑` is `F0 9F 9B 91`, so its final byte became a `'` that opened a string in the middle of a `Write-Info` line; the parser then ran off the end of the block. The old script contains 3 such single quotes and 19 double quotes after the round trip.

The same round trip through **ISO-8859-1 produces zero parse errors**, which is what refuted the first explanation: in true Latin-1 those bytes are C1 controls and the parser does not care. The distinction matters, so it is recorded in a test comment rather than left to be re-derived.

**Fix**, three layers, because operators run whatever command they pasted months ago:

1. Script responses send `text/plain; charset=utf-8`.
2. The generated one-liners use `Invoke-WebRequest -OutFile`, which per the 5.1 docs saves the response body to the file and returns nothing to the pipeline unless `-PassThru` is given, so there is no string decode at any point. This also covers the install commands, which had the same latent defect.
3. Both `.ps1` files are ASCII only, with a test pinning them that way. The new script survives the CP1252 round trip byte for byte and parses clean.

Confirmed against the 5.1 reference docs while doing this: `-OutFile` is in the same parameter set as `-Headers` and `-UseBasicParsing`, so the new one-liners are valid; and `Out-File -Encoding utf8` on 5.1 writes a BOM, which is why serving the file with a BOM would not have helped.

The uninstall command displayed in Settings also had a space inside its URL, because JSX collapses a multi-line literal into whitespace-separated words. Display and clipboard now share one string.

---

## Multi-context impact

No impact. Every change is request-level or host-local:

- `sanitizeReportPayload` is a pure function over one request's payload. No process state, no shared caches, no goroutines, no filesystem.
- The `Content-Type` change is per-response.
- The agent changes run on the monitored host.

No new env vars, no schema change, no migration, no new route, no change to middleware placement.

## Testing

- `make check` clean in both Go modules (fmt, vet, golangci-lint, tests), plus `GOOS=windows go vet ./...` for the build-tagged agent files.
- `npx biome check src/` clean, 177 frontend tests pass, `npm run build` succeeds.
- New tests: NUL and invalid-UTF-8 handling across the report payload; `sanitizeRawJSON` clean-passthrough, integer-precision and escaped-backslash edge cases; `textsan`; the `winexec` preamble and BOM trim; `stripEllipsis` against all three forms of the truncation marker; and an ASCII pin on both served PowerShell scripts.
- Out-of-tree verification against PowerShell 7: the parser reproduction of #769 above, the `[Console]::OutputEncoding` behaviour above, and the `ConvertTo-Json` NUL encoding.

**Still unverified, and worth a check on a real Windows host before merge:**

- Whether Windows PowerShell 5.1 honours a response `charset` in `Invoke-WebRequest`. Layers 2 and 3 of the #769 fix do not depend on it, so it is belt and braces either way, but it is asserted and not proven.
- Whether 5.1's `ConvertTo-Json` escapes non-ASCII to `\uXXXX`. If it does, the registry collector was never affected by #941 and only the Windows Update collector was. Does not change the fix.
- The end-to-end #941 result on a French, Swedish or Russian host.

## Notes

- Docker container and compliance data reach `text` columns on the same kind of agent payload but are not covered here, since they were not part of these reports. A NUL there would fail with 22021 rather than 22P05. The sanitiser lives in `internal/store/` so those paths can reuse it.
- The Lua reverse-proxy workaround posted in #824 can be removed once the server is updated. It only rewrote one hard-coded literal.
