### PR TITLE
Sweep for stalled compliance scans hourly rather than daily

### DIFF
--- a/server-source-code/internal/queue/server.go
+++ b/server-source-code/internal/queue/server.go
@@ -245,8 +245,10 @@ func NewScheduler(opts asynq.RedisClientOpt, db *database.DB, log *slog.Logger) 
 		return nil, err
 	}
 
+	// Hourly, not daily: the handler ends scans running over three hours, and a
+	// daily sweep left them holding the host's Run Scan button for most of a day.
 	complianceScanTask := asynq.NewTask(TypeComplianceScanCleanup, nil)
-	if _, err := scheduler.Register("0 1 * * *", complianceScanTask, asynq.Queue(QueueComplianceScanCleanup), asynq.Retention(AutomationRetention)); err != nil {
+	if _, err := scheduler.Register("0 * * * *", complianceScanTask, asynq.Queue(QueueComplianceScanCleanup), asynq.Retention(AutomationRetention)); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
The handler that ends stalled compliance scans looks for scans running over three hours, but the sweep that invokes it ran once a day at 01:00. A scan that stalled just after the sweep therefore stayed in `running` for most of the following day, roughly 21 hours after it had already passed the threshold meant to end it.

The job is correct; only its cadence was wrong, at eight times coarser than the condition it looks for. It now runs hourly, bounding the stale window to the threshold plus an hour. The work is a single `UPDATE` per context against scans already filtered by `started_at`, and the patch-run equivalent alongside it already runs every ten minutes.

### Why it started to matter

A stale row used to be a reporting nuisance: it kept the host in `activeScans` and on the dashboard, but Run Scan on the host page only disabled itself while its own request was in flight, so another scan could always be triggered.

#676 changed that, correctly, so a second click cannot queue a duplicate. Run Scan now also honours scans the server reports as running or queued, which is right for a scan genuinely in progress but meant a stalled row disabled the button on that host until the next daily sweep. #994 adds a tooltip pointing at Security Compliance for recovery; this shortens the wait itself.

### Checks

`make check` clean, 0 lint issues, no test failures.

`docs/Internal documentation/technical/architecture/queues.md` is updated. Its row for this job also described it as purging old scan records, which it does not do; it fails scans still running after three hours.

---

Closes #996.
