### PR TITLE
Size full-height states to the space inside main

### DIFF
--- a/frontend/src/pages/HostDetail.jsx
+++ b/frontend/src/pages/HostDetail.jsx
@@ -1330,7 +1330,7 @@ const HostDetail = () => {
 	const displayUptime = liveUptime || host.system_uptime || null;
 
 	return (
-		<div className="min-h-screen flex flex-col">
+		<div className="min-h-[calc(100vh-var(--app-main-inset))] flex flex-col">
 			{/* Header */}
 			<div className="flex flex-col md:flex-row md:items-start md:justify-between gap-4 mb-4 pb-4 border-b border-secondary-200 dark:border-secondary-600">
 				<div className="flex items-start gap-3">

--- a/frontend/src/pages/Repositories.jsx
+++ b/frontend/src/pages/Repositories.jsx
@@ -332,7 +332,7 @@ const Repositories = () => {
 	}
 
 	return (
-		<div className="min-h-screen flex flex-col">
+		<div className="min-h-[calc(100vh-var(--app-main-inset))] flex flex-col">
 			{/* Delete Confirmation Modal */}
 			{deleteModalData && (
 				<div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">

--- a/frontend/src/pages/compliance/HostDetail.jsx
+++ b/frontend/src/pages/compliance/HostDetail.jsx
@@ -115,7 +115,7 @@ const ComplianceHostDetail = () => {
 
 	if (isLoading) {
 		return (
-			<div className="flex items-center justify-center min-h-screen">
+			<div className="flex items-center justify-center min-h-[calc(100vh-var(--app-main-inset))]">
 				<RefreshCw className="h-8 w-8 animate-spin text-secondary-400" />
 			</div>
 		);

--- a/frontend/src/pages/docker/ContainerDetail.jsx
+++ b/frontend/src/pages/docker/ContainerDetail.jsx
@@ -28,7 +28,7 @@ const ContainerDetail = () => {
 
 	if (isLoading) {
 		return (
-			<div className="flex items-center justify-center min-h-screen">
+			<div className="flex items-center justify-center min-h-[calc(100vh-var(--app-main-inset))]">
 				<RefreshCw className="h-8 w-8 animate-spin text-secondary-400" />
 			</div>
 		);

--- a/frontend/src/pages/docker/HostDetail.jsx
+++ b/frontend/src/pages/docker/HostDetail.jsx
@@ -30,7 +30,7 @@ const HostDetail = () => {
 
 	if (isLoading) {
 		return (
-			<div className="flex items-center justify-center min-h-screen">
+			<div className="flex items-center justify-center min-h-[calc(100vh-var(--app-main-inset))]">
 				<RefreshCw className="h-8 w-8 animate-spin text-secondary-400" />
 			</div>
 		);

--- a/frontend/src/pages/docker/ImageDetail.jsx
+++ b/frontend/src/pages/docker/ImageDetail.jsx
@@ -31,7 +31,7 @@ const ImageDetail = () => {
 
 	if (isLoading) {
 		return (
-			<div className="flex items-center justify-center min-h-screen">
+			<div className="flex items-center justify-center min-h-[calc(100vh-var(--app-main-inset))]">
 				<RefreshCw className="h-8 w-8 animate-spin text-secondary-400" />
 			</div>
 		);

--- a/frontend/src/pages/docker/NetworkDetail.jsx
+++ b/frontend/src/pages/docker/NetworkDetail.jsx
@@ -31,7 +31,7 @@ const NetworkDetail = () => {
 
 	if (isLoading) {
 		return (
-			<div className="flex items-center justify-center min-h-screen">
+			<div className="flex items-center justify-center min-h-[calc(100vh-var(--app-main-inset))]">
 				<RefreshCw className="h-8 w-8 animate-spin text-secondary-400" />
 			</div>
 		);

--- a/frontend/src/pages/docker/VolumeDetail.jsx
+++ b/frontend/src/pages/docker/VolumeDetail.jsx
@@ -28,7 +28,7 @@ const VolumeDetail = () => {
 
 	if (isLoading) {
 		return (
-			<div className="flex items-center justify-center min-h-screen">
+			<div className="flex items-center justify-center min-h-[calc(100vh-var(--app-main-inset))]">
 				<RefreshCw className="h-8 w-8 animate-spin text-secondary-400" />
 			</div>
 		);


### PR DESCRIPTION
Stacked on #994, which introduces the `--app-main-inset` custom property this uses. Base is `fix/ui-batch-2` and GitHub will retarget to `main` once #994 merges. Review only the single commit here.

Eight pages asked for a full viewport height on content rendering inside `<main>`, which is already inset by 7.5rem. The document therefore ends up taller than the window and a second scrollbar appears beside the page's own. Same defect as #808, in a different place.

Six are loading or error states, so the overflow is transient. Two are the page body itself, so those overflow the whole time the page is open. Measured on Repositories at a 900px viewport:

```
before   /repositories   documentOverflow = 120px   main = 1020px
after    /repositories   documentOverflow =   0px   main =  900px
```

That is fifteen times the 8px in #808, and permanent rather than momentary.

`Login.jsx` keeps `min-h-screen` and is deliberately untouched: the login route renders outside `Layout` and genuinely owns the viewport.

### Checks

Biome clean over 158 files, `vite build` clean, `vitest` 177 passed with 3 skipped. The before and after figures above were measured against real builds of each state with the API stubbed.

---

Closes #995.
