### PR TITLE
Encode email bodies as quoted-printable and fold long subjects

### DIFF
--- a/server-source-code/internal/mailer/linelength_test.go
+++ b/server-source-code/internal/mailer/linelength_test.go
@@ -1,0 +1,127 @@
+package mailer
+
+import (
+	"io"
+	"mime/quotedprintable"
+	"strings"
+	"testing"
+)
+
+// assertSMTPLineLengths is carried across from @veteranbv's #861, which was
+// closed only because it patched a file that no longer builds messages.
+func assertSMTPLineLengths(t *testing.T, msg string) {
+	t.Helper()
+	for i, line := range strings.Split(msg, "\r\n") {
+		if len(line) > 998 {
+			t.Fatalf("SMTP line %d is %d octets, want <= 998", i+1, len(line))
+		}
+	}
+}
+
+// #845: a generated host_down body put more than 998 octets on one line, and
+// the body was written raw with no Content-Transfer-Encoding, so a compliant
+// MTA rejected the whole message with "maximum allowed line length is 998
+// octets". Shorter host_recovered alerts for the same hosts got through, which
+// is what pointed at the body rather than the headers.
+func TestRenderMessageWrapsLongBodyLines(t *testing.T) {
+	t.Parallel()
+
+	// One unbroken line, as the alert templates produce.
+	body := "<html><body><p>" + strings.Repeat("host-that-went-down.example.internal ", 80) + "</p></body></html>"
+	if len(body) <= 998 {
+		t.Fatalf("fixture is only %d octets; it must exceed 998 to exercise the bug", len(body))
+	}
+
+	out := string(renderMessage(
+		Config{From: "alerts@example.com", FromName: "PatchMon"},
+		Message{To: "ops@example.com", Subject: "host down", HTMLBody: body},
+	))
+
+	if !strings.Contains(out, "Content-Transfer-Encoding: quoted-printable\r\n") {
+		t.Error("missing quoted-printable transfer encoding")
+	}
+	if !strings.Contains(out, "=\r\n") {
+		t.Error("expected quoted-printable soft line breaks")
+	}
+	assertSMTPLineLengths(t, out)
+}
+
+// The encoding is only useful if the receiver gets the original bytes back.
+func TestRenderMessageBodyRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	body := "<html><body><p>" + strings.Repeat("a", 2500) + "</p><p>café = 100% ✓</p></body></html>"
+
+	out := string(renderMessage(
+		Config{From: "alerts@example.com"},
+		Message{To: "ops@example.com", Subject: "s", HTMLBody: body},
+	))
+
+	_, encoded, found := strings.Cut(out, "\r\n\r\n")
+	if !found {
+		t.Fatal("no header/body separator")
+	}
+	decoded, err := io.ReadAll(quotedprintable.NewReader(strings.NewReader(encoded)))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if string(decoded) != body {
+		t.Errorf("body did not round-trip through quoted-printable")
+	}
+}
+
+// A long subject is the other way to breach the limit, and the reporter could
+// not tell from the rejection which one they had hit.
+func TestRenderMessageFoldsLongSubject(t *testing.T) {
+	t.Parallel()
+
+	subject := "[ERROR] " + strings.Repeat("very-long-hostname.example.internal ", 40)
+
+	out := string(renderMessage(
+		Config{From: "alerts@example.com"},
+		Message{To: "ops@example.com", Subject: subject, HTMLBody: "<p>short</p>"},
+	))
+
+	if !strings.Contains(out, "\r\n\t") {
+		t.Error("long subject was not folded onto continuation lines")
+	}
+	assertSMTPLineLengths(t, out)
+}
+
+// Folding must not become a header-injection route.
+func TestRenderMessageSubjectCannotInjectHeaders(t *testing.T) {
+	t.Parallel()
+
+	out := string(renderMessage(
+		Config{From: "alerts@example.com"},
+		Message{
+			To:       "ops@example.com",
+			Subject:  "alert\r\nBcc: attacker@example.com",
+			HTMLBody: "<p>short</p>",
+		},
+	))
+
+	if strings.Contains(out, "\r\nBcc:") {
+		t.Error("subject newline created an injected Bcc header")
+	}
+	assertSMTPLineLengths(t, out)
+}
+
+// A non-ASCII display name must be RFC 2047 encoded rather than emitted as raw
+// 8-bit, and an encoded-word must not sit inside quotes.
+func TestRenderMessageEncodesNonASCIIFromName(t *testing.T) {
+	t.Parallel()
+
+	out := string(renderMessage(
+		Config{From: "alerts@example.com", FromName: "PatchMon Alertes Systèmes"},
+		Message{To: "ops@example.com", Subject: "s", HTMLBody: "<p>short</p>"},
+	))
+
+	if !strings.Contains(out, "=?utf-8?q?") {
+		t.Error("non-ASCII display name was not RFC 2047 encoded")
+	}
+	if strings.Contains(out, `"=?utf-8?q?`) {
+		t.Error("encoded-word must not be wrapped in quotes")
+	}
+	assertSMTPLineLengths(t, out)
+}

--- a/server-source-code/internal/mailer/mailer.go
+++ b/server-source-code/internal/mailer/mailer.go
@@ -9,6 +9,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"mime"
+	"mime/quotedprintable"
 	"net/mail"
 	"strings"
 	"time"
@@ -247,15 +250,24 @@ func validate(cfg Config, msg Message) *SendError {
 	return nil
 }
 
