### PR TITLE
Let a patch step give up on a pipe a grandchild is holding

### DIFF
--- a/agent-source-code/cmd/patchmon-agent/commands/serve.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/serve.go
@@ -1,7 +1,6 @@
 package commands
 
 import (
-	"bufio"
 	"context"
 	"crypto/tls"
 	"encoding/base64"
@@ -2193,6 +2192,10 @@ func (s *streamSink) Flush() {
 	}
 }
 
+// patchStepWaitDelay is how long a step allows for the process to exit and then
+// for its pipes to close. A flush in flight can still outlast it. Set by tests.
+var patchStepWaitDelay = 30 * time.Second
+
 // runStreamingPatchStep executes a command, streaming its stdout+stderr into
 // the provided sink. On context cancellation it sends SIGINT and allows
 // WaitDelay for the process to clean up (rollbacks etc.) before forcing a kill.
@@ -2208,51 +2211,53 @@ func runStreamingPatchStep(ctx context.Context, sink *streamSink, env []string, 
 		if cmd.Process == nil {
 			return nil
 		}
-		// os.Interrupt maps to SIGINT on Unix; on Windows the runtime emulates
-		// a best-effort interrupt. Subsequent WaitDelay will SIGKILL if needed.
+		// SIGINT on Unix. Windows rejects any signal but Kill, so there the
+		// process dies when WaitDelay elapses instead.
 		return cmd.Process.Signal(os.Interrupt)
 	}
-	cmd.WaitDelay = 30 * time.Second
+	cmd.WaitDelay = patchStepWaitDelay
 
-	stdout, err := cmd.StdoutPipe()
-	if err != nil {
-		return "", fmt.Errorf("stdout pipe: %w", err)
-	}
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		return "", fmt.Errorf("stderr pipe: %w", err)
-	}
+	// exec must own the pipes: WaitDelay cannot close one returned by StdoutPipe.
+	outStream := &stepStream{sink: sink}
+	errStream := &stepStream{sink: sink}
+	cmd.Stdout = outStream
+	cmd.Stderr = errStream
 	if err := cmd.Start(); err != nil {
 		return "", fmt.Errorf("start: %w", err)
 	}
 
-	// One builder per pipe, each written by a single goroutine, so lines within
-	// a stream stay intact even though the sink interleaves them.
-	var outCapture, errCapture strings.Builder
-	var wg sync.WaitGroup
-	copyPipe := func(rc io.ReadCloser, capture *strings.Builder) {
-		defer wg.Done()
-		br := bufio.NewReader(rc)
-		buf := make([]byte, 4096)
-		for {
-			n, readErr := br.Read(buf)
-			if n > 0 {
-				_, _ = sink.Write(buf[:n])
-				capture.Write(buf[:n])
-			}
-			if readErr != nil {
-				return
-			}
-		}
-	}
-	wg.Add(2)
-	go copyPipe(stdout, &outCapture)
-	go copyPipe(stderr, &errCapture)
-	wg.Wait()
-
 	waitErr := cmd.Wait()
+	// The command exited cleanly and only its pipes outlived it, so this is not a
+	// step failure. The tail of the output is lost though, and a caller may be
+	// parsing it, so say so where an operator will see it. The notice goes to the
+	// sink rather than the returned copy, which is what gets parsed.
+	if errors.Is(waitErr, exec.ErrWaitDelay) {
+		sink.WriteString("\n[patchmon] gave up reading output: a child process is still holding it open\n")
+		waitErr = nil
+	}
 	sink.Flush()
-	return outCapture.String() + "\n" + errCapture.String(), waitErr
+	return outStream.captured() + "\n" + errStream.captured(), waitErr
+}
+
+// stepStream tees one of a command's output streams into the shared sink and
+// into a buffer of its own. exec gives each stream its own goroutine, so a
+// buffer has one writer and its lines stay whole even though the sink
+// interleaves the two streams.
+type stepStream struct {
+	sink *streamSink
+	buf  strings.Builder
+}
+
+func (s *stepStream) Write(p []byte) (int, error) {
+	_, _ = s.sink.Write(p)
+	s.buf.Write(p)
+	return len(p), nil
+}
+
+// captured is safe to call once cmd.Wait has returned, which joins the copy
+// goroutines on every path including the WaitDelay one.
+func (s *stepStream) captured() string {
+	return s.buf.String()
 }
 
 // patchRunTrailer returns a short human-readable trailer the agent appends to

