### PR TITLE
fix(agent): do not report a broken pacman database as no updates

### DIFF
--- a/agent-source-code/internal/packages/pacman.go
+++ b/agent-source-code/internal/packages/pacman.go
@@ -2,6 +2,7 @@ package packages
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
 	"os/exec"
 	"regexp"
@@ -210,13 +211,16 @@ func (m *PacmanManager) getUpgradableFromLocalDB() ([]models.Package, error) {
 	cmd := runCommand("pacman", "-Qu")
 	output, err := cmd.Output()
 	if err != nil {
-		// Exits 1 when nothing is upgradable.
+		// -Qu exits 1 both when nothing is upgradable and on a genuine failure,
+		// so the exit code alone cannot tell them apart. Only a real failure
+		// writes to stderr. Without that check a broken package database is
+		// reported as "no updates available", which is worse than an error
+		// because it looks like a healthy host.
 		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		if isExitCode(err, 1) && errors.As(err, &exitErr) && len(bytes.TrimSpace(exitErr.Stderr)) == 0 {
 			return []models.Package{}, nil
 		}
-		m.logger.WithError(err).Error("pacman -Qu failed")
-		return nil, err
+		return nil, commandError("pacman -Qu", err)
 	}
 
 	return m.parseCheckUpdate(string(output)), nil

--- a/agent-source-code/internal/packages/pacman_fallback_test.go
+++ b/agent-source-code/internal/packages/pacman_fallback_test.go
@@ -1,29 +1,33 @@
 package packages
 
 import (
-	"fmt"
 	"io"
 	"os/exec"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/sirupsen/logrus"
 )
 
-// stubCommandLookup makes checkupdates appear absent and records what the
-// fallback tries to run.
-func stubCommandLookup(t *testing.T, stdout string, exitCode int) *struct {
+// recordedCmd captures what the fallback actually tried to run.
+type recordedCmd struct {
 	name string
 	args []string
-} {
+}
+
+// stubCommandLookup makes checkupdates appear absent and stubs the command
+// runner with fixed output.
+//
+// It swaps package-level vars, so callers must NOT call t.Parallel(): the
+// restore is scoped to the test and a parallel test would observe the swap.
+func stubCommandLookup(t *testing.T, stdout, stderr string, exitCode int) *recordedCmd {
 	t.Helper()
 
 	origLook, origRun := lookPath, runCommand
 	t.Cleanup(func() { lookPath, runCommand = origLook, origRun })
 
-	called := &struct {
-		name string
-		args []string
-	}{}
+	called := &recordedCmd{}
 
 	lookPath = func(file string) (string, error) {
 		if file == "checkupdates" {
@@ -35,10 +39,10 @@ func stubCommandLookup(t *testing.T, stdout string, exitCode int) *struct {
 	runCommand = func(name string, args ...string) *exec.Cmd {
 		called.name = name
 		called.args = args
-		if exitCode != 0 {
-			return exec.Command("sh", "-c", fmt.Sprintf("exit %d", exitCode))
-		}
-		return exec.Command("printf", "%s", stdout)
+		// stdout and stderr are passed as positional arguments so no quoting
+		// of the payload leaks into the shell command itself.
+		script := `printf '%s' "$1"; printf '%s' "$2" >&2; exit ` + strconv.Itoa(exitCode)
+		return exec.Command("sh", "-c", script, "sh", stdout, stderr)
 	}
 
 	return called
@@ -54,7 +58,7 @@ func newTestPacmanManager() *PacmanManager {
 // an error, which aborted the entire report and left the host with no OS,
 // architecture or agent version recorded, not merely no packages.
 func TestGetUpgradablePackages_FallsBackWhenCheckupdatesMissing(t *testing.T) {
-	called := stubCommandLookup(t, "device-mapper 2.03.41-1 -> 2.03.42-1\nlinux 6.9.1-1 -> 6.9.2-1\n", 0)
+	called := stubCommandLookup(t, "device-mapper 2.03.41-1 -> 2.03.42-1\nlinux 6.9.1-1 -> 6.9.2-1\n", "", 0)
 
 	m := newTestPacmanManager()
 	pkgs, err := m.getUpgradablePackages()
@@ -78,17 +82,56 @@ func TestGetUpgradablePackages_FallsBackWhenCheckupdatesMissing(t *testing.T) {
 	}
 }
 
-// pacman -Qu exits 1 when nothing is upgradable. That is a normal empty
-// result, not a failure.
-func TestGetUpgradablePackages_FallbackTreatsExit1AsEmpty(t *testing.T) {
-	stubCommandLookup(t, "", 1)
+// pacman -Qu exits 1 with no stderr when nothing is upgradable. That is a
+// normal empty result, not a failure.
+func TestGetUpgradablePackages_FallbackTreatsSilentExit1AsEmpty(t *testing.T) {
+	stubCommandLookup(t, "", "", 1)
 
 	m := newTestPacmanManager()
 	pkgs, err := m.getUpgradablePackages()
 	if err != nil {
-		t.Fatalf("exit 1 should mean no updates, got error: %v", err)
+		t.Fatalf("silent exit 1 should mean no updates, got error: %v", err)
 	}
 	if len(pkgs) != 0 {
 		t.Errorf("expected no packages, got %d: %+v", len(pkgs), pkgs)
+	}
+}
+
+// pacman -Qu also exits 1 on a genuine failure, and the only thing separating
+// the two is stderr. Reporting a broken package database as "no updates" would
+// make an unhealthy host look green, which is worse than surfacing the error.
+func TestGetUpgradablePackages_FallbackExit1WithStderrIsAnError(t *testing.T) {
+	stubCommandLookup(t, "", "error: could not open file /var/lib/pacman/sync/core.db\n", 1)
+
+	m := newTestPacmanManager()
+	_, err := m.getUpgradablePackages()
+	if err == nil {
+		t.Fatal("expected an error when pacman -Qu writes to stderr, got nil")
+	}
+	if !strings.Contains(err.Error(), "core.db") {
+		t.Errorf("expected stderr to be surfaced in the error, got: %v", err)
+	}
+}
+
+// pacman -Qu appends " [ignored]" for IgnorePkg entries, whereas checkupdates
+// filters them out itself. The shared parser happens to drop them because its
+// pattern is anchored and the trailing marker contains a space.
+//
+// That agreement is load-bearing but not obvious: relaxing checkUpdateRe to
+// tolerate trailing content would silently start reporting ignored packages as
+// pending updates, which is exactly the false positive this must never emit.
+func TestGetUpgradablePackages_FallbackExcludesIgnoredPackages(t *testing.T) {
+	stubCommandLookup(t, "device-mapper 2.03.41-1 -> 2.03.42-1\nlinux 6.9.1-1 -> 6.9.2-1 [ignored]\n", "", 0)
+
+	m := newTestPacmanManager()
+	pkgs, err := m.getUpgradablePackages()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(pkgs) != 1 {
+		t.Fatalf("expected ignored package to be excluded, got %d: %+v", len(pkgs), pkgs)
+	}
+	if pkgs[0].Name != "device-mapper" {
+		t.Errorf("wrong package survived: %q", pkgs[0].Name)
 	}
 }


### PR DESCRIPTION
Follow-up to #985, from review of that PR.

## Problem

The `pacman -Qu` fallback merged in #985 treats every exit 1 as "nothing upgradable". But `pacman -Qu` exits 1 in two quite different situations: when there is genuinely nothing to upgrade, and when it fails outright, for example because the sync database is missing or corrupt.

The consequence is the bad direction. A host with a broken package database reports zero pending updates and looks healthy, and nothing anywhere surfaces the failure. For a patch monitor a false clean result is worse than an error, because an error is at least visible.

## Fix

Only a real failure writes to stderr, so use that to tell the two apart.

Genuine failures now go through `commandError`, which is what the dnf backend already does for its own exit-code handling (`dnf.go:145-149`). Its doc comment describes this exact situation: `Output()` captures stderr but the error string is only ever "exit status N", which is useless for working out why a host reported zero updates. It also truncates long stderr and redacts credentials that repository URLs routinely carry.

## Tests

Adds coverage for two behaviours that were previously unpinned:

- A silent exit 1 is an empty result; an exit 1 with stderr is an error.
- Ignored packages are excluded. `pacman -Qu` appends ` [ignored]` inline for IgnorePkg entries whereas `checkupdates` filters them itself, so the two agree only because the shared parser pattern is anchored and the trailing marker contains a space. That agreement is load-bearing but easy to break: relaxing the pattern to tolerate trailing content would silently start reporting ignored packages as pending updates. The test locks it in.

The test stub also gains the ability to produce stderr, which it could not do before, and a note that callers must not use `t.Parallel()` since it swaps package-level vars.

`make check` passes and the package is clean under `-race`.