+// headerLineLimit is the soft wrap point for header lines. RFC 5322 recommends
+// 78 octets; RFC 5321's hard limit is 998.
+const headerLineLimit = 78
+
 // renderMessage builds the full RFC 5322 byte stream including headers.
 // Subject is stripped of CR/LF to prevent SMTP header injection. From uses the
 // FromName when present (encoded as a name-addr pair).
 func renderMessage(cfg Config, msg Message) []byte {
-	subject := strings.NewReplacer("\r", "", "\n", "").Replace(msg.Subject)
+	subject := foldHeader("Subject", stripCRLF(msg.Subject))
 	from := cfg.From
 	if strings.TrimSpace(cfg.FromName) != "" {
-		cleanName := strings.NewReplacer("\r", "", "\n", "").Replace(cfg.FromName)
-		from = fmt.Sprintf("%q <%s>", cleanName, cfg.From)
+		cleanName := stripCRLF(cfg.FromName)
+		if encoded := mime.QEncoding.Encode("utf-8", cleanName); encoded != cleanName {
+			// An RFC 2047 encoded-word must not be quoted.
+			from = fmt.Sprintf("%s <%s>", encoded, cfg.From)
+		} else {
+			from = fmt.Sprintf("%q <%s>", cleanName, cfg.From)
+		}
 	}
 	var b strings.Builder
 	fmt.Fprintf(&b, "From: %s\r\n", from)
@@ -263,7 +275,62 @@ func renderMessage(cfg Config, msg Message) []byte {
 	fmt.Fprintf(&b, "Subject: %s\r\n", subject)
 	b.WriteString("MIME-Version: 1.0\r\n")
 	b.WriteString("Content-Type: text/html; charset=utf-8\r\n")
+	b.WriteString("Content-Transfer-Encoding: quoted-printable\r\n")
 	b.WriteString("\r\n")
-	b.WriteString(msg.HTMLBody)
+
+	// RFC 5321 caps a line at 998 octets excluding CRLF, and a generated alert
+	// body routinely puts more than that on one line. Without an encoding a
+	// standards-compliant MTA is right to reject the whole message, which is
+	// what #845 saw: host_down alerts bounced with "maximum allowed line length
+	// is 998 octets" while shorter host_recovered alerts got through.
+	// quoted-printable inserts soft breaks, so no line can exceed the limit.
+	qp := quotedprintable.NewWriter(&b)
+	if _, err := io.WriteString(qp, msg.HTMLBody); err != nil {
+		// strings.Builder never fails; fall back to the raw body rather than
+		// silently sending an empty one.
+		_ = qp.Close()
+		return []byte(b.String() + msg.HTMLBody)
+	}
+	if err := qp.Close(); err != nil {
+		return []byte(b.String() + msg.HTMLBody)
+	}
 	return []byte(b.String())
+}
+
+func stripCRLF(s string) string {
+	return strings.NewReplacer("\r", "", "\n", "").Replace(s)
+}
+
+// foldHeader keeps a header line inside the RFC 5321 limit by folding it onto
+// continuation lines, and RFC 2047 encodes it when it is not plain ASCII. A
+// long subject is a second way to breach 998 octets, and the reporter on #845
+// could not tell from the rejection whether it was a header or the body.
+func foldHeader(name, value string) string {
+	if encoded := mime.QEncoding.Encode("utf-8", value); encoded != value {
+		// QEncoding already splits into encoded-words short enough to fold.
+		return strings.ReplaceAll(encoded, " ", "\r\n\t")
+	}
+	// +2 for the ": " separator.
+	if len(name)+2+len(value) <= headerLineLimit {
+		return value
+	}
+
+	var out strings.Builder
+	lineLen := len(name) + 2
+	for i, word := range strings.Fields(value) {
+		switch {
+		case i == 0:
+			out.WriteString(word)
+			lineLen += len(word)
+		case lineLen+1+len(word) > headerLineLimit:
+			out.WriteString("\r\n\t")
+			out.WriteString(word)
+			lineLen = 1 + len(word)
+		default:
+			out.WriteString(" ")
+			out.WriteString(word)
+			lineLen += 1 + len(word)
+		}
+	}
+	return out.String()
 }


### PR DESCRIPTION
Picks up @veteranbv's #861, which I closed only because it patched `notification_worker.go` and that no longer builds messages. The bug was always real.

`renderMessage` wrote the HTML body verbatim with a `Content-Type` but no `Content-Transfer-Encoding`, so any line over 998 octets breached RFC 5321 and a compliant MTA was right to reject the whole message. A generated host_down body is one unbroken line well past that. The fixture in the test comes out at 2993 octets on a single line.

That also explains the detail @ValorousSalmon gave on #845, which was the useful clue: none of their host_down alerts arrived, while every host_recovered alert for the same hosts did. Same transport, same headers, different template length.

The body now goes through `mime/quotedprintable`, which inserts soft breaks, and there is a test asserting it decodes back to the original bytes including non-ASCII. Long subjects were the other way to hit the same rejection, and the reporter noted they could not tell which they had hit, so those are folded onto continuation lines and RFC 2047 encoded when not plain ASCII. A non-ASCII display name gets the same treatment; it was previously emitted as raw 8-bit inside quotes, where an encoded-word is not allowed.

`assertSMTPLineLengths` is @veteranbv's helper, carried across as promised. Verified the tests fail without the change.

Fixes #845