### PR TITLE
Stop misreading successful dry runs as patch validation failures

### DIFF
--- a/agent-source-code/cmd/patchmon-agent/commands/serve.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/serve.go
@@ -2003,25 +2003,54 @@ func connectOnce(out chan<- wsMsg, dockerEvents <-chan interface{}, backoff *tim
 	}
 }
 
-// dryRunOutputIndicatesError returns true if the output contains dependency or
-// resolution error messages. Used to distinguish "declined" (exit 1, success)
-// from actual dependency/validation failures (exit 1, failure).
+// dryRunErrorLinePrefixes must open a line to count. Package names contain
+// these substrings: FreeBSD pkg lists "libgpg-error: 1.51" and a dnf table row
+// carries perl-Error, neither of which is a failure.
+var dryRunErrorLinePrefixes = []string{
+	"error:", "error ",
+}
+
+// dryRunErrorPhrases count anywhere in the output. Each is specific enough that
+// it cannot occur in a package name or a table column, so they carry the cases
+// where a tool does not open the line with Error:.
+var dryRunErrorPhrases = []string{
+	"transaction check error",
+	"depsolve error",
+	"failed to resolve the transaction",
+	"no match for argument",
+	"unable to find a match",
+	"unable to resolve",
+	"no packages available to install",
+	"cannot solve problem using sat solver",
+	"cannot find package",
+	"could not find",
+	"could not satisfy dependencies",
+	"unresolvable package conflicts",
+	"failed to prepare transaction",
+	"failed to commit transaction",
+	"failed to synchronize",
+}
+
+// dryRunOutputIndicatesError returns true if the output reports a dependency or
+// resolution failure. Used to distinguish "declined" (exit 1, success) from an
+// actual failure (exit 1, failure).
+//
+// A bare "Problem:" is deliberately absent: dnf opens one when it skips a
+// broken package and then resolves the rest, which is a successful dry run. A
+// fatal dnf problem is introduced by an "Error:" line.
 func dryRunOutputIndicatesError(output string) bool {
 	lower := strings.ToLower(output)
-	errorPatterns := []string{
-		"error:", "error ", "unable to find", "unable to resolve", "no match for",
-		"problem:", "transaction check error", "cannot install", "could not find",
-		"failed to synchronize", "dependency resolution", "conflict",
-		"no packages available to install", "pkg: no packages available",
-		"cannot find package",
-		// pacman-specific
-		"error: failed to prepare transaction", "could not satisfy dependencies",
-		"failed to commit transaction", "error: target not found",
-		"unresolvable package conflicts",
-	}
-	for _, p := range errorPatterns {
+	for _, p := range dryRunErrorPhrases {
 		if strings.Contains(lower, p) {
 			return true
+		}
+	}
+	for _, line := range strings.FieldsFunc(lower, func(r rune) bool { return r == '\n' || r == '\r' }) {
+		l := strings.TrimSpace(line)
+		for _, p := range dryRunErrorLinePrefixes {
+			if strings.HasPrefix(l, p) {
+				return true
+			}
 		}
 	}
 	return false
@@ -2033,7 +2062,7 @@ func dryRunOutputIndicatesError(output string) bool {
 // dry-run); we treat that as success. But if the output contains error messages
 // (e.g. "Unable to resolve", "Problem:"), we treat it as failure.
 func isDryRunExit1Success(err error, output string) bool {
-	if output == "" {
+	if strings.TrimSpace(output) == "" {
 		return false
 	}
 	if dryRunOutputIndicatesError(output) {
@@ -2152,6 +2181,11 @@ func (s *streamSink) Flush() {
 	s.lastFlush = time.Now()
 	s.mu.Unlock()
 
+	// A sink with no client only accumulates.
+	if s.client == nil {
+		return
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	if err := s.client.SendPatchOutput(ctx, s.patchRunID, "progress", chunk, ""); err != nil {
@@ -2162,7 +2196,12 @@ func (s *streamSink) Flush() {
 // runStreamingPatchStep executes a command, streaming its stdout+stderr into
 // the provided sink. On context cancellation it sends SIGINT and allows
 // WaitDelay for the process to clean up (rollbacks etc.) before forcing a kill.
-func runStreamingPatchStep(ctx context.Context, sink *streamSink, env []string, name string, args ...string) error {
+//
+// It also returns the step's own output, stdout then stderr, each kept whole
+// rather than interleaved chronologically. The sink mixes both pipes at
+// arbitrary byte boundaries, which is fine for a terminal view but splices
+// lines together, so anything parsing the result must read this copy.
+func runStreamingPatchStep(ctx context.Context, sink *streamSink, env []string, name string, args ...string) (string, error) {
 	cmd := exec.CommandContext(ctx, name, args...)
 	cmd.Env = env
 	cmd.Cancel = func() error {
@@ -2177,18 +2216,21 @@ func runStreamingPatchStep(ctx context.Context, sink *streamSink, env []string, 
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		return fmt.Errorf("stdout pipe: %w", err)
+		return "", fmt.Errorf("stdout pipe: %w", err)
 	}
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
-		return fmt.Errorf("stderr pipe: %w", err)
+		return "", fmt.Errorf("stderr pipe: %w", err)
 	}
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("start: %w", err)
+		return "", fmt.Errorf("start: %w", err)
 	}
 
+	// One builder per pipe, each written by a single goroutine, so lines within
+	// a stream stay intact even though the sink interleaves them.
+	var outCapture, errCapture strings.Builder
 	var wg sync.WaitGroup
-	copyPipe := func(rc io.ReadCloser) {
+	copyPipe := func(rc io.ReadCloser, capture *strings.Builder) {
 		defer wg.Done()
 		br := bufio.NewReader(rc)
 		buf := make([]byte, 4096)
@@ -2196,6 +2238,7 @@ func runStreamingPatchStep(ctx context.Context, sink *streamSink, env []string, 
 			n, readErr := br.Read(buf)
 			if n > 0 {
 				_, _ = sink.Write(buf[:n])
+				capture.Write(buf[:n])
 			}
 			if readErr != nil {
 				return
@@ -2203,13 +2246,13 @@ func runStreamingPatchStep(ctx context.Context, sink *streamSink, env []string, 
 		}
 	}
 	wg.Add(2)
-	go copyPipe(stdout)
-	go copyPipe(stderr)
+	go copyPipe(stdout, &outCapture)
+	go copyPipe(stderr, &errCapture)
 	wg.Wait()
 
 	waitErr := cmd.Wait()
 	sink.Flush()
-	return waitErr
+	return outCapture.String() + "\n" + errCapture.String(), waitErr
 }
 
 // patchRunTrailer returns a short human-readable trailer the agent appends to
@@ -2321,6 +2364,15 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 		upgradeBin = pkgManager
 	}
 
+	// Dry-run classification reads the package manager's own wording, so pin the
+	// message locale. Not LC_ALL: that also pins LC_CTYPE, and yum 3 on RHEL 7
+	// and Amazon Linux 2 runs on Python 2.7, which then falls back to ascii and
+	// dies on non-ASCII repo metadata.
+	if env == nil {
+		env = os.Environ()
+	}
+	env = append(env, "LC_MESSAGES=C")
+
 	if err := httpClient.SendPatchOutput(ctx, patchRunID, "started", "", ""); err != nil {
 		logger.WithError(err).Warn("Failed to send patch started to server")
 	}
@@ -2332,14 +2384,21 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 	// runStep streams a single package-manager command's output and returns
 	// (terminalError, shouldAbort). If isDryRunStep is true, exit-1 from tools
 	// that use it to signal "changes pending" is accepted as success.
+	// lastStepOutput holds the framed output of the step that just ran, for
+	// callers that parse it. Reading the sink instead would splice lines.
+	var lastStepOutput string
 	runStep := func(isDryRunStep bool, errTag, errFmt, name string, args ...string) (error, bool) {
 		sink.WriteString(formatCmd(name, args...))
 		sink.Flush()
-		err := runStreamingPatchStep(ctx, sink, env, name, args...)
+		stepOutput, err := runStreamingPatchStep(ctx, sink, env, name, args...)
+		lastStepOutput = stepOutput
 		if err == nil {
 			return nil, false
 		}
-		if isDryRunStep && isDryRunExit1Success(err, fullOutput.String()) {
+		// Classify this step's own output. An earlier step's diagnostics, such as
+		// pacman reporting a dead mirror it then recovered from, are not this
+		// step's failure.
+		if isDryRunStep && isDryRunExit1Success(err, stepOutput) {
 			return nil, false
 		}
 		logger.WithError(err).Warn(errTag + " failed")
@@ -2351,15 +2410,10 @@ func runPatch(patchRunID, patchType string, packageNames []string, dryRun bool) 
 	var stepErr error
 
 	if includeFreeBSDBase {
-		fetchStart := fullOutput.Len()
 		if err, abort := runStep(false, "freebsd-update fetch", "freebsd-update fetch failed: %w", freeBSDUpdateBin, "fetch", "--not-running-from-cron"); abort {
 			stepErr = err
 		}
-		fetchOutput := ""
-		if fullOutput.Len() > fetchStart {
-			fetchOutput = fullOutput.String()[fetchStart:]
-		}
-		if stepErr == nil && !dryRun && freeBSDUpdateOutputHasPendingUpdates(fetchOutput) {
+		if stepErr == nil && !dryRun && freeBSDUpdateOutputHasPendingUpdates(lastStepOutput) {
 			if err, abort := runStep(false, "freebsd-update install", "freebsd-update install failed: %w", freeBSDUpdateBin, "install"); abort {
 				stepErr = err
 			}

--- a/agent-source-code/cmd/patchmon-agent/commands/serve_dryrun_test.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/serve_dryrun_test.go
@@ -1,0 +1,212 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestDryRunOutputIndicatesError(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{
+			name: "yum declines and reports success",
+			output: `Loaded plugins: extras_suggestions, langpacks, priorities, update-motd
+239 packages excluded due to repository priority protections
+Resolving Dependencies
+--> Running transaction check
+---> Package vim-common.x86_64 2:9.0.2153-1.amzn2.0.4 will be updated
+---> Package vim-common.x86_64 2:9.0.2153-1.amzn2.0.6 will be an update
+--> Finished Dependency Resolution
+
+Dependencies Resolved
+
+Transaction Summary
+================================================================================
+Upgrade  5 Packages
+
+Total download size: 11 M
+Exiting on user command
+Your transaction was saved, rerun it with:
+ yum load-transaction /tmp/yum_save_tx.yumtx`,
+			want: false,
+		},
+		{
+			name: "package named like an error is not an error",
+			output: `Updating:
+ libgpg-error       x86_64   1.42-1.el8      baseos      250 k
+ perl-Error         noarch   1:0.17025-2     appstream    46 k
+Operation aborted.`,
+			want: false,
+		},
+		{
+			name: "dnf declines and reports success",
+			output: `Last metadata expiration check: 0:12:31 ago.
+Dependencies resolved.
+================================================================================
+ Package        Arch     Version            Repository   Size
+================================================================================
+Upgrading:
+ curl           x86_64   7.76.1-26.el9      baseos      301 k
+
+Transaction Summary
+Upgrade  1 Package
+
+Operation aborted.`,
+			want: false,
+		},
+		{
+			name: "pacman print target list is not an error",
+			output: `core/glibc 2.39-2
+extra/vim 9.1.0-1`,
+			want: false,
+		},
+		{
+			name: "yum dependency failure",
+			output: `--> Finished Dependency Resolution
+Error: Package: vim-enhanced-2:9.0.2153-1.amzn2.0.6.x86_64 (amzn2-core)
+           Requires: vim-common = 2:9.0.2153-1.amzn2.0.6
+ You could try using --skip-broken to work around the problem`,
+			want: true,
+		},
+		{
+			name: "yum transaction check error",
+			output: `Transaction Check Error:
+  file /usr/bin/vim from install of vim conflicts with file from package vim-minimal`,
+			want: true,
+		},
+		{
+			name: "dnf problem block",
+			output: `Error:
+ Problem: package foo-1.0-1.el9.x86_64 requires bar >= 2.0, but none of the providers can be installed`,
+			want: true,
+		},
+		{
+			name:   "dnf no match for argument",
+			output: "No match for argument: nosuchpackage\nError: Unable to find a match: nosuchpackage",
+			want:   true,
+		},
+		{
+			name:   "pacman target not found",
+			output: "error: target not found: nosuchpackage",
+			want:   true,
+		},
+		{
+			name:   "pacman unresolvable conflicts",
+			output: "error: unresolvable package conflicts detected\nerror: failed to prepare transaction (conflicting dependencies)",
+			want:   true,
+		},
+		{
+			name:   "pkg no packages available",
+			output: "pkg: No packages available to install matching 'nosuchpackage' have been found in the repositories",
+			want:   true,
+		},
+		{
+			name: "pkg lists a package whose name ends in error",
+			output: `Updating database digests format: 100%
+The following 2 package(s) will be affected (of 0 checked):
+
+Installed packages to be UPGRADED:
+	libgpg-error: 1.51 -> 1.52
+	curl: 8.11.0 -> 8.11.1
+
+Number of packages to be upgraded: 2`,
+			want: false,
+		},
+		{
+			name: "dnf skips a broken package and resolves the rest",
+			output: `Last metadata expiration check: 0:12:31 ago.
+Problem: cannot install the best update candidate for package kernel-5.14.0-70.el9.x86_64
+  - nothing provides kernel-core = 5.14.0-427 needed by kernel-5.14.0-427.el9.x86_64
+Upgrading:
+ curl        x86_64  7.76.1-26.el9   baseos  301 k
+Skipping packages with broken dependencies:
+ kernel      x86_64  5.14.0-427.el9  baseos  1.2 M
+
+Transaction Summary
+Upgrade  1 Package
+Skip     1 Package
+
+Operation aborted.`,
+			want: false,
+		},
+		{
+			name:   "dnf5 transaction failure",
+			output: "Failed to resolve the transaction:\nProblem: package foo requires bar, but none of the providers can be installed",
+			want:   true,
+		},
+		{
+			name:   "empty output",
+			output: "",
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := dryRunOutputIndicatesError(tt.output); got != tt.want {
+				t.Fatalf("dryRunOutputIndicatesError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsDryRunExit1Success(t *testing.T) {
+	exit1 := func() error {
+		err := exec.Command("sh", "-c", "exit 1").Run()
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) {
+			t.Fatalf("expected an ExitError, got %v", err)
+		}
+		return err
+	}()
+
+	declined := "--> Finished Dependency Resolution\nExiting on user command"
+	if !isDryRunExit1Success(exit1, declined) {
+		t.Error("a declined yum dry run should count as success")
+	}
+	if isDryRunExit1Success(exit1, "Error: Package: foo requires bar") {
+		t.Error("a genuine dependency failure should not count as success")
+	}
+	if isDryRunExit1Success(exit1, "") {
+		t.Error("empty output should not count as success")
+	}
+	// runStreamingPatchStep joins its two captures with a newline, so a silent
+	// command yields "\n" rather than "".
+	if isDryRunExit1Success(exit1, "\n") {
+		t.Error("a silent command should not count as success")
+	}
+	if isDryRunExit1Success(nil, declined) {
+		t.Error("a nil error is not an exit-1 decline")
+	}
+}
+
+// The sink interleaves stdout and stderr at byte boundaries, which splices a
+// stderr diagnostic onto the tail of a partial stdout line. Classification must
+// read the returned copy, where each stream is whole.
+func TestRunStreamingPatchStepKeepsEachStreamWhole(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses a POSIX shell")
+	}
+
+	var full strings.Builder
+	sink := newStreamSink(nil, "test-run", &full)
+
+	out, err := runStreamingPatchStep(context.Background(), sink, nil, "sh", "-c",
+		`printf 'Total download size: 11 M'; printf 'Error: Package: foo requires bar\n' >&2; exit 1`)
+	if err == nil {
+		t.Fatal("expected the command to exit non-zero")
+	}
+	if !strings.Contains(out, "\nError: Package: foo requires bar") {
+		t.Errorf("stderr diagnostic did not start a line in the returned output: %q", out)
+	}
+	if !dryRunOutputIndicatesError(out) {
+		t.Errorf("genuine failure classified as success: %q", out)
+	}
+}


### PR DESCRIPTION
Patch validation failed on Amazon Linux 2 whatever packages were selected. The dry run resolved correctly, printed its plan, declined at `--assumeno` and exited 1, which is the expected shape for a dry run, but the agent classified it as a failure.

### Why

`dryRunOutputIndicatesError` matched its patterns anywhere in the output rather than at the start of a line. Three of them fire on healthy output:

- `dependency resolution` matches yum 3's ordinary success line `--> Finished Dependency Resolution`. That breaks every yum 3 dry run: Amazon Linux 2, CentOS 7, RHEL 7, Oracle Linux 7.
- `error ` matches any package whose name ends in `error`. `libgpg-error` is on virtually every RHEL-family host, and FreeBSD pkg lists it as `libgpg-error: 1.51`, so this reaches dnf and pkg too.
- A bare `Problem:` flags dnf skipping a broken package and resolving the rest, which is a successful dry run.

### The fix

Matching is now an anchored `Error:` prefix plus a list of unanchored phrases specific enough that they cannot occur in a package name. `dependency resolution`, bare `conflict`, `Problem:` and `cannot install` are dropped: a fatal problem is always introduced by an `Error:` line, which is still caught.

Anchoring only holds if the input is framed by lines, and it was not. The sink mixes stdout and stderr at arbitrary byte boundaries, so a stderr diagnostic could land mid-line and never reach the start of one. Each pipe is now captured separately and everything that parses a step reads that copy. Two things fall out of it: a verdict is scoped to its own step, so an earlier recovered mirror error cannot fail a later one, and the FreeBSD base path stops reading spliced text, where a splice could make the agent skip `freebsd-update install` and still report success.

The message locale is pinned so the wording the classifier depends on is stable. `LC_MESSAGES` rather than `LC_ALL`, because `LC_ALL` would also pin `LC_CTYPE` and yum 3 runs on Python 2.7, which then falls back to ascii and dies on non-ASCII repo metadata, on exactly the platforms this fixes.

### Evidence

Old against new across 16 cases: **5 defects fixed, 0 regressions.** Four false positives (yum declining, `libgpg-error` in a dnf table, pkg's `libgpg-error: 1.51` listing, dnf skip-broken) and one false negative in an intermediate revision, pkg's SAT solver message, closed before merge. Every genuine failure case is detected identically before and after.

Both new false-positive tests fail against the previous implementation and pass now, so the behaviour is pinned rather than merely asserted.

The framing was measured on a replica of the copy loop rather than reasoned about:

```
sink    misclassified as SUCCESS:   95/200
capture correctly a FAILURE:       200/200
```

Cancellation was checked separately: the capture stays complete when the process is killed on deadline, and a cancelled step is never read as a successful dry run, because the error is not an exit-1.

### Checks

`make check` clean, `go test -race` clean including 200 iterations of the framing test.

### Known limitation, not introduced here

`WaitDelay` does not bound the read loop. `wg.Wait()` runs before `cmd.Wait()`, and WaitDelay's pipe closing only arms inside `cmd.Wait()`, so a grandchild holding the pipe write ends keeps the step running past both the context deadline and the 30 second delay. Measured at 8.01s against a 200ms deadline. Package managers spawn grandchildren routinely, rpm scriptlets and pacman hooks among them, so Stop can appear unresponsive mid-transaction. The structure is unchanged from `main` and the capture stays complete throughout, so it is out of scope here.

---

Closes #832.
