### PR TITLE
Correct the agent command table, --version is a flag

### DIFF
--- a/docs/patchmon-operator-guide.md
+++ b/docs/patchmon-operator-guide.md
@@ -3121,7 +3121,7 @@ patchmon-agent [command] [flags]
 | `config set-api` | Configure API credentials and server URL | Yes |
 | `check-version` | Check if an agent update is available | Yes |
 | `update-agent` | Download and install the latest agent version | Yes |
-| `version` | Print the agent version | No |
+| `--version` | Print the agent version. A flag, not a subcommand | No |
 
 #### Global Flags
 


### PR DESCRIPTION
The agent command reference in the operator guide listed `version` as a subcommand. There is no such subcommand, cobra supplies `--version` from the root command, so `patchmon-agent version` returns `Error: unknown command "version"`.

That table is the first place someone looks before typing the command, which is how @bartlomiejkida hit it in #876. The detailed section further down and the global flags table were both already correct, so this is the last place the old form survived.

The install scripts were fixed separately in `7995b11` and already use `--version`.

Fixes #876