--- a/agent-source-code/cmd/patchmon-agent/commands/serve_dryrun_test.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/serve_dryrun_test.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestDryRunOutputIndicatesError(t *testing.T) {
@@ -208,5 +209,50 @@ func TestRunStreamingPatchStepKeepsEachStreamWhole(t *testing.T) {
 	}
 	if !dryRunOutputIndicatesError(out) {
 		t.Errorf("genuine failure classified as success: %q", out)
+	}
+}
+
+// A package manager can leave a grandchild holding the output pipes open long
+// after it exits, for example an rpm scriptlet. The step must give up once
+// WaitDelay has elapsed rather than waiting for the grandchild, otherwise Stop
+// and the run timeout do nothing.
+func TestRunStreamingPatchStepGivesUpOnAHeldPipe(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses a POSIX shell")
+	}
+
+	restore := patchStepWaitDelay
+	patchStepWaitDelay = 500 * time.Millisecond
+	t.Cleanup(func() { patchStepWaitDelay = restore })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	var full strings.Builder
+	sink := newStreamSink(nil, "test-run", &full)
+
+	start := time.Now()
+	out, err := runStreamingPatchStep(ctx, sink, nil, "sh", "-c",
+		`sh -c 'sleep 5' & echo started; exit 0`)
+	elapsed := time.Since(start)
+
+	// Comfortably above the 500ms delay and below the grandchild's 5s, so this
+	// fires if the step ever goes back to waiting for the pipe to close.
+	if elapsed > 3*time.Second {
+		t.Fatalf("step waited %v for a held pipe; the context and WaitDelay were ignored", elapsed)
+	}
+	// The command exited 0. Only its pipes outlived it, so the step succeeded.
+	if err != nil {
+		t.Errorf("a held pipe should not fail a command that exited cleanly: %v", err)
+	}
+	if !strings.Contains(out, "started") {
+		t.Errorf("output written before the pipes were closed was lost: %q", out)
+	}
+	// The notice belongs in the terminal view, not in the copy callers parse.
+	if !strings.Contains(full.String(), "still holding it open") {
+		t.Errorf("truncation was not reported to the operator: %q", full.String())
+	}
+	if strings.Contains(out, "still holding it open") {
+		t.Error("the notice leaked into the parsed output")
 	}
 }


### PR DESCRIPTION
Stacked on #990, which rewrites the same function. Base is `fix/832-dry-run-error-detection` and GitHub will retarget this to `main` once #990 merges. Review only the single commit here.

### The bug

Pressing Stop, or a patch run hitting its timeout, did nothing for as long as something the package manager spawned kept the output pipes open. rpm scriptlets, pacman hooks and `freebsd-update` invoking `fetch` all do this routinely.

The step read `StdoutPipe` and `StderrPipe` itself and waited for both to reach EOF before calling `cmd.Wait()`. `WaitDelay` can only close pipes that `exec` owns, and a pipe returned by `StdoutPipe` belongs to the caller, so when a grandchild held the write end open the reads never finished, `cmd.Wait()` was never reached, and neither the context deadline nor the 30 second delay could intervene.

This is not something a shorter delay would have fixed. Measured against a 200 millisecond deadline with a grandchild living 8 seconds:

| `WaitDelay` | Returned after |
|---|---|
| 30s | 8.01s |
| 1s | 8.02s |
| 0 | 8.03s |

Identical regardless of the setting, because the delay never got a chance to act.

### The fix

`exec` now owns the pipes and the copying, so `WaitDelay` covers them, and `cmd.Wait()` is called with no blocking read in front of it. Same measurement afterwards returns in 1.00s with a 1 second delay.

Each stream is teed into the live sink and into a buffer of its own, keeping the contract added in #990 that the returned copy has each stream whole while the sink stays interleaved for the terminal view.

One consequence worth naming: a command that exits cleanly but outlives its pipes makes `Wait` return `ErrWaitDelay`. Left alone that would turn successful patch steps into failures, so it maps back to success. The tail of the output is lost in that case, and the FreeBSD base path decides whether to run `freebsd-update install` by matching that text, so the terminal gets an explicit notice instead of a silently skipped install. The notice goes to the sink only, never into the copy the parsers read.

### Evidence

The new test discriminates hard: **30.01s against the previous code, 0.51s after.** Confirmed independently in review, including with the shortened delay wired into the old shape so it had every chance to help.

Review also traced the Go 1.26.5 runtime rather than the documentation to confirm two things this depends on: `Wait` joins the copy goroutines on every path including the `WaitDelay` one, so reading the captures afterwards cannot race or truncate; and `ErrWaitDelay` is only ever returned when the process exited successfully, no cancel occurred and the watch error was nil, so mapping it to success cannot swallow a real failure.

Chunking changes from at most 4 KiB per write to at most 32 KiB, so bursty output produces fewer progress posts rather than more, well inside the body limit.

### Checks

`make check` clean, `go test -race -count=5` clean, and cross-builds pass for windows/amd64, windows/arm64, freebsd/amd64 and linux/arm, with `GOOS=windows go vet` clean. `runStreamingPatchStep` is unreachable on Windows at runtime, which returns earlier, but it still compiles and vets there.

---

Closes #991.
