### PR TITLE
fix(enrol): keep script defaults the injected header does not supply

### DIFF
--- a/docs/patchmon-api-integrations-guide.md
+++ b/docs/patchmon-api-integrations-guide.md
@@ -1568,13 +1568,6 @@ DEBUG=true ./proxmox_auto_enroll.sh
 HOST_PREFIX="prod-" ./proxmox_auto_enroll.sh
 ```
 
-#### Include Stopped Containers
-
-```bash
-# Also process stopped containers (enrollment only, agent install fails)
-SKIP_STOPPED=false ./proxmox_auto_enroll.sh
-```
-
 #### Force Install Mode (Broken Packages)
 
 If containers have broken packages (CloudPanel, WHM, cPanel, etc.) that block `apt-get`:
@@ -1738,7 +1731,6 @@ All configuration can be set via environment variables:
 | `CURL_FLAGS` | `-s` | Curl options | `-sk` (for self-signed SSL) |
 | `DRY_RUN` | `false` | Preview mode (no changes) | `true`/`false` |
 | `HOST_PREFIX` | `""` | Prefix for host names | `proxmox-`, `prod-`, etc. |
-| `SKIP_STOPPED` | `true` | Skip stopped containers | `true`/`false` |
 | `FORCE_INSTALL` | `false` | Bypass broken packages | `true`/`false` |
 | `DEBUG` | `false` | Enable debug logging | `true`/`false` |
 
@@ -1754,7 +1746,6 @@ AUTO_ENROLLMENT_SECRET="${AUTO_ENROLLMENT_SECRET:-your_secret_here}"
 CURL_FLAGS="${CURL_FLAGS:--s}"
 DRY_RUN="${DRY_RUN:-false}"
 HOST_PREFIX="${HOST_PREFIX:-}"
-SKIP_STOPPED="${SKIP_STOPPED:-true}"
 FORCE_INSTALL="${FORCE_INSTALL:-false}"
 ```
 

--- a/server-source-code/internal/agents/proxmox_auto_enroll.sh
+++ b/server-source-code/internal/agents/proxmox_auto_enroll.sh
@@ -30,9 +30,6 @@ AUTO_ENROLLMENT_SECRET="${AUTO_ENROLLMENT_SECRET:-}"
 CURL_FLAGS="${CURL_FLAGS:--s}"
 DRY_RUN="${DRY_RUN:-false}"
 HOST_PREFIX="${HOST_PREFIX:-}"
-SKIP_STOPPED="${SKIP_STOPPED:-true}"
-PARALLEL_INSTALL="${PARALLEL_INSTALL:-false}"
-MAX_PARALLEL="${MAX_PARALLEL:-5}"
 FORCE_INSTALL="${FORCE_INSTALL:-false}"
 
 # ===== COLOR OUTPUT =====
@@ -91,7 +88,6 @@ done
 info "Configuration validated successfully"
 info "PatchMon Server: $PATCHMON_URL"
 info "Dry Run Mode: $DRY_RUN"
-info "Skip Stopped Containers: $SKIP_STOPPED"
 echo ""
 
 # ===== DISCOVER LXC CONTAINERS =====
@@ -131,17 +127,9 @@ while IFS= read -r line; do
 
     info "Processing LXC $vmid: $name (status: $status)"
 
-    # Skip stopped containers if configured
-    if [[ "$status" != "running" ]] && [[ "$SKIP_STOPPED" == "true" ]]; then
-        warn "  Skipping $name - container not running"
-        ((skipped_count++)) || true
-        echo ""
-        continue
-    fi
-
-    # Check if container is stopped
+    # pct exec cannot reach a container that is not running
     if [[ "$status" != "running" ]]; then
-        warn "  Container $name is stopped - cannot gather info or install agent"
+        warn "  Skipping $name - container is $status, agent installation requires it running"
         ((skipped_count++)) || true
         echo ""
         continue

