### PR TITLE
fix(agent): collect Arch package inventory without pacman-contrib

### DIFF
--- a/agent-source-code/internal/packages/pacman.go
+++ b/agent-source-code/internal/packages/pacman.go
@@ -178,8 +178,8 @@ func (m *PacmanManager) getForeignPackages() map[string]installedPkg {
 // getUpgradablePackages runs checkupdates and returns parsed packages.
 func (m *PacmanManager) getUpgradablePackages() ([]models.Package, error) {
 	if _, err := lookPath("checkupdates"); err != nil {
-		m.logger.WithError(err).Error("checkupdates not found (pacman-contrib not installed)")
-		return nil, err
+		m.logger.WithError(err).Warn("checkupdates not found (pacman-contrib not installed), falling back to pacman -Qu")
+		return m.getUpgradableFromLocalDB()
 	}
 
 	upgradeCmd := runCommand("checkupdates")
@@ -198,6 +198,28 @@ func (m *PacmanManager) getUpgradablePackages() ([]models.Package, error) {
 
 	pkgs := m.parseCheckUpdate(string(upgradeOutput))
 	return pkgs, nil
+}
+
+// getUpgradableFromLocalDB lists upgradable packages from the local sync
+// database, for hosts without checkupdates available.
+//
+// Output is the same "name oldver -> newver" form checkupdates produces, so it
+// reuses the same parser. Results are only as fresh as the last database
+// refresh, whereas checkupdates syncs into a temporary database of its own.
+func (m *PacmanManager) getUpgradableFromLocalDB() ([]models.Package, error) {
+	cmd := runCommand("pacman", "-Qu")
+	output, err := cmd.Output()
+	if err != nil {
+		// Exits 1 when nothing is upgradable.
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return []models.Package{}, nil
+		}
+		m.logger.WithError(err).Error("pacman -Qu failed")
+		return nil, err
+	}
+
+	return m.parseCheckUpdate(string(output)), nil
 }
 
 // parseCheckUpdate parses checkupdates output

--- a/agent-source-code/internal/packages/pacman_fallback_test.go
+++ b/agent-source-code/internal/packages/pacman_fallback_test.go
@@ -1,0 +1,94 @@
+package packages
+
+import (
+	"fmt"
+	"io"
+	"os/exec"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+// stubCommandLookup makes checkupdates appear absent and records what the
+// fallback tries to run.
+func stubCommandLookup(t *testing.T, stdout string, exitCode int) *struct {
+	name string
+	args []string
+} {
+	t.Helper()
+
+	origLook, origRun := lookPath, runCommand
+	t.Cleanup(func() { lookPath, runCommand = origLook, origRun })
+
+	called := &struct {
+		name string
+		args []string
+	}{}
+
+	lookPath = func(file string) (string, error) {
+		if file == "checkupdates" {
+			return "", exec.ErrNotFound
+		}
+		return "/usr/bin/" + file, nil
+	}
+
+	runCommand = func(name string, args ...string) *exec.Cmd {
+		called.name = name
+		called.args = args
+		if exitCode != 0 {
+			return exec.Command("sh", "-c", fmt.Sprintf("exit %d", exitCode))
+		}
+		return exec.Command("printf", "%s", stdout)
+	}
+
+	return called
+}
+
+func newTestPacmanManager() *PacmanManager {
+	log := logrus.New()
+	log.SetOutput(io.Discard)
+	return &PacmanManager{logger: log}
+}
+
+// Without pacman-contrib installed, checkupdates is absent. That used to return
+// an error, which aborted the entire report and left the host with no OS,
+// architecture or agent version recorded, not merely no packages.
+func TestGetUpgradablePackages_FallsBackWhenCheckupdatesMissing(t *testing.T) {
+	called := stubCommandLookup(t, "device-mapper 2.03.41-1 -> 2.03.42-1\nlinux 6.9.1-1 -> 6.9.2-1\n", 0)
+
+	m := newTestPacmanManager()
+	pkgs, err := m.getUpgradablePackages()
+	if err != nil {
+		t.Fatalf("expected fallback to succeed, got error: %v", err)
+	}
+
+	if called.name != "pacman" || len(called.args) != 1 || called.args[0] != "-Qu" {
+		t.Errorf("expected fallback to run `pacman -Qu`, got %q %v", called.name, called.args)
+	}
+
+	if len(pkgs) != 2 {
+		t.Fatalf("expected 2 upgradable packages, got %d: %+v", len(pkgs), pkgs)
+	}
+	if pkgs[0].Name != "device-mapper" {
+		t.Errorf("first package name = %q, want %q", pkgs[0].Name, "device-mapper")
+	}
+	if pkgs[0].CurrentVersion != "2.03.41-1" || pkgs[0].AvailableVersion != "2.03.42-1" {
+		t.Errorf("first package versions = %q -> %q, want %q -> %q",
+			pkgs[0].CurrentVersion, pkgs[0].AvailableVersion, "2.03.41-1", "2.03.42-1")
+	}
+}
+
+// pacman -Qu exits 1 when nothing is upgradable. That is a normal empty
+// result, not a failure.
+func TestGetUpgradablePackages_FallbackTreatsExit1AsEmpty(t *testing.T) {
+	stubCommandLookup(t, "", 1)
+
+	m := newTestPacmanManager()
+	pkgs, err := m.getUpgradablePackages()
+	if err != nil {
+		t.Fatalf("exit 1 should mean no updates, got error: %v", err)
+	}
+	if len(pkgs) != 0 {
+		t.Errorf("expected no packages, got %d: %+v", len(pkgs), pkgs)
+	}
+}

--- a/server-source-code/internal/agents/patchmon_install.sh
+++ b/server-source-code/internal/agents/patchmon_install.sh
@@ -465,6 +465,17 @@ elif command -v pacman >/dev/null 2>&1; then
     echo ""
     info "Installing curl..."
     install_pacman_packages curl
+    # checkupdates (pacman-contrib, plus fakeroot at runtime) gives fresher
+    # update data than the agent's pacman -Qu fallback. Matched on command name
+    # rather than package name, so install_pacman_packages is not used here.
+    # Best-effort: a stale keyring or unreachable mirror must not fail the
+    # install, because the agent works without these.
+    if ! command_exists checkupdates || ! command_exists fakeroot; then
+        info "Installing pacman-contrib and fakeroot (optional, improves update detection)..."
+        if ! pacman -S --noconfirm --needed pacman-contrib fakeroot; then
+            warning "Could not install pacman-contrib/fakeroot; the agent will fall back to pacman -Qu"
+        fi
+    fi
 elif command -v apk >/dev/null 2>&1; then
     # Alpine Linux
     info "Detected apk (Alpine Linux)"


### PR DESCRIPTION
On a stock Arch Linux host the agent never reports a package inventory, and the damage is wider than it first appears.

## Cause

`checkupdates` ships in `pacman-contrib`, which is not installed by default on Arch. `getUpgradablePackages` returned an error when it was missing, and the caller propagates that error, so the **entire** report was abandoned rather than just the package section.

The visible result is a host with no OS version, no architecture, no package manager and no agent version recorded. That reads as several unrelated detection faults but is one missing dependency. From the agent log:

```
error   checkupdates not found (pacman-contrib not installed)
warning initial report failed  error="failed to get packages: exec: \"checkupdates\": executable file not found in $PATH"
```

## Fix

Fall back to `pacman -Qu`, which needs no extra packages and emits the same `name oldver -> newver` format, so the existing parser is reused unchanged. It exits 1 when nothing is upgradable, which is treated as an empty result rather than a failure.

`checkupdates` is still preferred where available, because it syncs a temporary database and so reports fresher data than the local sync database. The installer therefore makes a best-effort attempt to add `pacman-contrib` and `fakeroot`.

That attempt is deliberately non-fatal, and this matters. An earlier version of this fix installed those packages unconditionally, and on a real Arch VM it failed:

```
error: pacman-contrib: signature from "Daniel M. Capella <polyzen@archlinux.org>" is unknown trust
error: failed to commit transaction (invalid or corrupted package (PGP signature))
```

The image had a stale `archlinux-keyring`. Because `pacman -S` was a bare command under `set -e`, that aborted the whole install, which would have broken Arch installs that currently succeed. It is now guarded so a stale keyring or unreachable mirror cannot fail an install.

## Verification

Same host, `checkupdates` absent, comparing the current agent against this branch:

```
STOCK: Error: failed to get packages: exec: "checkupdates": executable file not found in $PATH
FIXED: exit 0
```

Server side after the fixed agent reports, where all of these were previously unknown or empty:

```
os_type: Arch Linux
architecture: x86_64
package_manager: pacman
```

`make check` passes in both `agent-source-code` and `server-source-code`, and `sh -n` passes on the installer. Adds tests for the fallback path and for the exit-1-means-empty case.