### PR TITLE
fix(installer): detect whether systemd is running, not merely installed

### DIFF
--- a/server-source-code/internal/agents/patchmon_install.sh
+++ b/server-source-code/internal/agents/patchmon_install.sh
@@ -689,7 +689,9 @@ fi
 # Step 5: Setup service for WebSocket connection
 # Note: The service will automatically send an initial report on startup (see serve.go)
 # Detect init system and create appropriate service
-if command -v systemctl >/dev/null 2>&1; then
+# /run/systemd/system exists only when systemd is the running init. The
+# systemctl binary alone is also present when systemd is merely installed.
+if [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1; then
     # Systemd is available
     info "Setting up systemd service..."
     

--- a/server-source-code/internal/agents/patchmon_remove.sh
+++ b/server-source-code/internal/agents/patchmon_remove.sh
@@ -75,8 +75,10 @@ info "🗑️  Starting PatchMon Agent Removal..."
 info "🛑 Stopping PatchMon service..."
 SERVICE_STOPPED=0
 
-# Check for systemd service
-if command -v systemctl >/dev/null 2>&1; then
+# Check for systemd service. /run/systemd/system exists only when systemd is the
+# running init; the systemctl binary alone is also present when systemd is
+# merely installed, and every systemctl call then fails.
+if [ -d /run/systemd/system ] && command -v systemctl >/dev/null 2>&1; then
     info "📋 Checking systemd service status..."
     
     # Check if service is active


### PR DESCRIPTION
The installer decides which init system to target with:

```sh
if command -v systemctl >/dev/null 2>&1; then
```

That is true whenever the **systemd package is installed**, which is not the same as systemd being the **running init**. On a host where systemd is present but not pid 1, the installer commits to the systemd branch and then dies:

```
INFO: Setting up systemd service...
Failed to get D-Bus connection: Operation not permitted
```

Under `set -e` that aborts the whole install. The irony is that the script already has a crontab fallback for exactly this situation, at the end of the same if/elif chain, and it is never reached.

## Fix

Also test `/run/systemd/system`, which exists only when systemd is pid 1. This is the conventional check and is what makes the existing fallback reachable.

`patchmon_remove.sh` gated its systemd handling the same way and would have failed the same way, so it gets the same guard.

## Who this affects

Hosts where systemd is installed but is not the active init: containers, chroots, and WSL1. A normal systemd machine is unchanged, because both conditions hold.

## Verification

Found while adding CentOS 7 to an end-to-end test matrix. CentOS 7 ships systemd 219, which predates cgroup v2 and so cannot run as init on a cgroup v2 host, while `/usr/bin/systemctl` is still present: precisely the case above.

Before, on that host, the install aborted at `Failed to get D-Bus connection`. After:

```
$ ps -p 1 -o comm=          -> sleep
$ command -v systemctl      -> /usr/bin/systemctl
$ [ -d /run/systemd/system ] -> absent

SUCCESS: Your system is now being monitored by PatchMon!
  agent-running
  ✅ Initial report sent successfully
```

Regression check on a normal systemd host (Debian 12, systemd as pid 1):

```
run/systemd/system: EXISTS
INFO: Setting up systemd service...
  • Systemd service configured and running
$ systemctl is-active patchmon-agent.service -> active
```

`sh -n` passes on both scripts.