--- a/server-source-code/internal/handler/auto_enrollment.go
+++ b/server-source-code/internal/handler/auto_enrollment.go
@@ -672,33 +672,14 @@ func (h *AutoEnrollmentHandler) ServeScript(w http.ResponseWriter, r *http.Reque
 		}
 	}
 
-	shebang := "#!/bin/sh"
-	if scriptType == "proxmox-lxc" {
-		shebang = "#!/bin/bash"
-	}
-	envBlock := shebang + "\n# PatchMon Auto-Enrollment Configuration (Auto-generated)\n" +
-		"export PATCHMON_URL=\"" + serverURL + "\"\n" +
-		"export AUTO_ENROLLMENT_KEY=\"" + token.TokenKey + "\"\n" +
-		"export AUTO_ENROLLMENT_SECRET=\"" + tokenSecret + "\"\n" +
-		"export CURL_FLAGS=\"" + curlFlags + "\"\n" +
-		"export FORCE_INSTALL=\"" + map[bool]string{true: "true", false: "false"}[forceInstall] + "\"\n\n"
-
-	scriptStr := string(script)
-	scriptStr = strings.ReplaceAll(scriptStr, "\r\n", "\n")
-	scriptStr = strings.ReplaceAll(scriptStr, "\r", "\n")
-	if strings.HasPrefix(scriptStr, "#!") {
-		scriptStr = "#" + scriptStr[1:]
-	}
-	// Remove the configuration section (between # ===== CONFIGURATION ===== and # ===== COLOR OUTPUT =====)
-	configStart := strings.Index(scriptStr, "# ===== CONFIGURATION =====")
-	colorStart := strings.Index(scriptStr, "# ===== COLOR OUTPUT =====")
-	if configStart >= 0 && colorStart > configStart {
-		scriptStr = scriptStr[:configStart] + scriptStr[colorStart:]
-	}
-
 	out := bytes.Buffer{}
