### PR TITLE
Ten quick-win bug fixes for 2.0.3

### DIFF
--- a/agent-source-code/cmd/patchmon-agent/commands/serve.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/serve.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -2231,6 +2232,29 @@ func patchRunTrailer(wasStopped bool, stepErr error, dryRun bool) string {
 	}
 }
 
+// dpkgConfOptions stop dpkg prompting on a modified conffile.
+var dpkgConfOptions = []string{
+	"-o", "Dpkg::Options::=--force-confdef",
+	"-o", "Dpkg::Options::=--force-confold",
+}
+
+// aptUpgradeArgs builds the apt-get arguments for a full upgrade.
+func aptUpgradeArgs(dryRun bool) []string {
+	if dryRun {
+		return []string{"-s", "--with-new-pkgs", "upgrade"}
+	}
+	return append(slices.Clone(dpkgConfOptions), "--with-new-pkgs", "upgrade", "-y")
+}
+
+// aptOnlyUpgradeArgs builds the apt-get arguments for upgrading named packages.
+func aptOnlyUpgradeArgs(dryRun bool, packageNames []string) []string {
+	if dryRun {
+		return append([]string{"-s", "--only-upgrade", "install"}, packageNames...)
+	}
+	args := append(slices.Clone(dpkgConfOptions), "--only-upgrade", "install", "-y")
+	return append(args, packageNames...)
+}
+
 // When dryRun is true, simulates and sends dry_run_completed instead of completed.
 func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
