### PR TITLE
Five UI fixes: scrollbars, stale filters, chart navigation and duplicate scans

### DIFF
--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1843,7 +1843,7 @@ const Layout = ({ children }) => {
 						</div>
 					</div>
 
-					<main className="flex-1 py-6 bg-secondary-50 dark:bg-transparent pt-24">
+					<main className="flex-1 pt-[var(--app-main-pt)] pb-[var(--app-main-pb)] bg-secondary-50 dark:bg-transparent">
 						<div className="px-4 sm:px-6 lg:px-8">{content}</div>
 					</main>
 				</div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -14,6 +14,14 @@
 }
 
 @layer base {
+	/* Vertical padding of <main> in Layout.jsx. Pages that clamp themselves to
+	   the viewport subtract --app-main-inset, so the two cannot drift apart. */
+	:root {
+		--app-main-pt: 6rem;
+		--app-main-pb: 1.5rem;
+		--app-main-inset: calc(var(--app-main-pt) + var(--app-main-pb));
+	}
+
 	html {
 		font-family: Inter, ui-sans-serif, system-ui;
 	}

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -31,6 +31,7 @@ import {
 import {
 	AlertTriangle,
 	CheckCircle,
+	ChevronRight,
 	Eye,
 	EyeOff,
 	Folder,
@@ -1335,17 +1336,7 @@ const Dashboard = () => {
 
 			case "updateStatus":
 				return (
-					<button
-						type="button"
-						className="card p-4 sm:p-6 cursor-pointer hover:shadow-card-hover dark:hover:shadow-card-hover-dark transition-shadow duration-200 w-full text-left h-full flex flex-col"
-						onClick={handleUpdateStatusClick}
-						onKeyDown={(e) => {
-							if (e.key === "Enter" || e.key === " ") {
-								e.preventDefault();
-								handleUpdateStatusClick();
-							}
-						}}
-					>
+					<div className="card p-4 sm:p-6 w-full h-full flex flex-col">
 						<h3 className="text-lg font-medium text-secondary-900 dark:text-white mb-4 flex-shrink-0">
 							Update Status
 						</h3>
@@ -1357,7 +1348,15 @@ const Dashboard = () => {
 								/>
 							</div>
 						</div>
-					</button>
+						<button
+							type="button"
+							onClick={handleUpdateStatusClick}
+							className="mt-3 flex items-center justify-center gap-1.5 w-full py-2 min-h-[44px] sm:min-h-0 text-sm font-medium text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300 hover:underline flex-shrink-0"
+						>
+							View hosts needing updates
+							<ChevronRight className="h-4 w-4" />
+						</button>
+					</div>
 				);
 
 			case "packagePriority":
@@ -1966,6 +1965,12 @@ const Dashboard = () => {
 			},
 		},
 		onClick: handleUpdateStatusChartClick,
+		onHover: (event, elements) => {
+			const target = event.native?.target;
+			if (target) {
+				target.style.cursor = elements.length > 0 ? "pointer" : "default";
+			}
+		},
 	};
 
 	const packagePriorityChartOptions = {

--- a/frontend/src/pages/Docker.jsx
+++ b/frontend/src/pages/Docker.jsx
@@ -577,7 +577,7 @@ const Docker = () => {
 	};
 
 	return (
-		<div className="space-y-6 md:h-[calc(100vh-7rem)] md:flex md:flex-col md:overflow-hidden">
+		<div className="space-y-6 md:h-[calc(100vh-var(--app-main-inset))] md:flex md:flex-col md:overflow-hidden">
 			<div className="flex items-center justify-between">
 				<div>
 					<h1 className="text-2xl font-semibold text-secondary-900 dark:text-white">

--- a/frontend/src/pages/Hosts.jsx
+++ b/frontend/src/pages/Hosts.jsx
@@ -1762,7 +1762,7 @@ const Hosts = () => {
 	}
 
 	return (
-		<div className="min-h-0 flex flex-col md:h-[calc(100vh-7rem)] md:overflow-hidden">
+		<div className="min-h-0 flex flex-col md:h-[calc(100vh-var(--app-main-inset))] md:overflow-hidden">
 			{/* Page Header */}
 			<div className="flex items-center justify-between mb-6">
 				<div>

--- a/frontend/src/pages/Packages.jsx
+++ b/frontend/src/pages/Packages.jsx
@@ -651,7 +651,7 @@ const Packages = () => {
 	}
 
 	return (
-		<div className="min-h-0 flex flex-col md:h-[calc(100vh-7rem)] md:overflow-hidden">
+		<div className="min-h-0 flex flex-col md:h-[calc(100vh-var(--app-main-inset))] md:overflow-hidden">
 			{/* Page Header */}
 			<div className="flex items-center justify-between mb-6">
 				<div>

--- a/frontend/src/pages/Packages.jsx
+++ b/frontend/src/pages/Packages.jsx
@@ -95,13 +95,14 @@ const Packages = () => {
 		};
 	}, [searchTerm]);
 
-	// Handle host filter from URL parameter
+	// The URL is the source of truth for these two filters. Each effect depends
+	// on its own param so writing one cannot reset the other.
+	const hostParam = searchParams.get("host");
+	const filterParam = searchParams.get("filter");
+
 	useEffect(() => {
-		const hostParam = searchParams.get("host");
-		if (hostParam) {
-			setHostFilter(hostParam);
-		}
-	}, [searchParams]);
+		setHostFilter(hostParam || "all");
+	}, [hostParam]);
 
 	// Column configuration
 	const [columnConfig, setColumnConfig] = useState(() => {
@@ -168,16 +169,17 @@ const Packages = () => {
 		}
 	};
 
-	// Handle URL filter parameters
 	useEffect(() => {
-		const filter = searchParams.get("filter");
-		if (filter === "outdated") {
+		if (filterParam === "outdated") {
 			setCategoryFilter("all");
 			setUpdateStatusFilter("needs-updates");
-		} else if (filter === "security" || filter === "security-updates") {
+		} else if (
+			filterParam === "security" ||
+			filterParam === "security-updates"
+		) {
 			setUpdateStatusFilter("security-updates");
 			setCategoryFilter("all");
-		} else if (filter === "regular") {
+		} else if (filterParam === "regular") {
 			setUpdateStatusFilter("regular-updates");
 			setCategoryFilter("all");
 		} else {
@@ -185,7 +187,7 @@ const Packages = () => {
 			setUpdateStatusFilter("all-packages");
 			setCategoryFilter("all");
 		}
-	}, [searchParams]);
+	}, [filterParam]);
 
 	const {
 		data: packagesResponse,
@@ -348,6 +350,16 @@ const Packages = () => {
 		staleTime: 60 * 1000,
 		refetchOnWindowFocus: false,
 	});
+
+	const selectHostFilter = (value) => {
+		const next = new URLSearchParams(searchParams);
+		if (value && value !== "all") {
+			next.set("host", value);
+		} else {
+			next.delete("host");
+		}
+		setSearchParams(next, { replace: true });
+	};
 
 	const clearHostFilter = () => {
 		setHostFilter("all");
@@ -945,7 +957,7 @@ const Packages = () => {
 							<div className="sm:w-48">
 								<select
 									value={hostFilter}
-									onChange={(e) => setHostFilter(e.target.value)}
+									onChange={(e) => selectHostFilter(e.target.value)}
 									className="w-full px-3 py-2 border border-secondary-300 dark:border-secondary-600 rounded-md focus:ring-2 focus:ring-primary-500 focus:border-transparent bg-white dark:bg-secondary-800 text-secondary-900 dark:text-white"
 								>
 									<option value="all">All Hosts</option>

--- a/frontend/src/pages/Patching.jsx
+++ b/frontend/src/pages/Patching.jsx
@@ -24,7 +24,7 @@ import {
 	X,
 	XCircle,
 } from "lucide-react";
-import { Fragment, useEffect, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import {
 	Link,
 	useLocation,
@@ -1358,8 +1358,11 @@ function PoliciesTab() {
 	});
 
 	const { data: hostsData } = useQuery({
-		queryKey: ["hosts-list"],
-		queryFn: () => adminHostsAPI.list().then((res) => res.data),
+		// Distinct key: other pages cache the default first-page response under
+		// "hosts-list", and the exclusion picker intersects this with group
+		// membership, so a truncated page renders as "nothing left to exclude".
+		queryKey: ["hosts-list", "all"],
+		queryFn: () => adminHostsAPI.list({ all: true }).then((res) => res.data),
 	});
 	const hosts = hostsData?.data || [];
 
@@ -1741,7 +1744,11 @@ function PolicyAssignments({ policy, hosts, hostGroups, onUpdate }) {
 	const [addTargetId, setAddTargetId] = useState("");
 	const [addExclusionHostId, setAddExclusionHostId] = useState("");
 
-	const { data: fullPolicy } = useQuery({
+	const {
+		data: fullPolicy,
+		isPending: policyPending,
+		isError: policyError,
+	} = useQuery({
 		queryKey: ["patching-policy", policy.id],
 		queryFn: () => patchingAPI.getPolicyById(policy.id),
 		enabled: !!policy.id,
@@ -1814,6 +1821,30 @@ function PolicyAssignments({ policy, hosts, hostGroups, onUpdate }) {
 		const g = hostGroups.find((x) => x.id === a.target_id);
 		return g?.name || a.target_id;
 	};
+
+	const assignedGroupIds = useMemo(
+		() =>
+			new Set(
+				assignments
+					.filter((a) => a.target_type === "host_group")
+					.map((a) => a.target_id),
+			),
+		[assignments],
+	);
+
+	// An exclusion only has meaning against a group assignment, so the picker
+	// offers members of the assigned groups that are not already excluded.
+	const excludableHosts = useMemo(() => {
+		if (assignedGroupIds.size === 0) return [];
+		const excludedHostIds = new Set(exclusions.map((e) => e.host_id));
+		return hosts.filter(
+			(h) =>
+				!excludedHostIds.has(h.id) &&
+				(h.host_group_memberships || []).some((m) =>
+					assignedGroupIds.has(m?.host_groups?.id ?? m?.id),
+				),
+		);
+	}, [hosts, exclusions, assignedGroupIds]);
 
 	return (
 		<div className="px-4 pb-4 pt-3 bg-secondary-50 dark:bg-secondary-900/50 border-t border-secondary-200 dark:border-secondary-600">
@@ -1917,28 +1948,49 @@ function PolicyAssignments({ policy, hosts, hostGroups, onUpdate }) {
 						))}
 					</ul>
 				)}
-				<div className="flex flex-wrap items-center gap-2">
-					<select
-						value={addExclusionHostId}
-						onChange={(e) => setAddExclusionHostId(e.target.value)}
-						className="rounded border border-secondary-300 dark:border-secondary-600 bg-white dark:bg-secondary-700 text-secondary-900 dark:text-white text-sm px-2 py-1 min-w-[160px]"
-					>
-						<option value="">Select host to exclude...</option>
-						{hosts.map((h) => (
-							<option key={h.id} value={h.id}>
-								{h.friendly_name || h.hostname || h.id}
+				{policyPending ? (
+					<p className="text-sm text-secondary-500 dark:text-secondary-400">
+						Loading assignments...
+					</p>
+				) : policyError ? (
+					<p className="text-sm text-danger-600 dark:text-danger-400">
+						Could not load this policy's assignments.
+					</p>
+				) : assignedGroupIds.size === 0 ? (
+					<p className="text-sm text-secondary-500 dark:text-secondary-400">
+						Assign a host group to this policy before excluding hosts from it.
+					</p>
+				) : (
+					<div className="flex flex-wrap items-center gap-2">
+						<select
+							value={addExclusionHostId}
+							onChange={(e) => setAddExclusionHostId(e.target.value)}
+							disabled={excludableHosts.length === 0}
+							className="rounded border border-secondary-300 dark:border-secondary-600 bg-white dark:bg-secondary-700 text-secondary-900 dark:text-white text-sm px-2 py-1 min-w-[160px] disabled:opacity-50 disabled:cursor-not-allowed"
+						>
+							<option value="">
+								{excludableHosts.length === 0
+									? "No hosts left to exclude"
+									: "Select host to exclude..."}
 							</option>
-						))}
-					</select>
-					<button
-						type="button"
-						onClick={() => addExclusionHostId && addExclusionMutation.mutate()}
-						disabled={!addExclusionHostId || addExclusionMutation.isPending}
-						className="btn-outline text-sm py-1"
-					>
-						Exclude host
-					</button>
-				</div>
+							{excludableHosts.map((h) => (
+								<option key={h.id} value={h.id}>
+									{h.friendly_name || h.hostname || h.id}
+								</option>
+							))}
+						</select>
+						<button
+							type="button"
+							onClick={() =>
+								addExclusionHostId && addExclusionMutation.mutate()
+							}
+							disabled={!addExclusionHostId || addExclusionMutation.isPending}
+							className="btn-outline text-sm py-1 disabled:opacity-50 disabled:cursor-not-allowed"
+						>
+							Exclude host
+						</button>
+					</div>
+				)}
 			</div>
 		</div>
 	);

--- a/frontend/src/pages/compliance/HostDetail.jsx
+++ b/frontend/src/pages/compliance/HostDetail.jsx
@@ -19,12 +19,17 @@ const ComplianceHostDetail = () => {
 	const queryClient = useQueryClient();
 	const toast = useToast();
 
+	// Set when a scan is triggered and honoured until the server reports it as
+	// active, mirroring the pendingScans window on the Compliance overview.
+	const [pendingScanAt, setPendingScanAt] = useState(null);
+
 	const triggerScanMutation = useMutation({
 		mutationFn: () => complianceAPI.triggerScan(id, { profile_type: "all" }),
 		onSuccess: (response) => {
 			const msg = response?.data?.message || "Compliance scan triggered";
 			const jobId = response?.data?.job_id || response?.data?.jobId;
 			toast.success(jobId ? `${msg} - Job ID: ${jobId}` : msg);
+			setPendingScanAt(Date.now());
 			queryClient.invalidateQueries({ queryKey: ["compliance-latest", id] });
 			queryClient.invalidateQueries({ queryKey: ["compliance-active-scans"] });
 		},
@@ -33,6 +38,37 @@ const ComplianceHostDetail = () => {
 			toast.error(`Failed to start scan: ${errorMsg}`);
 		},
 	});
+
+	const { data: activeScansData } = useQuery({
+		queryKey: ["compliance-active-scans"],
+		queryFn: () => complianceAPI.getActiveScans().then((res) => res.data),
+		staleTime: 30 * 1000,
+		refetchInterval: (query) => {
+			if (pendingScanAt !== null) return 5000;
+			const active = query.state?.data?.activeScans?.length > 0;
+			return active ? 30000 : 120000;
+		},
+	});
+
+	const hasRunningScan = (activeScansData?.activeScans || []).some(
+		(scan) => scan.hostId === id,
+	);
+
+	useEffect(() => {
+		if (pendingScanAt === null) return;
+		if (hasRunningScan) {
+			setPendingScanAt(null);
+			return;
+		}
+		const timer = setTimeout(
+			() => setPendingScanAt(null),
+			Math.max(60000 - (Date.now() - pendingScanAt), 0),
+		);
+		return () => clearTimeout(timer);
+	}, [pendingScanAt, hasRunningScan]);
+
+	const scanInFlight =
+		triggerScanMutation.isPending || hasRunningScan || pendingScanAt !== null;
 
 	// Fetch host details
 	const {
@@ -131,24 +167,24 @@ const ComplianceHostDetail = () => {
 								<button
 									type="button"
 									onClick={() => triggerScanMutation.mutate()}
-									disabled={
-										triggerScanMutation.isPending || !ws_status?.connected
-									}
-									className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-white bg-green-600 hover:bg-green-700 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+									disabled={scanInFlight || !ws_status?.connected}
+									className="inline-flex items-center gap-1.5 px-3 py-1.5 min-h-[44px] sm:min-h-0 text-sm font-medium text-white bg-green-600 hover:bg-green-700 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
 									title={
 										!ws_status?.connected
 											? "Host is disconnected"
-											: triggerScanMutation.isPending
-												? "Scan in progress…"
-												: "Run compliance scan now"
+											: hasRunningScan
+												? "A compliance scan is already running on this host. Cancel it from Security Compliance."
+												: scanInFlight
+													? "A scan has just been queued for this host"
+													: "Run compliance scan now"
 									}
 								>
-									{triggerScanMutation.isPending ? (
+									{scanInFlight ? (
 										<RefreshCw className="h-4 w-4 animate-spin" />
 									) : (
 										<Play className="h-4 w-4" />
 									)}
-									{triggerScanMutation.isPending ? "Scanning…" : "Run Scan"}
+									{scanInFlight ? "Scanning…" : "Run Scan"}
 								</button>
 							</div>
 							<p className="mt-1 text-sm text-secondary-600 dark:text-white">

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -134,7 +134,7 @@ export const dashboardAPI = {
 // Admin Hosts API (for management interface)
 export const adminHostsAPI = {
 	create: (data) => api.post("/hosts/create", data),
-	list: () => api.get("/hosts/admin/list"),
+	list: (params = {}) => api.get("/hosts/admin/list", { params }),
 	delete: (hostId) => api.delete(`/hosts/${hostId}`),
 	deleteBulk: (hostIds) => api.delete("/hosts/bulk", { data: { hostIds } }),
 	regenerateCredentials: (hostId) =>


### PR DESCRIPTION
Five UI fixes, one commit each, all confirmed still present on `main` before any code was written.

| Issue | Fix |
|---|---|
| #808 | the viewport clamp no longer drifts from the layout padding |
| #657 | the host filter clears when the host param goes away |
| #664 | only in-scope hosts are offered when excluding from a policy |
| #930 | a pie segment click chooses its own filter |
| #676 | Run Scan no longer queues a second scan |

### #808 was arithmetic, and it was measured

`<main>` is padded 6rem top and 1.5rem bottom, so 7.5rem, while Hosts, Packages and Docker each clamped themselves to `calc(100vh-7rem)`. Every one of those pages was sized for 8px more room than exists, so the body scrolled 8px alongside the region's own scrollbar. Measured on a real build before and after, at viewport heights 720 through 1440:

```
before  /hosts /packages /docker   documentOverflow = 8px
after   /hosts /packages /docker   documentOverflow = 0px
```

The padding and the three clamps now read one custom property, so they cannot disagree again. Docker is not named in the issue but had the identical bug.

### #930 was only half fixed before

The per-segment filter already came from the backend, but the chart sat inside a button that navigated unconditionally, and Chart.js listens on the canvas natively, so its handler ran first and the button's ran last and won. Every segment went to the same place. Verified per segment in a browser rather than by reading:

| Segment clicked | Before | After |
|---|---|---|
| Up to date | `?filter=needsUpdates` | `?filter=upToDate` |
| Needs updates | `?filter=needsUpdates` | `?filter=needsUpdates` |
| Not reporting | `?filter=needsUpdates` | `?filter=inactive` |

The card is no longer a button and the whole-card action is its own labelled control beneath the chart, which also gives the pie segments back their keyboard-inaccessible-but-at-least-correct behaviour without a stopPropagation race.

### #657 was worse than reported

`/packages` is a single persistent route, so returning to it from `/packages?host=X` changed the search params without remounting and the filter stayed on the old host. The visible symptom was the Patch All button, but the package query stayed scoped to that host too, so the table showed a filtered list while the heading said all hosts.

The URL now owns the filter. Two regressions were caught and closed during review, both of which only showed up when driven in a browser: an unconditional reset discarded dropdown selections, and once the picker started writing a param it re-ran the sibling filter effect and wiped the Update Status and Category dropdowns. Each effect now depends on the single param it consumes.

### #664 and #676

The exclusion picker listed every host in the fleet, including ones the policy was never assigned to, where an exclusion has no meaning: the server resolves a direct host assignment before any exclusion check. It now offers members of the policy's assigned groups, fetches the full host list rather than the first hundred, and distinguishes loading, error and no-group-assigned instead of silently showing an empty control.

Run Scan only disabled itself while its own request was in flight, so a second click queued another scan on a host already scanning. It now accounts for scans the server reports as running or queued, covers the gap between triggering and the server seeing it, and names the reason it is disabled.

### Checks

Biome clean over 158 files, `vite build` clean, `vitest` 177 passed with 3 skipped. Before and after behaviour for #808, #930 and #657 was measured against real builds of each state with the API stubbed, rather than inferred from the diff.

### Follow-ups, deliberately not in this PR

Two things surfaced during review and are raised separately: a stalled compliance scan has no reaper, which #676 makes reachable from the host page, and nine pages use `min-h-screen` inside `<main>` and overflow by the full inset while loading, which is the same defect class as #808.

---

Closes #808, closes #657, closes #664, closes #930, closes #676.