-	out.WriteString(envBlock)
-	out.WriteString(scriptStr)
+	out.WriteString(buildEnrollmentScript(script, scriptType, enrollmentScriptEnv{
+		ServerURL:    serverURL,
+		TokenKey:     token.TokenKey,
+		TokenSecret:  tokenSecret,
+		CurlFlags:    curlFlags,
+		ForceInstall: forceInstall,
+	}))
 
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.Header().Set("Content-Disposition", "inline; filename=\""+scriptType+"_auto_enroll.sh\"")
@@ -707,6 +688,54 @@ func (h *AutoEnrollmentHandler) ServeScript(w http.ResponseWriter, r *http.Reque
 	w.Header().Set("Pragma", "no-cache")
 	w.WriteHeader(http.StatusOK)
 	_, _ = w.Write(out.Bytes())
+}
+
+// enrollmentScriptEnv is the set of values the server injects into a served
+// enrolment script.
+type enrollmentScriptEnv struct {
+	ServerURL    string
+	TokenKey     string
+	TokenSecret  string
+	CurlFlags    string
+	ForceInstall bool
+}
+
+// buildEnrollmentScript prepends an exported configuration header to the
+// embedded script.
+//
+// The script's own configuration block is left intact: every variable there is
+// VAR="${VAR:-default}" and this header runs first, so an injected value wins
+// and an uninjected one keeps its default.
+func buildEnrollmentScript(script []byte, scriptType string, env enrollmentScriptEnv) string {
+	shebang := "#!/bin/sh"
+	if scriptType == "proxmox-lxc" {
+		shebang = "#!/bin/bash"
+	}
+
+	forceInstall := "false"
+	if env.ForceInstall {
+		forceInstall = "true"
+	}
+
+	envBlock := shebang + "\n# PatchMon Auto-Enrollment Configuration (Auto-generated)\n" +
+		"export PATCHMON_URL=\"" + env.ServerURL + "\"\n" +
+		"export AUTO_ENROLLMENT_KEY=\"" + env.TokenKey + "\"\n" +
+		"export AUTO_ENROLLMENT_SECRET=\"" + env.TokenSecret + "\"\n" +
+		"export CURL_FLAGS=\"" + env.CurlFlags + "\"\n" +
+		"export FORCE_INSTALL=\"" + forceInstall + "\"\n\n"
+
+	body := string(script)
+	body = strings.ReplaceAll(body, "\r\n", "\n")
+	body = strings.ReplaceAll(body, "\r", "\n")
+	// The embedded script carries its own shebang; comment it out so the one
+	// above is the only interpreter line. Prepend rather than replace: the old
+	// form was "#" + body[1:], which overwrote the leading "#" with a "#" and
+	// so left the shebang exactly as it was.
+	if strings.HasPrefix(body, "#!") {
+		body = "#" + body
+	}
+
+	return envBlock + body
 }
 
 func generateEnrollmentCredentials() (tokenKey, tokenSecret, hashedSecret string, err error) {

--- a/server-source-code/internal/handler/auto_enrollment_script_test.go
+++ b/server-source-code/internal/handler/auto_enrollment_script_test.go
@@ -36,9 +36,6 @@ func TestBuildEnrollmentScript_KeepsUninjectedDefaults(t *testing.T) {
 			want: []string{
 				`DRY_RUN="${DRY_RUN:-false}"`,
 				`HOST_PREFIX="${HOST_PREFIX:-}"`,
-				`SKIP_STOPPED="${SKIP_STOPPED:-true}"`,
-				`PARALLEL_INSTALL="${PARALLEL_INSTALL:-false}"`,
-				`MAX_PARALLEL="${MAX_PARALLEL:-5}"`,
 			},
 		},
 		{

--- a/server-source-code/internal/handler/auto_enrollment_script_test.go
+++ b/server-source-code/internal/handler/auto_enrollment_script_test.go
@@ -1,0 +1,140 @@
+package handler
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/PatchMon/PatchMon/server-source-code/internal/agents"
+)
+
+func testEnv() enrollmentScriptEnv {
+	return enrollmentScriptEnv{
+		ServerURL:   "http://patchmon.test:3000",
+		TokenKey:    "patchmon_ae_key",
+		TokenSecret: "secret",
+		CurlFlags:   "-s",
+	}
+}
+
+// The served script must keep the defaults for every variable the injected
+// header does not supply.
+//
+// The header and the configuration block are complementary, not redundant: an
+// injected value wins the ${VAR:-default} substitution, an uninjected one keeps
+// its default. Stripping the block dropped the latter.
+func TestBuildEnrollmentScript_KeepsUninjectedDefaults(t *testing.T) {
+	tests := []struct {
+		name       string
+		scriptType string
+		script     []byte
+		want       []string
+	}{
+		{
+			name:       "proxmox-lxc",
+			scriptType: "proxmox-lxc",
+			script:     agents.ProxmoxAutoEnrollScript,
+			want: []string{
+				`DRY_RUN="${DRY_RUN:-false}"`,
+				`HOST_PREFIX="${HOST_PREFIX:-}"`,
+				`SKIP_STOPPED="${SKIP_STOPPED:-true}"`,
+				`PARALLEL_INSTALL="${PARALLEL_INSTALL:-false}"`,
+				`MAX_PARALLEL="${MAX_PARALLEL:-5}"`,
+			},
+		},
+		{
+			name:       "direct-host",
+			scriptType: "direct-host",
+			script:     agents.DirectHostAutoEnrollScript,
+			want:       []string{`FRIENDLY_NAME="${FRIENDLY_NAME:-}"`},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildEnrollmentScript(tt.script, tt.scriptType, testEnv())
+			for _, want := range tt.want {
+				if !strings.Contains(got, want) {
+					t.Errorf("served script lost a default it must keep: %s", want)
+				}
+			}
+		})
+	}
+}
+
+// An injected value must beat the script's default, which is what makes it safe
+// to leave the configuration block in place.
+func TestBuildEnrollmentScript_InjectedValuesPrecedeDefaults(t *testing.T) {
+	got := buildEnrollmentScript(agents.DirectHostAutoEnrollScript, "direct-host", testEnv())
+
+	header, body, found := strings.Cut(got, "# ===== CONFIGURATION =====")
+	if !found {
+		t.Fatal("configuration block missing from served script")
+	}
+	if !strings.Contains(header, `export PATCHMON_URL="http://patchmon.test:3000"`) {
+		t.Error("injected server URL not exported ahead of the configuration block")
+	}
+	if !strings.Contains(body, `PATCHMON_URL="${PATCHMON_URL:-`) {
+		t.Error("configuration block does not use :- substitution, so the export would be overwritten")
+	}
+}
+
+// Only the generated header may carry an interpreter line; the embedded
+// script's own shebang is commented out.
+func TestBuildEnrollmentScript_SingleShebang(t *testing.T) {
+	for _, tt := range []struct {
+		scriptType string
+		script     []byte
+		want       string
+	}{
+		{"proxmox-lxc", agents.ProxmoxAutoEnrollScript, "#!/bin/bash"},
+		{"direct-host", agents.DirectHostAutoEnrollScript, "#!/bin/sh"},
+	} {
+		t.Run(tt.scriptType, func(t *testing.T) {
+			got := buildEnrollmentScript(tt.script, tt.scriptType, testEnv())
+
+			if !strings.HasPrefix(got, tt.want+"\n") {
+				t.Errorf("expected leading %q", tt.want)
+			}
+			if n := strings.Count(got, "\n#!"); n != 0 {
+				t.Errorf("found %d further shebang line(s); the embedded one should be commented out", n)
+			}
+		})
+	}
+}
+
+// PATCHMON_URL is the one variable whose default is a real placeholder rather
+// than empty, so it is the one where losing the ${VAR:-default} form does
+// visible damage: every enrolling host would be pointed at
+// https://patchmon.example.com. An empty default cannot fail this way, which is
+// why this case is called out separately from the table above.
+func TestBuildEnrollmentScript_ServerURLPlaceholderNeverUnconditional(t *testing.T) {
+	for _, tt := range []struct {
+		scriptType string
+		script     []byte
+	}{
+		{"proxmox-lxc", agents.ProxmoxAutoEnrollScript},
+		{"direct-host", agents.DirectHostAutoEnrollScript},
+	} {
+		t.Run(tt.scriptType, func(t *testing.T) {
+			got := buildEnrollmentScript(tt.script, tt.scriptType, testEnv())
+
+			if strings.Contains(got, `PATCHMON_URL="https://patchmon.example.com"`) {
+				t.Error("placeholder URL assigned unconditionally; the injected server URL would be overwritten")
+			}
+			if !strings.Contains(got, `export PATCHMON_URL="http://patchmon.test:3000"`) {
+				t.Error("injected server URL missing from the header")
+			}
+		})
+	}
+}
+
+func TestBuildEnrollmentScript_ForceInstall(t *testing.T) {
+	env := testEnv()
+	env.ForceInstall = true
+	if got := buildEnrollmentScript(agents.DirectHostAutoEnrollScript, "direct-host", env); !strings.Contains(got, `export FORCE_INSTALL="true"`) {
+		t.Error("ForceInstall not reflected in the header")
+	}
+	if got := buildEnrollmentScript(agents.DirectHostAutoEnrollScript, "direct-host", testEnv()); !strings.Contains(got, `export FORCE_INSTALL="false"`) {
+		t.Error("default FORCE_INSTALL should be false")
+	}
+}


