### PR TITLE
fix(install): serve the correct OS installer for FreeBSD hosts

### DIFF
--- a/server-source-code/internal/handler/install.go
+++ b/server-source-code/internal/handler/install.go
@@ -89,6 +89,32 @@ func normalizeLineEndings(b []byte) []byte {
 	return []byte(s)
 }
 
+// inferHostOS resolves the OS to serve for a host when the request does not
+// specify one, using what the host has already reported about itself.
+func inferHostOS(expectedPlatform *string, osType string) string {
+	if expectedPlatform != nil {
+		ep := strings.ToLower(*expectedPlatform)
+		if ep == "windows" {
+			return "windows"
+		}
+		if strings.Contains(ep, "freebsd") || strings.Contains(ep, "pfsense") {
+			return "freebsd"
+		}
+		return "linux"
+	}
+	if osType != "" {
+		reported := strings.ToLower(osType)
+		if strings.Contains(reported, "windows") {
+			return "windows"
+		}
+		if strings.Contains(reported, "freebsd") || strings.Contains(reported, "pfsense") {
+			return "freebsd"
+		}
+		return "linux"
+	}
+	return "linux"
+}
+
 // ServeInstall handles GET /api/v1/hosts/install.
 // Requires X-API-ID and X-API-KEY headers. Serves the install script with env vars and bootstrap token injected.
 func (h *InstallHandler) ServeInstall(w http.ResponseWriter, r *http.Request) {
@@ -145,7 +171,7 @@ func (h *InstallHandler) ServeInstall(w http.ResponseWriter, r *http.Request) {
 	}
 	osParam := r.URL.Query().Get("os")
 	if osParam != "linux" && osParam != "freebsd" && osParam != "windows" {
-		osParam = "linux"
+		osParam = inferHostOS(host.ExpectedPlatform, host.OSType)
 	}
 
 	// Windows: serve PowerShell script with env vars
@@ -915,28 +941,8 @@ func (h *InstallHandler) ServeAgentVersion(w http.ResponseWriter, r *http.Reques
 	}
 
 	osParam := r.URL.Query().Get("os")
-	if osParam == "" && host.ExpectedPlatform != nil {
-		ep := strings.ToLower(*host.ExpectedPlatform)
-		if ep == "windows" {
-			osParam = "windows"
-		} else if strings.Contains(ep, "freebsd") || strings.Contains(ep, "pfsense") {
-			osParam = "freebsd"
-		} else {
-			osParam = "linux"
-		}
-	}
-	if osParam == "" && host.OSType != "" {
-		reported := strings.ToLower(host.OSType)
-		if strings.Contains(reported, "windows") {
-			osParam = "windows"
-		} else if strings.Contains(reported, "freebsd") || strings.Contains(reported, "pfsense") {
-			osParam = "freebsd"
-		} else {
-			osParam = "linux"
-		}
-	}
 	if osParam == "" {
-		osParam = "linux"
+		osParam = inferHostOS(host.ExpectedPlatform, host.OSType)
 	}
 
 	validOss := map[string]bool{"linux": true, "freebsd": true, "windows": true}
@@ -1079,28 +1085,8 @@ func (h *InstallHandler) ServeAgentDownload(w http.ResponseWriter, r *http.Reque
 	}
 
 	osParam := r.URL.Query().Get("os")
-	if osParam == "" && host.ExpectedPlatform != nil {
-		ep := strings.ToLower(*host.ExpectedPlatform)
-		if ep == "windows" {
-			osParam = "windows"
-		} else if strings.Contains(ep, "freebsd") || strings.Contains(ep, "pfsense") {
-			osParam = "freebsd"
-		} else {
-			osParam = "linux"
-		}
-	}
-	if osParam == "" && host.OSType != "" {
-		reported := strings.ToLower(host.OSType)
-		if strings.Contains(reported, "windows") {
-			osParam = "windows"
-		} else if strings.Contains(reported, "freebsd") || strings.Contains(reported, "pfsense") {
-			osParam = "freebsd"
-		} else {
-			osParam = "linux"
-		}
-	}
 	if osParam == "" {
-		osParam = "linux"
+		osParam = inferHostOS(host.ExpectedPlatform, host.OSType)
 	}
 
 	validOss := map[string]bool{"linux": true, "freebsd": true, "windows": true}

--- a/server-source-code/internal/handler/install_inferos_test.go
+++ b/server-source-code/internal/handler/install_inferos_test.go
@@ -1,0 +1,39 @@
+package handler
+
+import "testing"
+
+func TestInferHostOS(t *testing.T) {
+	tests := []struct {
+		name             string
+		expectedPlatform *string
+		osType           string
+		want             string
+	}{
+		{name: "expected platform windows", expectedPlatform: strPtr("windows"), want: "windows"},
+		{name: "expected platform freebsd", expectedPlatform: strPtr("FreeBSD"), want: "freebsd"},
+		{name: "expected platform pfsense", expectedPlatform: strPtr("pfSense"), want: "freebsd"},
+		{name: "expected platform linux", expectedPlatform: strPtr("linux"), want: "linux"},
+		{name: "expected platform empty falls back to linux", expectedPlatform: strPtr(""), want: "linux"},
+		{name: "expected platform wins over os type", expectedPlatform: strPtr("linux"), osType: "FreeBSD 14.4-RELEASE", want: "linux"},
+
+		// The regression case: a FreeBSD host that reported its OS but has no
+		// expected platform must not be treated as Linux, or it is served a
+		// Linux agent binary it cannot execute.
+		{name: "os type freebsd", osType: "FreeBSD 14.4-RELEASE", want: "freebsd"},
+		{name: "os type pfsense", osType: "pfSense 2.7", want: "freebsd"},
+		{name: "os type windows", osType: "Windows Server 2022", want: "windows"},
+		{name: "os type debian", osType: "Debian GNU/Linux", want: "linux"},
+		{name: "os type rocky", osType: "Rocky Linux", want: "linux"},
+
+		{name: "nothing known defaults to linux", want: "linux"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := inferHostOS(tt.expectedPlatform, tt.osType)
+			if got != tt.want {
+				t.Errorf("inferHostOS(%v, %q) = %q, want %q", tt.expectedPlatform, tt.osType, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Enrolling a FreeBSD host through the documented one-liner installs a Linux agent binary, which then dies with `Exec format error`. The host enrols successfully and then never reports, so FreeBSD enrolment is unusable in practice.

## Cause

1. `direct_host_auto_enroll.sh` requests `/api/v1/hosts/install?arch=...` and never sends an `os` parameter.
2. `ServeInstall` read `os` from the query string and defaulted anything unrecognised to `linux`.
3. It then wrote `export PATCHMON_OS="linux"` into the generated script body. Since that is an assignment inside the script, it overrides the caller environment, so setting `PATCHMON_OS=freebsd` externally has no effect.
4. `patchmon_install.sh` then downloaded the agent with `os=linux`.

The server serves a correct FreeBSD binary when it is actually asked for one, so only the plumbing was wrong. The installer detects FreeBSD correctly for dependency handling via `uname -s`, which is why the output reads `Detected FreeBSD (pkg)` and masks the real problem.

## Fix

`ServeAgentVersion` and `ServeAgentDownload` already inferred the OS from the host record, with the same logic duplicated inline in both. This extracts it into `inferHostOS` and calls it from `ServeInstall` when the `os` parameter is absent or unrecognised, so a host that has already told us it runs FreeBSD is no longer handed a Linux installer.

Behaviour at the two existing call sites is unchanged. The helper preserves the original semantics exactly, including the case where `expected_platform` is set but empty.

## Verification

On a FreeBSD 14.4 VM, before the change:

```
INFO: Detected FreeBSD (pkg)
INFO: Platform: linux
...
/tmp/inst.sh: /usr/local/bin/patchmon-agent: Exec format error
ERROR: Failed to validate API credentials or reach server
```

The downloaded binary was `ELF 64-bit LSB executable, x86-64, version 1 (SYSV)`, while requesting `?os=freebsd` directly returns `ELF 64-bit LSB executable, x86-64, version 1 (FreeBSD)`.

`make check` passes. Adds a table-driven test covering the regression and each inference path.