@@ -2381,11 +2405,11 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 				// applies the patch, installs nothing, and reports them as
 				// outdated again forever.
 				if dryRun {
-					if err, abort := runStep(false, "apt-get -s upgrade", "apt-get -s upgrade failed: %w", "apt-get", "-s", "--with-new-pkgs", "upgrade"); abort {
+					if err, abort := runStep(false, "apt-get -s upgrade", "apt-get -s upgrade failed: %w", "apt-get", aptUpgradeArgs(true)...); abort {
 						stepErr = err
 					}
 				} else {
-					if err, abort := runStep(false, "apt-get upgrade", "apt-get upgrade failed: %w", "apt-get", "--with-new-pkgs", "upgrade", "-y"); abort {
+					if err, abort := runStep(false, "apt-get upgrade", "apt-get upgrade failed: %w", "apt-get", aptUpgradeArgs(false)...); abort {
 						stepErr = err
 					}
 				}
@@ -2429,12 +2453,12 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 			switch pkgManager {
 			case "apt":
 				if dryRun {
-					args := append([]string{"-s", "--only-upgrade", "install"}, packageNames...)
+					args := aptOnlyUpgradeArgs(true, packageNames)
 					if err, abort := runStep(false, "apt-get -s --only-upgrade install", "apt-get -s --only-upgrade install failed: %w", "apt-get", args...); abort {
 						stepErr = err
 					}
 				} else {
-					args := append([]string{"--only-upgrade", "install", "-y"}, packageNames...)
+					args := aptOnlyUpgradeArgs(false, packageNames)
 					if err, abort := runStep(false, "apt-get --only-upgrade install", "apt-get --only-upgrade install failed: %w", "apt-get", args...); abort {
 						stepErr = err
 					}

--- a/agent-source-code/cmd/patchmon-agent/commands/serve_patching_test.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/serve_patching_test.go
@@ -30,6 +30,55 @@ func TestSplitFreeBSDPatchTargets(t *testing.T) {
 	})
 }
 
+func TestAptArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		got  []string
+		want []string
+	}{
+		{
+			name: "upgrade forces conffile defaults",
+			got:  aptUpgradeArgs(false),
+			want: []string{"-o", "Dpkg::Options::=--force-confdef", "-o", "Dpkg::Options::=--force-confold", "--with-new-pkgs", "upgrade", "-y"},
+		},
+		{
+			name: "simulated upgrade stays unchanged",
+			got:  aptUpgradeArgs(true),
+			want: []string{"-s", "--with-new-pkgs", "upgrade"},
+		},
+		{
+			name: "package upgrade forces conffile defaults",
+			got:  aptOnlyUpgradeArgs(false, []string{"curl", "git"}),
+			want: []string{"-o", "Dpkg::Options::=--force-confdef", "-o", "Dpkg::Options::=--force-confold", "--only-upgrade", "install", "-y", "curl", "git"},
+		},
+		{
+			name: "simulated package upgrade stays unchanged",
+			got:  aptOnlyUpgradeArgs(true, []string{"curl"}),
+			want: []string{"-s", "--only-upgrade", "install", "curl"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !reflect.DeepEqual(tt.got, tt.want) {
+				t.Fatalf("args = %v, want %v", tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAptArgsDoNotShareBacking(t *testing.T) {
+	first := aptOnlyUpgradeArgs(false, []string{"curl"})
+	second := aptUpgradeArgs(false)
+
+	if !reflect.DeepEqual(dpkgConfOptions, []string{"-o", "Dpkg::Options::=--force-confdef", "-o", "Dpkg::Options::=--force-confold"}) {
+		t.Fatalf("dpkgConfOptions mutated: %v", dpkgConfOptions)
+	}
+	if reflect.DeepEqual(first, second) {
+		t.Fatal("expected distinct argument lists")
+	}
+}
+
 func TestFreeBSDUpdateOutputHasPendingUpdates(t *testing.T) {
 	t.Run("detects pending updates", func(t *testing.T) {
 		output := `The following files will be updated as part of updating to 14.2-RELEASE-p3:

--- a/agent-source-code/internal/integrations/compliance/openscap.go
+++ b/agent-source-code/internal/integrations/compliance/openscap.go
@@ -260,13 +260,8 @@ func (s *OpenSCAPScanner) GetScannerDetails() *models.ComplianceScannerDetails {
 	mismatchWarning := ""
 	if contentFile != "" && s.osInfo.Version != "" {
 		baseName := filepath.Base(contentFile)
-		osVersion := strings.ReplaceAll(s.osInfo.Version, ".", "")
-		majorVersion := strings.Split(s.osInfo.Version, ".")[0]
-		contentOSName := s.getContentOSName()
 		// Match if file contains full version (e.g. 2204) or distro+major (e.g. rhel9, almalinux9)
-		versionMatch := strings.Contains(baseName, osVersion) ||
-			strings.Contains(baseName, contentOSName+majorVersion)
-		if !versionMatch {
+		if !s.contentFileMatchesOSVersion(baseName) {
 			contentMismatch = true
 			mismatchWarning = fmt.Sprintf("Content file %s may not match OS version %s.", baseName, s.osInfo.Version)
 		}
@@ -498,17 +493,33 @@ func (s *OpenSCAPScanner) checkContentCompatibility() {
 	}).Debug("Checking SCAP content compatibility")
 
 	// Check if content file matches OS version (SSG uses major version, e.g. ssg-rhel9 for 9.x)
-	contentOSName := s.getContentOSName()
-	majorVersion := strings.Split(s.osInfo.Version, ".")[0]
-	osVersion := strings.ReplaceAll(s.osInfo.Version, ".", "")
-	versionMatch := strings.Contains(baseName, osVersion) ||
-		strings.Contains(baseName, contentOSName+majorVersion)
-	if !versionMatch {
+	if !s.contentFileMatchesOSVersion(baseName) {
 		s.logger.WithFields(logrus.Fields{
 			"os_version":   s.osInfo.Version,
 			"content_file": baseName,
 		}).Warn("SCAP content may not match OS version - scan results may show many 'notapplicable' rules. Consider updating ssg-base package.")
 	}
+}
+
+// contentFileMatchesOSVersion reports whether a datastream file name belongs to
+// this OS version, accepting any of the product name variants for the distro.
+func (s *OpenSCAPScanner) contentFileMatchesOSVersion(baseName string) bool {
+	if strings.Contains(baseName, strings.ReplaceAll(s.osInfo.Version, ".", "")) {
+		return true
+	}
+
+	majorVersion := strings.Split(s.osInfo.Version, ".")[0]
+	contentOSName := s.getContentOSName()
+	names := contentOSNameVariants(contentOSName)
+	if contentOSName != s.osInfo.Name {
+		names = append(names, contentOSNameVariants(s.osInfo.Name)...)
+	}
+	for _, name := range names {
+		if strings.Contains(baseName, name+majorVersion) {
+			return true
+		}
+	}
+	return false
 }
 
 // SSGContentDownloader abstracts the ability to download SSG content from the PatchMon server.
@@ -577,32 +588,20 @@ func (s *OpenSCAPScanner) UpgradeSSGContentFromServer(downloader SSGContentDownl
 // pickSSGFile selects the best datastream file for this OS from the available server files.
 func (s *OpenSCAPScanner) pickSSGFile(available []string) string {
 	contentOSName := s.getContentOSName()
-	major := strings.Split(s.osInfo.Version, ".")[0]
-
-	candidates := []string{
-		fmt.Sprintf("ssg-%s%s-ds.xml", contentOSName, strings.ReplaceAll(s.osInfo.Version, ".", "")),
-		fmt.Sprintf("ssg-%s%s-ds.xml", contentOSName, major),
-		fmt.Sprintf("ssg-%s-ds.xml", contentOSName),
-	}
 
 	avail := make(map[string]bool, len(available))
 	for _, f := range available {
 		avail[f] = true
 	}
 
-	for _, c := range candidates {
+	for _, c := range ssgFileCandidates(contentOSName, s.osInfo.Version) {
 		if avail[c] {
 			return c
 		}
 	}
 
 	if contentOSName != s.osInfo.Name {
-		fallbacks := []string{
-			fmt.Sprintf("ssg-%s%s-ds.xml", s.osInfo.Name, strings.ReplaceAll(s.osInfo.Version, ".", "")),
-			fmt.Sprintf("ssg-%s%s-ds.xml", s.osInfo.Name, major),
-			fmt.Sprintf("ssg-%s-ds.xml", s.osInfo.Name),
-		}
-		for _, c := range fallbacks {
+		for _, c := range ssgFileCandidates(s.osInfo.Name, s.osInfo.Version) {
 			if avail[c] {
 				return c
 			}
@@ -610,6 +609,42 @@ func (s *OpenSCAPScanner) pickSSGFile(available []string) string {
 	}
 
 	return ""
+}
+
+// contentOSNameVariants returns the SSG product names to try for an OS name, in
+// preference order. A few distributions ship a datastream whose product name is
+// not their os-release ID: Rocky's scap-security-guide package provides
+// ssg-rl9-ds.xml, and SUSE's products are sle12/sle15, not sles12/sles15.
+func contentOSNameVariants(osName string) []string {
+	switch osName {
+	case "rocky":
+		return []string{osName, "rl"}
+	case "sles":
+		return []string{osName, "sle"}
+	case "alma":
+		return []string{osName, "almalinux"}
+	case "opensuse-leap":
+		return []string{osName, "opensuse"}
+	}
+	return []string{osName}
+}
+
+// ssgFileCandidates returns the datastream filenames to try for an OS name and
+// version, in preference order.
+func ssgFileCandidates(osName, version string) []string {
+	compact := strings.ReplaceAll(version, ".", "")
+	major := strings.Split(version, ".")[0]
+
+	variants := contentOSNameVariants(osName)
+	candidates := make([]string, 0, len(variants)*3)
+	for _, name := range variants {
+		candidates = append(candidates,
+			fmt.Sprintf("ssg-%s%s-ds.xml", name, compact),
+			fmt.Sprintf("ssg-%s%s-ds.xml", name, major),
+			fmt.Sprintf("ssg-%s-ds.xml", name),
+		)
+	}
+	return candidates
 }
 
 // UpgradeSSGContent upgrades the SCAP Security Guide content from GitHub releases (legacy fallback).
@@ -1088,15 +1123,23 @@ func (s *OpenSCAPScanner) getContentFile() string {
 	// Get the base distribution name for content file lookup
 	contentOSName := s.getContentOSName()
 
-	// Build possible content file names
-	patterns := []string{
-		fmt.Sprintf("ssg-%s%s-ds.xml", contentOSName, strings.ReplaceAll(s.osInfo.Version, ".", "")),
-		fmt.Sprintf("ssg-%s%s-ds.xml", contentOSName, strings.Split(s.osInfo.Version, ".")[0]),
-		fmt.Sprintf("ssg-%s-ds.xml", contentOSName),
+	if path := s.findContentFile(contentOSName); path != "" {
+		return path
 	}
 
-	// Check each pattern
-	for _, pattern := range patterns {
+	// If still not found and we normalized to a base distribution, try the original OS name as fallback
+	if contentOSName != s.osInfo.Name {
+		if path := s.findContentFile(s.osInfo.Name); path != "" {
+			return path
+		}
+	}
+
+	return ""
+}
+
+// findContentFile looks on disk for a datastream belonging to one OS name.
+func (s *OpenSCAPScanner) findContentFile(osName string) string {
+	for _, pattern := range ssgFileCandidates(osName, s.osInfo.Version) {
 		path := filepath.Join(scapContentDir, pattern)
 		if _, err := os.Stat(path); err == nil {
 			return path
@@ -1104,27 +1147,10 @@ func (s *OpenSCAPScanner) getContentFile() string {
 	}
 
 	// Try to find any matching file; when multiple exist, prefer the one that matches OS version
-	matches, err := filepath.Glob(filepath.Join(scapContentDir, fmt.Sprintf("ssg-%s*-ds.xml", contentOSName)))
-	if err == nil && len(matches) > 0 {
-		return s.bestContentMatch(matches, contentOSName)
-	}
-
-	// If still not found and we normalized to a base distribution, try the original OS name as fallback
-	if contentOSName != s.osInfo.Name {
-		patterns = []string{
-			fmt.Sprintf("ssg-%s%s-ds.xml", s.osInfo.Name, strings.ReplaceAll(s.osInfo.Version, ".", "")),
-			fmt.Sprintf("ssg-%s%s-ds.xml", s.osInfo.Name, strings.Split(s.osInfo.Version, ".")[0]),
-			fmt.Sprintf("ssg-%s-ds.xml", s.osInfo.Name),
-		}
-		for _, pattern := range patterns {
-			path := filepath.Join(scapContentDir, pattern)
-			if _, err := os.Stat(path); err == nil {
-				return path
-			}
-		}
-		matches, err := filepath.Glob(filepath.Join(scapContentDir, fmt.Sprintf("ssg-%s*-ds.xml", s.osInfo.Name)))
+	for _, name := range contentOSNameVariants(osName) {
+		matches, err := filepath.Glob(filepath.Join(scapContentDir, fmt.Sprintf("ssg-%s*-ds.xml", name)))
 		if err == nil && len(matches) > 0 {
-			return s.bestContentMatch(matches, s.osInfo.Name)
+			return s.bestContentMatch(matches, name)
 		}
 	}
 

--- a/agent-source-code/internal/integrations/compliance/openscap_content_test.go
+++ b/agent-source-code/internal/integrations/compliance/openscap_content_test.go
@@ -1,0 +1,118 @@
+package compliance
+
+import (
+	"testing"
+
+	"patchmon-agent/pkg/models"
+)
+
+func TestPickSSGFile(t *testing.T) {
+	tests := []struct {
+		name      string
+		osName    string
+		osVersion string
+		idLike    string
+		available []string
+		want      string
+	}{
+		{
+			name:      "rocky 9 rl datastream",
+			osName:    "rocky",
+			osVersion: "9.5",
+			idLike:    "rhel centos fedora",
+			available: []string{"ssg-rhel9-ds.xml", "ssg-rl9-ds.xml"},
+			want:      "ssg-rl9-ds.xml",
+		},
+		{
+			name:      "rocky 8 rl datastream",
+			osName:    "rocky",
+			osVersion: "8.10",
+			idLike:    "rhel centos fedora",
+			available: []string{"ssg-rl8-ds.xml", "ssg-rl9-ds.xml"},
+			want:      "ssg-rl8-ds.xml",
+		},
+		{
+			name:      "rocky prefers rocky-named datastream when present",
+			osName:    "rocky",
+			osVersion: "9.5",
+			available: []string{"ssg-rocky9-ds.xml", "ssg-rl9-ds.xml"},
+			want:      "ssg-rocky9-ds.xml",
+		},
+		{
+			name:      "sles maps to sle product",
+			osName:    "sles",
+			osVersion: "15.6",
+			available: []string{"ssg-sle15-ds.xml"},
+			want:      "ssg-sle15-ds.xml",
+		},
+		{
+			name:      "legacy alma maps to almalinux product",
+			osName:    "alma",
+			osVersion: "9.4",
+			available: []string{"ssg-almalinux9-ds.xml"},
+			want:      "ssg-almalinux9-ds.xml",
+		},
+		{
+			name:      "opensuse leap falls back to opensuse product",
+			osName:    "opensuse-leap",
+			osVersion: "15.6",
+			idLike:    "suse opensuse",
+			available: []string{"ssg-opensuse-ds.xml"},
+			want:      "ssg-opensuse-ds.xml",
+		},
+		{
+			name:      "ubuntu keeps full version match",
+			osName:    "ubuntu",
+			osVersion: "24.04",
+			available: []string{"ssg-ubuntu2204-ds.xml", "ssg-ubuntu2404-ds.xml"},
+			want:      "ssg-ubuntu2404-ds.xml",
+		},
+		{
+			name:      "no match",
+			osName:    "rocky",
+			osVersion: "9.5",
+			available: []string{"ssg-debian12-ds.xml"},
+			want:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &OpenSCAPScanner{
+				osInfo: models.ComplianceOSInfo{Name: tt.osName, Version: tt.osVersion},
+				idLike: tt.idLike,
+			}
+			if got := s.pickSSGFile(tt.available); got != tt.want {
+				t.Fatalf("pickSSGFile() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestContentFileMatchesOSVersion(t *testing.T) {
+	tests := []struct {
+		name      string
+		osName    string
+		osVersion string
+		baseName  string
+		want      bool
+	}{
+		{"rocky rl datastream", "rocky", "9.5", "ssg-rl9-ds.xml", true},
+		{"rocky wrong major", "rocky", "9.5", "ssg-rl8-ds.xml", false},
+		{"sles sle datastream", "sles", "15.6", "ssg-sle15-ds.xml", true},
+		{"rhel exact", "rhel", "9.4", "ssg-rhel9-ds.xml", true},
+		{"ubuntu full version", "ubuntu", "24.04", "ssg-ubuntu2404-ds.xml", true},
+		{"ubuntu mismatch", "ubuntu", "24.04", "ssg-ubuntu2204-ds.xml", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &OpenSCAPScanner{
+				osInfo: models.ComplianceOSInfo{Name: tt.osName, Version: tt.osVersion},
+			}
+			if got := s.contentFileMatchesOSVersion(tt.baseName); got != tt.want {
+				t.Fatalf("contentFileMatchesOSVersion(%q) = %v, want %v", tt.baseName, got, tt.want)
+			}
+		})
+	}
+}

--- a/agent-source-code/internal/repositories/apt.go
+++ b/agent-source-code/internal/repositories/apt.go
@@ -284,7 +284,8 @@ func (m *APTManager) parseDEB822Sources(filename string) ([]models.Repository, e
 
 			parts := strings.SplitN(line, ":", 2)
 			if len(parts) == 2 {
-				key := strings.TrimSpace(parts[0])
+				// Field names are case-insensitive per sources.list(5)
+				key := strings.ToLower(strings.TrimSpace(parts[0]))
 				value := strings.TrimSpace(parts[1])
 				currentEntry[key] = value
 			}
@@ -300,20 +301,21 @@ func (m *APTManager) parseDEB822Sources(filename string) ([]models.Repository, e
 	return repositories, scanner.Err()
 }
 
-// processDEB822Entry processes a single DEB822 repository entry
+// processDEB822Entry processes a single DEB822 repository entry.
+// Keys are lower-cased by parseDEB822Sources.
 func (m *APTManager) processDEB822Entry(entry map[string]string) []models.Repository {
 	var repositories []models.Repository
 
 	// Check if explicitly disabled (Enabled: no)
 	// Per sources.list(5), Enabled defaults to yes if not specified
-	enabled := entry["Enabled"]
+	enabled := strings.ToLower(entry["enabled"])
 	isEnabled := enabled != "no" && enabled != "false"
 
-	types := entry["Types"]
-	uris := entry["URIs"]
-	suites := entry["Suites"]
-	components := entry["Components"]
-	name := entry["X-Repolib-Name"]
+	types := entry["types"]
+	uris := entry["uris"]
+	suites := entry["suites"]
+	components := entry["components"]
+	name := entry["x-repolib-name"]
 
 	if uris == "" || suites == "" {
 		return repositories

--- a/agent-source-code/internal/repositories/apt_test.go
+++ b/agent-source-code/internal/repositories/apt_test.go
@@ -88,6 +88,93 @@ deb http://security.ubuntu.com/ubuntu jammy-security main
 	assert.GreaterOrEqual(t, len(repos), 2)
 }
 
+func TestAPTManager_parseDEB822Sources_FieldCasing(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel)
+	manager := NewAPTManager(logger)
+
+	tests := []struct {
+		name            string
+		content         string
+		expectedURL     string
+		expectedDist    string
+		expectedComp    string
+		expectedType    string
+		expectedEnabled bool
+	}{
+		{
+			name: "canonical casing",
+			content: `Types: deb
+URIs: http://archive.ubuntu.com/ubuntu
+Suites: noble
+Components: main restricted
+`,
+			expectedURL:     "http://archive.ubuntu.com/ubuntu",
+			expectedDist:    "noble",
+			expectedComp:    "main restricted",
+			expectedType:    "deb",
+			expectedEnabled: true,
+		},
+		{
+			name: "lowercase field names",
+			content: `types: deb
+uris: http://archive.ubuntu.com/ubuntu
+suites: noble
+components: main
+`,
+			expectedURL:     "http://archive.ubuntu.com/ubuntu",
+			expectedDist:    "noble",
+			expectedComp:    "main",
+			expectedType:    "deb",
+			expectedEnabled: true,
+		},
+		{
+			name: "mixed casing",
+			content: `Types: deb-src
+Uris: https://deb.debian.org/debian
+SUITES: trixie
+CoMpOnEnTs: main contrib
+Enabled: Yes
+`,
+			expectedURL:     "https://deb.debian.org/debian",
+			expectedDist:    "trixie",
+			expectedComp:    "main contrib",
+			expectedType:    "deb-src",
+			expectedEnabled: true,
+		},
+		{
+			name: "disabled with capitalised value",
+			content: `Types: deb
+Uris: http://archive.ubuntu.com/ubuntu
+Suites: noble
+Components: main
+enabled: No
+`,
+			expectedURL:     "http://archive.ubuntu.com/ubuntu",
+			expectedDist:    "noble",
+			expectedComp:    "main",
+			expectedType:    "deb",
+			expectedEnabled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testFile := filepath.Join(t.TempDir(), "test.sources")
+			require.NoError(t, os.WriteFile(testFile, []byte(tt.content), 0644))
+
+			repos, err := manager.parseDEB822Sources(testFile)
+			require.NoError(t, err)
+			require.Len(t, repos, 1)
+			assert.Equal(t, tt.expectedURL, repos[0].URL)
+			assert.Equal(t, tt.expectedDist, repos[0].Distribution)
+			assert.Equal(t, tt.expectedComp, repos[0].Components)
+			assert.Equal(t, tt.expectedType, repos[0].RepoType)
+			assert.Equal(t, tt.expectedEnabled, repos[0].IsEnabled)
+		})
+	}
+}
+
 func TestIsValidSuiteComponents(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -80,7 +80,7 @@ services:
         max-file: "3"
 
   guacd:
-    image: guacamole/guacd:latest
+    image: guacamole/guacd:1.6.0
     restart: unless-stopped
     read_only: true
     tmpfs:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     restart: unless-stopped
     env_file: .env
     ports:
-      - "3000:3000"
+      - "${PORT:-3000}:${PORT:-3000}"
     networks:
       - patchmon-internal
     depends_on:

--- a/docker/env.example
+++ b/docker/env.example
@@ -123,7 +123,7 @@ GUACD_ADDRESS=guacd:4822
 # DB_CONNECT_TIMEOUT=10
 # DB_TRANSACTION_LONG_TIMEOUT=60000
 
-## Server - Port 3000 is the frontend port, which is proxying backend queries to the backend. This is handled by the server itself. If you change this port, you change the port that is used to access PatchMon and therefore will also need to ammend the "ports" values in your docker-compose.yml
+## Server - Port 3000 is the frontend port, which is proxying backend queries to the backend. This is handled by the server itself. Changing it changes the port PatchMon is accessed on; the compose port mapping follows this value, so you only need to update CORS_ORIGIN to match.
 # PORT=3000
 # APP_ENV=production
 

--- a/docs/patchmon-admin-guide.md
+++ b/docs/patchmon-admin-guide.md
@@ -4150,7 +4150,7 @@ RDP is provided under the **remote_access** capability module.
 
 Key components:
 
-- **`guacd`**: Apache Guacamole's daemon, shipped as a sidecar container in PatchMon's Docker Compose (`guacamole/guacd:1.5.5`). Runs on `4822/tcp` inside the `patchmon-internal` network. No public ports.
+- **`guacd`**: Apache Guacamole's daemon, shipped as a sidecar container in PatchMon's Docker Compose (`guacamole/guacd:1.6.0`). Runs on `4822/tcp` inside the `patchmon-internal` network. No public ports.
 - **PatchMon server**: acts as the Guacamole WebSocket tunnel endpoint and owns the RDP ticket store. It asks the host's agent to set up a local TCP proxy, then hands that proxy to `guacd`.
 - **Agent proxy**: on receiving `rdp_proxy` over its WebSocket, the agent opens a local TCP bridge and forwards bytes between PatchMon and `localhost:3389` on the Windows host. Requires `integrations.rdp-proxy-enabled: true` in the agent config.
 - **Windows host**: runs the standard Windows RDP service on `127.0.0.1:3389` (bound to localhost via the agent; no inbound exposure needed).

--- a/docs/patchmon-operator-guide.md
+++ b/docs/patchmon-operator-guide.md
@@ -160,7 +160,7 @@ services:
     restart: unless-stopped
     env_file: .env
     ports:
-      - "3000:3000"
+      - "${PORT:-3000}:${PORT:-3000}"
     networks:
       - patchmon-internal
     depends_on:
@@ -1542,7 +1542,7 @@ General HTTP server and network settings.
 
 | Variable | Default | Required | Description |
 |----------|---------|----------|-------------|
-| `PORT` | `3000` | No | TCP port the server listens on. |
+| `PORT` | `3000` | No | TCP port the server listens on. In the Docker Compose stack the published port mapping follows this value, so you only need to update `CORS_ORIGIN` to match. |
 | `APP_ENV` | `production` | No | Runtime environment. Accepted values: `production`, `development`. `NODE_ENV` is also read as a backward-compatibility alias; `APP_ENV` takes precedence when both are set. |
 | `CORS_ORIGIN` | `http://localhost:3000` | No | Allowed CORS origin(s). Must match the exact URL you use to access PatchMon in your browser (protocol, hostname, and port; no path, no trailing slash). To allow multiple origins, separate them with a comma and no spaces (e.g. `https://patchmon.example.com,https://patchmon.internal.lan`). |
 | `ENABLE_HSTS` | `false` | No | When `true`, the server adds an `HTTP Strict Transport Security` header to responses. Enable this only when PatchMon is served over HTTPS. |
@@ -5261,12 +5261,12 @@ A stock `docker-compose.yml` deployment runs four containers on the `patchmon-in
 
 | Service | Image | Port (exposed) | Depends on |
 |---------|-------|----------------|-----------|
-| `server` | `ghcr.io/patchmon/patchmon-server:latest` | `3000:3000` | `database`, `redis`, `guacd` |
+| `server` | `ghcr.io/patchmon/patchmon-server:latest` | `${PORT:-3000}:${PORT:-3000}` | `database`, `redis`, `guacd` |
 | `database` | `postgres:17-alpine` | not exposed | n/a |
 | `redis` | `redis:7-alpine` | not exposed | n/a |
 | `guacd` | `guacamole/guacd:1.6.0` | not exposed | n/a |
 
-The `server` container embeds the Go HTTP server, the frontend, the queue worker, and the migration runner. No separate migration job is needed. In front of it you typically run Nginx / Traefik / Caddy / Cloudflare that terminates TLS and forwards to `server:3000`.
+The `server` container embeds the Go HTTP server, the frontend, the queue worker, and the migration runner. No separate migration job is needed. In front of it you typically run Nginx / Traefik / Caddy / Cloudflare that terminates TLS and forwards to `server:3000`, or to whichever port you set `PORT` to.
 
 ### Gathering Diagnostic Info
 

--- a/docs/patchmon-operator-guide.md
+++ b/docs/patchmon-operator-guide.md
@@ -37,7 +37,7 @@ PatchMon runs as a single container backed by three supporting services. The Pat
 | `server` | `ghcr.io/patchmon/patchmon-server` | PatchMon application (API + frontend + migrations) |
 | `database` | `postgres:17-alpine` | Primary data store |
 | `redis` | `redis:7-alpine` | Background job queues (asynq) |
-| `guacd` | `guacamole/guacd:1.5.5` | RDP gateway (required for in-browser RDP) |
+| `guacd` | `guacamole/guacd:1.6.0` | RDP gateway (required for in-browser RDP) |
 
 All four services communicate over an isolated internal Docker network (`patchmon-internal`). Only the `server` port is exposed to the host.
 
@@ -191,7 +191,7 @@ services:
       - patchmon-internal
 
   guacd:
-    image: guacamole/guacd:1.5.5
+    image: guacamole/guacd:1.6.0
     restart: unless-stopped
     networks:
       - patchmon-internal
@@ -380,7 +380,7 @@ If your version of the chart still ships with separate backend and frontend depl
 | Server | `ghcr.io/patchmon/patchmon-server` | `2.0.0` |
 | Database | `docker.io/postgres` | `17-alpine` |
 | Redis | `docker.io/redis` | `7-alpine` |
-| guacd (RDP sidecar, optional) | `docker.io/guacamole/guacd` | `1.5.5` |
+| guacd (RDP sidecar, optional) | `docker.io/guacamole/guacd` | `1.6.0` |
 
 #### Available tags (server image)
 
@@ -671,7 +671,7 @@ guacd:
   enabled: true
   image:
     repository: guacamole/guacd
-    tag: "1.5.5"
+    tag: "1.6.0"
 ```
 
 > **Verify against the latest chart.** `guacd` support was added after the original 1.4.x chart; if your chart version does not include a `guacd.enabled` option, you can deploy it as a separate Deployment and Service in the same namespace and set `GUACD_ADDRESS` to its ClusterIP hostname.
@@ -771,7 +771,7 @@ This changes every image pull to use the specified registry:
 - `registry.example.com/postgres:17-alpine`
 - `registry.example.com/redis:7-alpine`
 - `registry.example.com/patchmon/patchmon-server:2.0.0`
-- `registry.example.com/guacamole/guacd:1.5.5` (when RDP is enabled)
+- `registry.example.com/guacamole/guacd:1.6.0` (when RDP is enabled)
 
 #### Horizontal Pod Autoscaling
 
@@ -4949,7 +4949,7 @@ For these reasons, `rdp-proxy-enabled` **cannot be toggled from the PatchMon UI 
 
 ##### Prerequisites
 
-- The PatchMon **server** must have `guacd` available (the default Docker Compose stack includes `guacamole/guacd:1.5.5` as a sidecar).
+- The PatchMon **server** must have `guacd` available (the default Docker Compose stack includes `guacamole/guacd:1.6.0` as a sidecar).
 - The **Windows host** must have Remote Desktop enabled.
 - The PatchMon agent must be installed on the Windows host.
 - PatchMon only needs RDP listening on `localhost:3389` on the Windows host. You do not need to expose RDP publicly.
@@ -5264,7 +5264,7 @@ A stock `docker-compose.yml` deployment runs four containers on the `patchmon-in
 | `server` | `ghcr.io/patchmon/patchmon-server:latest` | `3000:3000` | `database`, `redis`, `guacd` |
 | `database` | `postgres:17-alpine` | not exposed | n/a |
 | `redis` | `redis:7-alpine` | not exposed | n/a |
-| `guacd` | `guacamole/guacd:1.5.5` | not exposed | n/a |
+| `guacd` | `guacamole/guacd:1.6.0` | not exposed | n/a |
 
 The `server` container embeds the Go HTTP server, the frontend, the queue worker, and the migration runner. No separate migration job is needed. In front of it you typically run Nginx / Traefik / Caddy / Cloudflare that terminates TLS and forwards to `server:3000`.
 

--- a/frontend/src/pages/Hosts.jsx
+++ b/frontend/src/pages/Hosts.jsx
@@ -3025,6 +3025,10 @@ const ColumnSettingsModal = ({
 		setDraggedIndex(null);
 	};
 
+	const handleDragEnd = () => {
+		setDraggedIndex(null);
+	};
+
 	return (
 		<div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
 			<div className="bg-white dark:bg-secondary-800 rounded-lg shadow-xl max-w-lg w-full max-h-[85vh] flex flex-col">
@@ -3059,6 +3063,7 @@ const ColumnSettingsModal = ({
 								onDragStart={(e) => handleDragStart(e, index)}
 								onDragOver={handleDragOver}
 								onDrop={(e) => handleDrop(e, index)}
+								onDragEnd={handleDragEnd}
 								onKeyDown={(e) => {
 									if (e.key === "Enter" || e.key === " ") {
 										e.preventDefault();

--- a/frontend/src/pages/Hosts.jsx
+++ b/frontend/src/pages/Hosts.jsx
@@ -63,12 +63,13 @@ const HOSTS_DEFAULT_PAGE_SIZE = 50;
 const HOSTS_PAGE_SIZE_STORAGE_KEY = "hosts-page-size";
 const WS_STATUS_BATCH_SIZE = 200;
 
-// The Reporting filter depends on live WebSocket state the server does not
-// hold, so it has to run client-side. To keep the row count, the range text
-// and the page controls honest we fetch an unpaginated slab, filter it, then
-// paginate the filtered result ourselves. The cap bounds that fetch; when the
-// fleet exceeds it the UI says so rather than quietly showing a partial list.
-const REPORTING_FILTER_FETCH_LIMIT = 1000;
+// The Reporting and Connection filters depend on live WebSocket state the
+// server does not hold, so they have to run client-side. To keep the row count,
+// the range text and the page controls honest we fetch an unpaginated slab,
+// filter it, then paginate the filtered result ourselves. The cap bounds that
+// fetch; when the fleet exceeds it the UI says so rather than quietly showing a
+// partial list.
+const LIVE_FILTER_FETCH_LIMIT = 1000;
 
 const HOSTS_SORT_FIELDS = {
 	agent_version: "agent_version",
@@ -118,6 +119,7 @@ const fetchWsStatusBatches = async (apiIds) => {
 const Hosts = () => {
 	const hostGroupFilterId = useId();
 	const statusFilterId = useId();
+	const connectionFilterId = useId();
 	const osFilterId = useId();
 	const osVersionFilterId = useId();
 	const [showAddModal, setShowAddModal] = useState(false);
@@ -149,6 +151,7 @@ const Hosts = () => {
 	const [sortDirection, setSortDirection] = useState("asc");
 	const [groupFilter, setGroupFilter] = useState("all");
 	const [statusFilter, setStatusFilter] = useState("all");
+	const [connectionFilter, setConnectionFilter] = useState("all");
 	const [osFilter, setOsFilter] = useState("all");
 	const [osVersionFilter, setOsVersionFilter] = useState("all");
 	const [showFilters, setShowFilters] = useState(false);
@@ -405,13 +408,17 @@ const Hosts = () => {
 		next.set("filter", "stale");
 		navigate(`/hosts?${next.toString()}`, { replace: true });
 	}, [urlFilter, searchParams, navigate]);
-	// The Reporting filter (reporting / overdue / stale) is derived from live
-	// WebSocket state that the server does not hold at query time, so it has to
-	// run client-side. While it is active we ask the server for one bounded slab
-	// rather than a page, then filter and paginate that slab locally, so the
-	// count, the range text and the page controls always agree with the rows on
-	// screen.
+	// The Reporting filter (reporting / overdue / stale) and the Connection
+	// filter (connected / offline) are derived from live WebSocket state that the
+	// server does not hold at query time, so they have to run client-side. While
+	// either is active we ask the server for one bounded slab rather than a page,
+	// then filter and paginate that slab locally, so the count, the range text
+	// and the page controls always agree with the rows on screen.
 	const reportingFilterActive = Boolean(statusFilter && statusFilter !== "all");
+	const connectionFilterActive = Boolean(
+		connectionFilter && connectionFilter !== "all",
+	);
+	const liveFilterActive = reportingFilterActive || connectionFilterActive;
 
 	const hostsQueryParams = useMemo(() => {
 		const params = {};
@@ -432,8 +439,8 @@ const Hosts = () => {
 		}
 		if (searchParams.get("reboot") === "true") params.reboot = "true";
 		if (hideStale) params.hideStale = "true";
-		if (reportingFilterActive) {
-			params.limit = REPORTING_FILTER_FETCH_LIMIT;
+		if (liveFilterActive) {
+			params.limit = LIVE_FILTER_FETCH_LIMIT;
 			params.offset = 0;
 		} else {
 			params.limit = pageSize;
@@ -450,7 +457,7 @@ const Hosts = () => {
 		urlFilter,
 		searchParams,
 		hideStale,
-		reportingFilterActive,
+		liveFilterActive,
 		pageSize,
 		offset,
 		sortField,
@@ -498,6 +505,7 @@ const Hosts = () => {
 		search: debouncedSearch,
 		group: groupFilter,
 		status: statusFilter,
+		connection: connectionFilter,
 		os: osFilter,
 		osVersion: osVersionFilter,
 		filter: urlFilter,
@@ -1065,20 +1073,30 @@ const Hosts = () => {
 		selectedHostIdsSetForFilter,
 	]);
 
-	// Apply the new tri-state Status filter (reporting / overdue / stale) on
-	// top of the backend / legacy-mode filter result. Cross-couples each host's
-	// reportingState with the live WS map so the dropdown matches what the user
-	// sees in the Reporting pill. Done here rather than in the predicate above
-	// so the pill colours and the filter logic stay in lock-step.
+	// Apply the tri-state Status filter (reporting / overdue / stale) and the
+	// Connection filter (connected / offline) on top of the backend / legacy-mode
+	// filter result. Both cross-couple each host with the live WS map so the
+	// dropdowns match what the user sees in the Reporting and Connection pills.
+	// Done here rather than in the predicate above so the pill colours and the
+	// filter logic stay in lock-step.
 	const filteredHosts = useMemo(() => {
-		if (!statusFilter || statusFilter === "all") return filteredAndSortedHosts;
+		if (!reportingFilterActive && !connectionFilterActive) {
+			return filteredAndSortedHosts;
+		}
 		return filteredAndSortedHosts.filter((host) => {
-			// Treat missing WS data as "assume connected" so the dropdown
-			// matches the pill, which uses the same convention.
+			// Treat missing WS data as "assume connected" so the dropdowns
+			// match the pills, which use the same convention.
 			const wsEntry = wsStatusMap[host.api_id];
 			const wsConnectedOrUnknown =
 				wsEntry === undefined || wsEntry?.connected === true;
+			if (
+				connectionFilterActive &&
+				wsConnectedOrUnknown !== (connectionFilter === "connected")
+			) {
+				return false;
+			}
 			return (
+				!reportingFilterActive ||
 				deriveReportingState(
 					host,
 					wsConnectedOrUnknown,
@@ -1088,34 +1106,35 @@ const Hosts = () => {
 		});
 	}, [
 		filteredAndSortedHosts,
+		reportingFilterActive,
+		connectionFilterActive,
+		connectionFilter,
 		statusFilter,
 		wsStatusMap,
 		updateIntervalMinutes,
 	]);
 
-	// Pagination is derived AFTER the Reporting filter so the footer count, the
-	// range text and the page controls describe the rows actually rendered. With
-	// no Reporting filter the server already returned exactly one page and this
-	// is a pass-through.
-	const totalHosts = reportingFilterActive
-		? filteredHosts.length
-		: serverTotalHosts;
+	// Pagination is derived AFTER the client-side filters so the footer count,
+	// the range text and the page controls describe the rows actually rendered.
+	// With no client-side filter the server already returned exactly one page and
+	// this is a pass-through.
+	const totalHosts = liveFilterActive ? filteredHosts.length : serverTotalHosts;
 	const totalPages = Math.max(1, Math.ceil(totalHosts / pageSize));
 	const visibleHosts = useMemo(() => {
-		if (!reportingFilterActive) return filteredHosts;
+		if (!liveFilterActive) return filteredHosts;
 		const start = (page - 1) * pageSize;
 		return filteredHosts.slice(start, start + pageSize);
-	}, [filteredHosts, reportingFilterActive, page, pageSize]);
+	}, [filteredHosts, liveFilterActive, page, pageSize]);
 	const pageStart =
 		visibleHosts.length === 0
 			? 0
-			: (reportingFilterActive ? (page - 1) * pageSize : hostsPage.offset) + 1;
+			: (liveFilterActive ? (page - 1) * pageSize : hostsPage.offset) + 1;
 	const pageEnd = pageStart === 0 ? 0 : pageStart + visibleHosts.length - 1;
 
 	// The client-side slab is bounded, so say so rather than silently hiding
 	// matches that fell outside it.
-	const reportingFilterTruncated =
-		reportingFilterActive && serverTotalHosts > REPORTING_FILTER_FETCH_LIMIT;
+	const liveFilterTruncated =
+		liveFilterActive && serverTotalHosts > LIVE_FILTER_FETCH_LIMIT;
 
 	// Clamp out-of-range deep links (`?page=999`) and pages that empty out after
 	// a delete, but only once the totals are known so a legitimate deep link is
@@ -1671,6 +1690,7 @@ const Hosts = () => {
 		setSearchTerm("");
 		setGroupFilter("all");
 		setStatusFilter("all");
+		setConnectionFilter("all");
 		setOsFilter("all");
 		setOsVersionFilter("all");
 		setGroupBy("none");
@@ -1693,6 +1713,20 @@ const Hosts = () => {
 		newSearchParams.set("filter", "needsUpdates");
 		newSearchParams.delete("reboot"); // Clear reboot filter when switching to needsUpdates
 		navigate(`/hosts?${newSearchParams.toString()}`, { replace: true });
+	};
+
+	// Offline is the actionable half of the Connection Status card, so that is
+	// what the card filters to. Live WS state is not a backend filter, so this
+	// stays in local state like the Reporting filter rather than in the URL.
+	const handleConnectionStatusClick = () => {
+		resetLocalFilters();
+		setConnectionFilter("offline");
+		setShowFilters(true);
+		const newSearchParams = new URLSearchParams(searchParams);
+		newSearchParams.delete("filter");
+		newSearchParams.delete("reboot");
+		newSearchParams.delete("selected");
+		setSearchParams(newSearchParams, { replace: true });
 	};
 
 	if (isLoading && !hostsResponse) {
@@ -1823,7 +1857,12 @@ const Hosts = () => {
 						</div>
 					</div>
 				</button>
-				<div className="card p-4 text-left w-full">
+				<button
+					type="button"
+					className="card p-4 cursor-pointer hover:shadow-card-hover dark:hover:shadow-card-hover-dark transition-shadow duration-200 text-left w-full min-h-[44px]"
+					onClick={handleConnectionStatusClick}
+					title="Click to filter hosts that are offline"
+				>
 					<div className="flex items-center">
 						<Wifi className="h-5 w-5 text-primary-600 mr-2" />
 						<div className="flex-1">
@@ -1862,7 +1901,7 @@ const Hosts = () => {
 							})()}
 						</div>
 					</div>
-				</div>
+				</button>
 			</div>
 
 			{/* Hosts List */}
@@ -2039,6 +2078,24 @@ const Hosts = () => {
 									</div>
 									<div>
 										<label
+											htmlFor={connectionFilterId}
+											className="block text-sm font-medium text-secondary-700 dark:text-secondary-200 mb-1"
+										>
+											Connection
+										</label>
+										<select
+											id={connectionFilterId}
+											value={connectionFilter}
+											onChange={(e) => setConnectionFilter(e.target.value)}
+											className="w-full border border-secondary-300 dark:border-secondary-600 rounded-lg px-3 py-2.5 sm:py-2 focus:ring-2 focus:ring-primary-500 focus:border-primary-500 bg-white dark:bg-secondary-800 text-secondary-900 dark:text-white min-h-[44px]"
+										>
+											<option value="all">All</option>
+											<option value="connected">Connected</option>
+											<option value="offline">Offline</option>
+										</select>
+									</div>
+									<div>
+										<label
 											htmlFor={osFilterId}
 											className="block text-sm font-medium text-secondary-700 dark:text-secondary-200 mb-1"
 										>
@@ -2115,15 +2172,14 @@ const Hosts = () => {
 						)}
 					</div>
 
-					{reportingFilterTruncated && (
+					{liveFilterTruncated && (
 						<div className="mb-4 flex items-start gap-2 rounded-md border border-warning-200 dark:border-warning-700 bg-warning-50 dark:bg-warning-900 p-3">
 							<AlertTriangle className="h-4 w-4 flex-shrink-0 mt-0.5 text-warning-600 dark:text-warning-300" />
 							<p className="text-sm text-warning-800 dark:text-warning-200">
-								The Reporting filter is applied to the first{" "}
-								{REPORTING_FILTER_FETCH_LIMIT.toLocaleString()} hosts only, out
-								of {serverTotalHosts.toLocaleString()} matching your other
-								filters. Narrow the search, group or OS filters to cover every
-								host.
+								The Reporting and Connection filters are applied to the first{" "}
+								{LIVE_FILTER_FETCH_LIMIT.toLocaleString()} hosts only, out of{" "}
+								{serverTotalHosts.toLocaleString()} matching your other filters.
+								Narrow the search, group or OS filters to cover every host.
 							</p>
 						</div>
 					)}

--- a/frontend/src/pages/Packages.jsx
+++ b/frontend/src/pages/Packages.jsx
@@ -1439,6 +1439,10 @@ const ColumnSettingsModal = ({
 		setDraggedIndex(null);
 	};
 
+	const handleDragEnd = () => {
+		setDraggedIndex(null);
+	};
+
 	return (
 		<div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
 			<div className="bg-white dark:bg-secondary-800 rounded-lg p-6 w-full max-w-md">
@@ -1466,6 +1470,7 @@ const ColumnSettingsModal = ({
 							onDragStart={(e) => handleDragStart(e, index)}
 							onDragOver={handleDragOver}
 							onDrop={(e) => handleDrop(e, index)}
+							onDragEnd={handleDragEnd}
 							className={`flex items-center justify-between p-3 border rounded-lg cursor-move w-full ${
 								draggedIndex === index
 									? "opacity-50"

--- a/frontend/src/pages/Packages.jsx
+++ b/frontend/src/pages/Packages.jsx
@@ -747,7 +747,23 @@ const Packages = () => {
 					isHostScoped ? "sm:grid-cols-3" : "sm:grid-cols-4 lg:grid-cols-5"
 				}`}
 			>
-				<div className="card p-4 cursor-pointer hover:shadow-card-hover dark:hover:shadow-card-hover-dark transition-shadow duration-200">
+				<button
+					type="button"
+					onClick={() => {
+						setUpdateStatusFilter("all-packages");
+						setCategoryFilter("all");
+						setSearchTerm("");
+						const next = new URLSearchParams(searchParams);
+						next.delete("filter");
+						setSearchParams(next, { replace: true });
+					}}
+					className="card p-4 cursor-pointer hover:shadow-card-hover dark:hover:shadow-card-hover-dark transition-shadow duration-200 text-left w-full min-h-[44px]"
+					title={
+						isHostScoped
+							? "Click to show all of this host's packages"
+							: "Click to show all packages"
+					}
+				>
 					<div className="flex items-center">
 						<Package className="h-5 w-5 text-primary-600 mr-2" />
 						<div>
@@ -759,10 +775,10 @@ const Packages = () => {
 							</p>
 						</div>
 					</div>
-				</div>
+				</button>
 
 				{!isHostScoped && (
-					<div className="card p-4 cursor-pointer hover:shadow-card-hover dark:hover:shadow-card-hover-dark transition-shadow duration-200">
+					<div className="card p-4">
 						<div className="flex items-center">
 							<Package className="h-5 w-5 text-blue-600 mr-2" />
 							<div>

--- a/frontend/src/pages/Repositories.jsx
+++ b/frontend/src/pages/Repositories.jsx
@@ -985,6 +985,10 @@ const ColumnSettingsModal = ({
 		setDraggedIndex(null);
 	};
 
+	const handleDragEnd = () => {
+		setDraggedIndex(null);
+	};
+
 	return (
 		<div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
 			<div className="bg-white dark:bg-secondary-800 rounded-lg p-6 w-full max-w-md">
@@ -1012,6 +1016,7 @@ const ColumnSettingsModal = ({
 							onDragStart={(e) => handleDragStart(e, index)}
 							onDragOver={handleDragOver}
 							onDrop={(e) => handleDrop(e, index)}
+							onDragEnd={handleDragEnd}
 							className="flex items-center justify-between p-3 bg-secondary-50 dark:bg-secondary-700 rounded-lg cursor-move hover:bg-secondary-100 dark:hover:bg-secondary-600 transition-colors w-full"
 						>
 							<div className="flex items-center gap-3">

--- a/server-source-code/internal/agents/direct_host_auto_enroll.sh
+++ b/server-source-code/internal/agents/direct_host_auto_enroll.sh
@@ -94,7 +94,22 @@ echo ""
 info "Gathering host information..."
 
 # Get hostname
-hostname=$(hostname)
+hostname=""
+if command -v hostname >/dev/null 2>&1; then
+    hostname=$(hostname 2>/dev/null || echo "")
+fi
+if [ -z "$hostname" ] && command -v hostnamectl >/dev/null 2>&1; then
+    hostname=$(hostnamectl --static 2>/dev/null || echo "")
+fi
+if [ -z "$hostname" ] && [ -f /etc/hostname ]; then
+    hostname=$(head -n 1 /etc/hostname 2>/dev/null || echo "")
+fi
+if [ -z "$hostname" ]; then
+    hostname=$(uname -n 2>/dev/null || echo "")
+fi
+if [ -z "$hostname" ]; then
+    error "Could not determine hostname. Install 'hostname' or set /etc/hostname, then retry."
+fi
 
 # Use FRIENDLY_NAME env var if provided, otherwise use hostname
 if [ -n "$FRIENDLY_NAME" ]; then
@@ -119,7 +134,23 @@ if [ -f /etc/os-release ]; then
 fi
 
 # Get IP address (first non-loopback)
-ip_address=$(hostname -I 2>/dev/null | awk '{print $1}' || echo "unknown")
+ip_address=""
+if command -v hostname >/dev/null 2>&1; then
+    ip_address=$(hostname -I 2>/dev/null | awk '{print $1}' || echo "")
+fi
+if [ -z "$ip_address" ] && command -v ip >/dev/null 2>&1; then
+    ip_address=$(ip route get 1.1.1.1 2>/dev/null | awk '{for (i = 1; i < NF; i++) if ($i == "src") { print $(i + 1); exit }}' || echo "")
+    if [ -z "$ip_address" ]; then
+        ip_address=$(ip -4 -o addr show scope global 2>/dev/null | awk '{print $4}' | cut -d'/' -f1 | head -n 1 || echo "")
+    fi
+fi
+if [ -z "$ip_address" ] && command -v ifconfig >/dev/null 2>&1; then
+    ip_address=$(ifconfig 2>/dev/null | awk '/inet /{addr = $2; sub(/^addr:/, "", addr); if (addr !~ /^127\./) { print addr; exit }}' || echo "")
+fi
+if [ -z "$ip_address" ]; then
+    warn "Could not determine an IP address for this host"
+    ip_address="unknown"
+fi
 
 # Detect architecture
 arch_raw=$(uname -m 2>/dev/null || echo "unknown")

--- a/server-source-code/internal/agents/proxmox_auto_enroll.sh
+++ b/server-source-code/internal/agents/proxmox_auto_enroll.sh
@@ -150,7 +150,11 @@ while IFS= read -r line; do
     # Get container details
     debug "  Gathering container information..."
     hostname=$(timeout 5 pct exec "$vmid" -- hostname 2>/dev/null </dev/null || echo "$name")
-    ip_address=$(timeout 5 pct exec "$vmid" -- hostname -I 2>/dev/null </dev/null | awk '{print $1}' || echo "unknown")
+    ip_address=$(timeout 5 pct exec "$vmid" -- hostname -I 2>/dev/null </dev/null | awk '{print $1}' || echo "")
+    if [ -z "$ip_address" ]; then
+        ip_address=$(timeout 5 pct exec "$vmid" -- ip route get 1.1.1.1 2>/dev/null </dev/null | awk '{for (i = 1; i < NF; i++) if ($i == "src") { print $(i + 1); exit }}' || echo "")
+    fi
+    [ -n "$ip_address" ] || ip_address="unknown"
     os_info=$(timeout 5 pct exec "$vmid" -- cat /etc/os-release 2>/dev/null </dev/null | grep "^PRETTY_NAME=" | cut -d'"' -f2 || echo "unknown")
     
     # Detect container architecture

--- a/server-source-code/internal/handler/common.go
+++ b/server-source-code/internal/handler/common.go
@@ -17,17 +17,41 @@ func hostFromRequest(r *http.Request) string {
 	return strings.TrimSpace(r.Header.Get("X-Forwarded-Host"))
 }
 
+// passwordPolicy is the client-side validation shape shared with the login and
+// first-time setup screens.
+type passwordPolicy struct {
+	MinLength        int  `json:"min_length"`
+	RequireUppercase bool `json:"require_uppercase"`
+	RequireLowercase bool `json:"require_lowercase"`
+	RequireNumber    bool `json:"require_number"`
+	RequireSpecial   bool `json:"require_special"`
+}
+
+// resolvePasswordPolicy reads the policy from resolved config, falling back to
+// the built-in defaults when no config resolves.
+func resolvePasswordPolicy(resolved *config.ResolvedConfig) passwordPolicy {
+	p := passwordPolicy{
+		MinLength:        8,
+		RequireUppercase: true,
+		RequireLowercase: true,
+		RequireNumber:    true,
+		RequireSpecial:   true,
+	}
+	if resolved != nil {
+		p.MinLength = resolved.PasswordMinLength
+		p.RequireUppercase = resolved.PasswordRequireUppercase
+		p.RequireLowercase = resolved.PasswordRequireLowercase
+		p.RequireNumber = resolved.PasswordRequireNumber
+		p.RequireSpecial = resolved.PasswordRequireSpecial
+	}
+	return p
+}
+
 // ValidatePasswordPolicy checks password against resolved config. Returns descriptive error.
 func ValidatePasswordPolicy(resolved *config.ResolvedConfig, password string) error {
-	minLen := 8
-	needUpper, needLower, needNum, needSpecial := true, true, true, true
-	if resolved != nil {
-		minLen = resolved.PasswordMinLength
-		needUpper = resolved.PasswordRequireUppercase
-		needLower = resolved.PasswordRequireLowercase
-		needNum = resolved.PasswordRequireNumber
-		needSpecial = resolved.PasswordRequireSpecial
-	}
+	policy := resolvePasswordPolicy(resolved)
+	minLen := policy.MinLength
+	needUpper, needLower, needNum, needSpecial := policy.RequireUppercase, policy.RequireLowercase, policy.RequireNumber, policy.RequireSpecial
 	if len(password) < minLen {
 		return fmt.Errorf("password must be at least %d characters", minLen)
 	}

--- a/server-source-code/internal/handler/password_policy_test.go
+++ b/server-source-code/internal/handler/password_policy_test.go
@@ -1,0 +1,76 @@
+package handler
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/PatchMon/PatchMon/server-source-code/internal/config"
+)
+
+// TestResolvePasswordPolicy_UsesResolvedConfig guards the login-settings payload
+// against drifting from what ValidatePasswordPolicy enforces.
+func TestResolvePasswordPolicy_UsesResolvedConfig(t *testing.T) {
+	t.Parallel()
+
+	resolved := &config.ResolvedConfig{
+		PasswordMinLength:        12,
+		PasswordRequireUppercase: false,
+		PasswordRequireLowercase: true,
+		PasswordRequireNumber:    false,
+		PasswordRequireSpecial:   false,
+	}
+	got := resolvePasswordPolicy(resolved)
+	want := passwordPolicy{
+		MinLength:        12,
+		RequireUppercase: false,
+		RequireLowercase: true,
+		RequireNumber:    false,
+		RequireSpecial:   false,
+	}
+	if got != want {
+		t.Fatalf("resolvePasswordPolicy() = %+v, want %+v", got, want)
+	}
+
+	// A password the emitted policy accepts must also pass server-side validation.
+	if err := ValidatePasswordPolicy(resolved, "abcdefghijkl"); err != nil {
+		t.Errorf("password allowed by the emitted policy must validate, got %v", err)
+	}
+}
+
+// TestResolvePasswordPolicy_DefaultsWithoutConfig covers the no-settings-row branch.
+func TestResolvePasswordPolicy_DefaultsWithoutConfig(t *testing.T) {
+	t.Parallel()
+
+	want := passwordPolicy{
+		MinLength:        8,
+		RequireUppercase: true,
+		RequireLowercase: true,
+		RequireNumber:    true,
+		RequireSpecial:   true,
+	}
+	if got := resolvePasswordPolicy(nil); got != want {
+		t.Fatalf("resolvePasswordPolicy(nil) = %+v, want %+v", got, want)
+	}
+}
+
+// TestPasswordPolicyJSONKeys pins the field names the first-time setup wizard reads.
+func TestPasswordPolicyJSONKeys(t *testing.T) {
+	t.Parallel()
+
+	b, err := json.Marshal(resolvePasswordPolicy(nil))
+	if err != nil {
+		t.Fatalf("marshal password policy: %v", err)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal password policy: %v", err)
+	}
+	if _, ok := got["min_length"].(float64); !ok {
+		t.Errorf("min_length must be a number, payload is %s", b)
+	}
+	for _, key := range []string{"require_uppercase", "require_lowercase", "require_number", "require_special"} {
+		if _, ok := got[key].(bool); !ok {
+			t.Errorf("%s must be a boolean, payload is %s", key, b)
+		}
+	}
+}

--- a/server-source-code/internal/handler/settings.go
+++ b/server-source-code/internal/handler/settings.go
@@ -253,6 +253,14 @@ func (h *SettingsHandler) isDiscordProperlyConfigured(s *models.Settings) bool {
 	return err == nil
 }
 
+// resolvedConfigFor resolves config from a freshly read settings row rather than h.resolved.
+func (h *SettingsHandler) resolvedConfigFor(ctx context.Context, s *models.Settings) *config.ResolvedConfig {
+	if h.cfg == nil {
+		return h.resolved
+	}
+	return config.ResolveConfig(ctx, h.cfg, s)
+}
+
 // GetLoginSettings handles GET /settings/login-settings (public, used by login screen and first-time admin setup).
 // Includes has_admin_users and oidc fields for first-time setup flow (replaces /auth/check-admin-users).
 func (h *SettingsHandler) GetLoginSettings(w http.ResponseWriter, r *http.Request) {
@@ -293,6 +301,7 @@ func (h *SettingsHandler) GetLoginSettings(w http.ResponseWriter, r *http.Reques
 				"autoCreateUsers":  false,
 				"canBypassWelcome": false,
 			},
+			"password_policy": resolvePasswordPolicy(h.resolvedConfigFor(r.Context(), nil)),
 		})
 		return
 	}
@@ -349,6 +358,7 @@ func (h *SettingsHandler) GetLoginSettings(w http.ResponseWriter, r *http.Reques
 			"autoCreateUsers":  s.OidcAutoCreateUsers,
 			"canBypassWelcome": canBypassWelcome,
 		},
+		"password_policy": resolvePasswordPolicy(h.resolvedConfigFor(r.Context(), s)),
 	})
 }
 

--- a/tools/migrate1-4-2_to_2-0-0.sh
+++ b/tools/migrate1-4-2_to_2-0-0.sh
@@ -237,30 +237,17 @@ elif [[ "$OLD_FRONTEND_HOST_PORT" == "3000" ]]; then
 else
     echo "  Custom frontend host port detected: ${OLD_FRONTEND_HOST_PORT}"
 
-    # Patch the server.ports line in the new compose file:
-    #   "3000:3000"  →  "<custom>:3000"
-    # Uses awk to scope the replacement strictly within the "server:" service
-    # block, so no other service's ports line is ever touched.
-    awk -v port="${OLD_FRONTEND_HOST_PORT}" '
-        /^  server:$/         { in_server=1 }
-        in_server && /^  [a-z]/ && !/^  server:$/ { in_server=0 }
-        in_server             { sub(/"3000:3000"/, "\"" port ":3000\"") }
-        { print }
-    ' docker-compose.yml > docker-compose.yml.tmp && mv docker-compose.yml.tmp docker-compose.yml
-    echo "  Updated docker-compose.yml server ports: \"${OLD_FRONTEND_HOST_PORT}:3000\""
-
-    # Also write PORT= into the new .env so the Go server binds to the right port
-    # inside the container (the container-side port stays 3000 in this model, but
-    # set it explicitly so it is visible to the user).
+    # The compose port mapping follows PORT, so carrying the old host port
+    # through .env is all that is needed.
     if grep -q "^#\?[[:space:]]*PORT=" "$NEW_ENV"; then
-        sed -i "s|^#\?[[:space:]]*PORT=.*|PORT=3000|" "$NEW_ENV"
+        sed -i "s|^#\?[[:space:]]*PORT=.*|PORT=${OLD_FRONTEND_HOST_PORT}|" "$NEW_ENV"
     else
-        echo "PORT=3000" >> "$NEW_ENV"
+        echo "PORT=${OLD_FRONTEND_HOST_PORT}" >> "$NEW_ENV"
     fi
-    echo "  Ensured PORT=3000 is set in .env (container-internal port)."
+    echo "  Set PORT=${OLD_FRONTEND_HOST_PORT} in .env."
     echo ""
-    echo "  NOTE: The server container now listens internally on port 3000 and is"
-    echo "  exposed to your host on port ${OLD_FRONTEND_HOST_PORT}."
+    echo "  NOTE: The server container listens on port ${OLD_FRONTEND_HOST_PORT} and is"
+    echo "  exposed to your host on the same port."
     echo "  Update CORS_ORIGIN in .env to use port ${OLD_FRONTEND_HOST_PORT} if it"
     echo "  references the old port."
 fi


### PR DESCRIPTION
Ten small, independent bug fixes, one commit each. All were confirmed still present on `main` before any code was written, as part of a sweep over the open issue list.

| Issue | Fix |
|---|---|
| #765 | guacd pinned to a tag that publishes an arm64 image |
| #767 | the published Docker port follows `PORT` |
| #696 | the login endpoint returns the resolved password policy |
| #936 | auto-enrolment no longer assumes `hostname(1)` is installed |
| #859 | Rocky's SCAP content is found under its `rl` product name |
| #776 | apt patch runs no longer stall on a dpkg conffile prompt |
| #872 | deb822 field names are matched case-insensitively |
| #952 | the Connection Status card filters the host list |
| #673 | the Packages summary cards no longer offer a click that does nothing |
| #678 | the column picker clears its drag state when a reorder is abandoned |

### Notes on three of them

**#765** is a version pin, not a bump for its own sake. `guacamole/guacd:latest` and `1.5.5` publish `amd64` only, and the server has a hard `depends_on: guacd: condition: service_healthy`, so the whole stack failed to start on arm64. `1.6.0` is the first tag with an arm64 manifest. The eight `1.5.5` references in the docs are updated to match.

**#767** turned out to reach further than the compose file. The 1.4.2 migration script rewrites the literal `"3000:3000"` in the compose file it downloads at runtime, so making the mapping dynamic would have silently discarded a custom port on migration. That rewrite is now redundant and has been removed; the old host port is carried through `PORT` instead.

**#859** grew once the product names were checked against the live ComplianceAsCode list rather than assumed. Rocky was the reported case, but `sles` was building `ssg-sles15-ds.xml` when the product is `sle15`, and the legacy `alma` path was building `ssg-alma8-ds.xml` when only `almalinux9` exists. Both were broken the same way. `centos` to `cs` was considered and rejected, because no such product exists. The version-match check had to move with it, otherwise Rocky 9.5 would find `ssg-rl9-ds.xml` and then immediately report it as a content mismatch.

### Checks

`make check` clean in both `agent-source-code` and `server-source-code`, Biome clean over `frontend/src`, `sh -n` clean on both enrolment scripts and `bash -n` on the migration script.

New tests cover the SSG filename candidates and version matching, the deb822 field casing, the apt argument builders, and the password policy JSON shape.

### Review notes

An independent review of this branch found two problems that are fixed here, both worth knowing about:

- The first draft of #936 dropped an `|| echo` guard in `proxmox_auto_enroll.sh`, which runs under `set -eo pipefail`. A container missing `hostname` would have aborted the entire enrolment run rather than degrading to `unknown`, leaving every later container un-enrolled. Reproduced with a failing `pct` stub, then fixed.
- The migration script problem described under #767 above.

`docker-compose.dev.yml` deliberately keeps its hardcoded mapping, since it sets environment inline rather than through `env_file`.

---

Closes #765, closes #767, closes #696, closes #936, closes #859, closes #776, closes #872, closes #952, closes #673, closes #678.
