### PR TITLE
fix(enrol): send the host OS when requesting the install script

### DIFF
--- a/server-source-code/internal/agents/direct_host_auto_enroll.sh
+++ b/server-source-code/internal/agents/direct_host_auto_enroll.sh
@@ -124,7 +124,7 @@ ip_address=$(hostname -I 2>/dev/null | awk '{print $1}' || echo "unknown")
 # Detect architecture
 arch_raw=$(uname -m 2>/dev/null || echo "unknown")
 case "$arch_raw" in
-    "x86_64")
+    "x86_64"|"amd64")
         architecture="amd64"
         ;;
     "i386"|"i686")
@@ -139,6 +139,19 @@ case "$arch_raw" in
     *)
         warn "  ⚠ Unknown architecture '$arch_raw', defaulting to amd64"
         architecture="amd64"
+        ;;
+esac
+
+# Detect OS. The server cannot work this out for itself at this point: the host
+# record is created with os_type "unknown" and no expected_platform, so it has
+# no signal until the agent's first report, which cannot happen until the
+# correct binary is installed.
+case "$(uname -s 2>/dev/null)" in
+    "FreeBSD")
+        os_type="freebsd"
+        ;;
+    *)
+        os_type="linux"
         ;;
 esac
 
@@ -243,13 +256,13 @@ if [ "$http_code" = "201" ]; then
     # ===== INSTALL AGENT =====
     info "Installing PatchMon agent..."
 
-    # Build install URL with force flag and architecture
-    install_url="$PATCHMON_URL/api/v1/hosts/install?arch=$architecture"
+    # Build install URL with force flag, architecture and OS
+    install_url="$PATCHMON_URL/api/v1/hosts/install?arch=$architecture&os=$os_type"
     if [ "$FORCE_INSTALL" = "true" ]; then
         install_url="$install_url&force=true"
         info "Using force mode - will bypass broken packages"
     fi
-    info "Using architecture: $architecture"
+    info "Using architecture: $architecture ($os_type)"
     
     # Download and execute installation script
     install_exit_code=0

--- a/server-source-code/internal/handler/install_inferos_test.go
+++ b/server-source-code/internal/handler/install_inferos_test.go
@@ -26,6 +26,13 @@ func TestInferHostOS(t *testing.T) {
 		{name: "os type rocky", osType: "Rocky Linux", want: "linux"},
 
 		{name: "nothing known defaults to linux", want: "linux"},
+
+		// A freshly auto-enrolled host carries the literal string "unknown"
+		// with no expected platform, so there is nothing to infer from and this
+		// correctly yields linux. That is exactly why the enrolment script has
+		// to send os= itself: inference cannot help on the one path where the
+		// host has not reported anything yet.
+		{name: "os type unknown yields no signal", osType: "unknown", want: "linux"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Follow-up to #984. That PR extracted `inferHostOS` and wired it into `ServeInstall`, which is correct and worth having, but it does not fix FreeBSD enrolment on its own. This completes it.

## Why #984 was not sufficient

Server-side inference has nothing to infer from at the moment it is needed. A host created by auto-enrolment is written as:

```go
OSType:    "unknown",
OSVersion: "unknown",
```

and `expected_platform` is never set by the auto-enrolment handler (only by the manual create API). Those values persist until the agent sends its first report, which cannot happen until a runnable binary is installed. So at the instant `direct_host_auto_enroll.sh` calls `/api/v1/hosts/install`, `inferHostOS(nil, "unknown")` matches neither windows nor freebsd and correctly returns `linux`. The FreeBSD host still received a Linux binary.

The enrolment script also already knows the answer and discards it: it posts `metadata.os_info` derived from `/etc/os-release`, and the enrol handler declares `Metadata json.RawMessage` without ever reading it.

## Fix

Derive the OS from `uname -s` in the enrolment script and pass it as `os=` on the install URL. The server already honours an explicit `os` parameter, so this is the piece that actually makes FreeBSD work.

Also accept `amd64` as an architecture value. `uname -m` reports `amd64` on FreeBSD, which fell through to the unknown-architecture branch and printed a warning before defaulting to the value it had just been given.

`inferHostOS` remains worth keeping: it fixes the re-install case, where a host has already reported `os_type = FreeBSD 14.x` and a caller omits `os=`.

## Verification

Enrolling a real FreeBSD 14.4 VM through the script, against an unmodified server:

```
INFO: Using architecture: amd64 (freebsd)
SUCCESS: Agent installed successfully
SUCCESS: Auto-enrollment complete!
```

The binary on disk is now `ELF 64-bit LSB executable, x86-64, version 1 (FreeBSD)` rather than SYSV, and the spurious architecture warning is gone. The host reports fully:

```
status: active, os_type: FreeBSD, os_version: 14.4-RELEASE,
architecture: amd64, package_manager: pkg, agent_version: 2.0.3-rc.183
```

with 12 packages inventoried. Before this change the same flow ended at `Exec format error`.

Adds a test case pinning that `os_type = "unknown"` yields no signal, which is the condition that made inference alone insufficient.