### PR DESCRIPTION
The enrolment script endpoint cuts out the script's entire `# ===== CONFIGURATION =====` block, then prepends a generated header. The header supplies **five** variables. The Proxmox script's block defines **ten**.

The other five arrive unset, losing their defaults: `DRY_RUN`, `HOST_PREFIX`, `SKIP_STOPPED`, `PARALLEL_INSTALL`, `MAX_PARALLEL`.

## What this does and does not change

**Enrolment behaviour on a default run is unchanged.** Being precise about that, because it is easy to overstate:

- `SKIP_STOPPED` losing its `true` looks like it should matter, but a **second, unconditional guard** sits immediately after it:

  ```bash
  if [[ "$status" != "running" ]] && [[ "$SKIP_STOPPED" == "true" ]]; then   # :135
  if [[ "$status" != "running" ]]; then                                       # :143
  ```

  Both `continue` and both increment `skipped_count`, so a stopped container was skipped either way. Only the wording of the `warn` line differed.
- `PARALLEL_INSTALL` and `MAX_PARALLEL` appear **only on their own declaration lines**. There is no parallel install path in the script, so their defaults were never read.

**The user-visible effect** is the script's own banner, which printed the values blank:

```
[INFO] Dry Run Mode:
[INFO] Skip Stopped Containers:
```

and now prints `false` and `true`.

**The real argument for the change** is that it is correct by construction: a default added to a config block in future survives into the served script instead of being silently dropped. That property is worth having on the code path that installs an agent on every new host.

## Fix

The block never needed removing. Every variable in it is `VAR="${VAR:-default}"`, and the header runs first, so an injected value already wins the substitution while an uninjected one keeps its default.

`direct-host` was unaffected either way: its single uninjected variable is `FRIENDLY_NAME`, whose default is empty.

## Also in here

The assembly is extracted into `buildEnrollmentScript` so it can be tested at all; it was previously inline in the handler behind token validation and settings lookups.

That test then caught a second, older no-op:

```go
scriptStr = "#" + scriptStr[1:]   // replaces the leading "#" with "#"
```

meant to comment out the embedded script's shebang, and it never has. Harmless, because a shebang mid-file is just a comment, but it does not do what it says. Now prepends instead.

## Tests

Five cases, and three of them fail against the old code, so they discriminate rather than decorate. Re-adding the strip produces:

```
served script lost a default it must keep: SKIP_STOPPED="${SKIP_STOPPED:-true}"
```

One is worth calling out: `PATCHMON_URL` is the only variable whose default is a real placeholder (`https://patchmon.example.com`) rather than empty, so it is the only one where losing the `${VAR:-default}` form would ship a broken installer to every enrolling host. A test now asserts that placeholder is never assigned unconditionally.

`make check` passes, 0 lint issues.

## Also fixes #1000: the dead SKIP_STOPPED toggle

Two further commits ride with this one, because the change above is what turns the
next problem from cosmetic into misleading.

`SKIP_STOPPED` never worked. The guard that honours it is followed immediately by an
unconditional one that skips any container whose status is not `running`, so a stopped
container was skipped whatever the toggle held. Before this PR the banner printed
`Skip Stopped Containers:` with no value: uninformative, but not false. Now that the
served script carries its own defaults again, that line prints the operator's `false`
back at them while stopped containers are skipped regardless. That is a promotion from
silent to actively wrong, so the toggle goes.

Making stopped containers enrollable was the alternative, and it is rejected on
mechanism rather than taste: the loop reads hostname, IP address and os-release through
`pct exec` at the top of the body, before it reaches the install step, and none of those
can reach a container that is not running. Reordering that is a much larger change.

`PARALLEL_INSTALL` and `MAX_PARALLEL` go the same way, since neither appears anywhere but
its own declaration line and the loop has always been sequential. `DRY_RUN` is untouched:
unlike the three removed here it is declared, printed and actually read.

The integrations guide described both behaviours at once, so it is now made
self-consistent with what the script does.

Closes #1000
