### PR TITLE
fix(auth): make session inactivity track the user, and renew access tokens

### DIFF
--- a/docker/env.example
+++ b/docker/env.example
@@ -91,6 +91,9 @@ GUACD_ADDRESS=guacd:4822
 ## Authentication / Lockout
 # MAX_LOGIN_ATTEMPTS=5
 # LOCKOUT_DURATION_MINUTES=15
+## SESSION_INACTIVITY_TIMEOUT_MINUTES counts minutes without user activity
+## (clicks, typing, scrolling, pointer movement). Automatic page refreshes do
+## not count, so an unattended browser still times out. Set 0 to disable.
 # SESSION_INACTIVITY_TIMEOUT_MINUTES=30
 # TFA_MAX_REMEMBER_SESSIONS=5
 

--- a/docs/patchmon-operator-guide.md
+++ b/docs/patchmon-operator-guide.md
@@ -1603,7 +1603,7 @@ Settings for JWT tokens, browser sessions, account lockout, two-factor authentic
 | Variable | Default | Required | Description |
 |----------|---------|----------|-------------|
 | `JWT_SECRET` | _(none)_ | **Yes** | See [Required Variables](#1-required-variables). |
-| `JWT_EXPIRES_IN` | `1h` | No | How long an access token is valid. Accepts duration strings: `30m`, `1h`, `2h`, `1d`. Shorter values are more secure but require more frequent token refreshes. |
+| `JWT_EXPIRES_IN` | `1h` | No | How long an access token is valid. Accepts duration strings: `30m`, `1h`, `2h`, `1d`. The web interface renews the token automatically in the background, so a short value is not visible to signed-in users; it only controls how quickly a stolen token becomes useless. |
 | `AUTH_BROWSER_SESSION_COOKIES` | `false` | No | When set to `true`, the `token` and `refresh_token` cookies are issued without a `Max-Age` attribute, making them session cookies that are cleared when the browser is closed rather than persisting across browser restarts. |
 
 #### Account Lockout
@@ -1619,7 +1619,19 @@ Lockout is applied per user account after repeated failed login attempts.
 
 | Variable | Default | Required | Description |
 |----------|---------|----------|-------------|
-| `SESSION_INACTIVITY_TIMEOUT_MINUTES` | `30` | No | Minutes of inactivity before a user session is automatically invalidated. Each authenticated request resets the timer. |
+| `SESSION_INACTIVITY_TIMEOUT_MINUTES` | `30` | No | Minutes without user activity before a session is invalidated and the browser returns to the login screen. Set to `0` to disable the inactivity timeout entirely. |
+
+"Activity" means someone actually using the interface: clicking, typing, scrolling, moving the
+pointer, or switching back to the tab. Pages that refresh data on a timer do not count, so a
+browser left open on an unattended machine still times out.
+
+The timer is enforced by the server and evaluated when the next request arrives, so a session that
+has been idle past the limit ends at the next click or background refresh rather than at the exact
+second the limit passes. Signing out, or an administrator revoking the session, ends it immediately
+either way.
+
+This setting is independent of `JWT_EXPIRES_IN`. Access tokens are renewed in the background for as
+long as the session stays active, so a value larger than `JWT_EXPIRES_IN` works as expected.
 
 #### Two-Factor Authentication (TFA)
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -17,6 +17,7 @@ import { SettingsProvider } from "./contexts/SettingsContext";
 import { ThemeProvider } from "./contexts/ThemeContext";
 import { ToastProvider } from "./contexts/ToastContext";
 import { UpdateNotificationProvider } from "./contexts/UpdateNotificationContext";
+import { useSessionHeartbeat } from "./hooks/useSessionHeartbeat";
 import Automation from "./pages/Automation";
 import Compliance from "./pages/Compliance";
 // Eager load main nav pages for instant navigation (no loading flash)
@@ -97,6 +98,10 @@ function AppRoutes() {
 		firstTimeWizardActive,
 	} = useAuth();
 	const isAuth = isAuthenticated(); // Call the function to get boolean value
+
+	// Mounted above the route tree so every authenticated screen beats, including
+	// the ones under SettingsLayout rather than Layout.
+	useSessionHeartbeat(isAuth);
 
 	// Show loading while checking setup or initialising
 	if (

--- a/frontend/src/contexts/AuthContext.jsx
+++ b/frontend/src/contexts/AuthContext.jsx
@@ -8,6 +8,7 @@ import {
 import { flushSync } from "react-dom";
 import { AUTH_PHASES, isAuthPhase } from "../constants/authPhases";
 import { isCorsError } from "../utils/api";
+import { fetchWithSessionRefresh } from "../utils/sessionRefresh";
 
 // Development-only logging to prevent error details exposure in production
 const isDev = import.meta.env.DEV;
@@ -61,7 +62,7 @@ export const AuthProvider = ({ children }) => {
 					Authorization: `Bearer ${authToken}`,
 				};
 			}
-			const response = await fetch(
+			const response = await fetchWithSessionRefresh(
 				"/api/v1/permissions/user-permissions",
 				fetchOptions,
 			);
@@ -100,7 +101,10 @@ export const AuthProvider = ({ children }) => {
 			if (authToken) {
 				fetchOptions.headers = { Authorization: `Bearer ${authToken}` };
 			}
-			const response = await fetch("/api/v1/me/context", fetchOptions);
+			const response = await fetchWithSessionRefresh(
+				"/api/v1/me/context",
+				fetchOptions,
+			);
 			if (response.ok) {
 				const data = await response.json();
 				if (data?.tenant) {
@@ -191,7 +195,7 @@ export const AuthProvider = ({ children }) => {
 
 			try {
 				// First, try to validate via API using httpOnly cookies
-				const response = await fetch("/api/v1/auth/profile", {
+				const response = await fetchWithSessionRefresh("/api/v1/auth/profile", {
 					credentials: "include",
 					signal: abortController.signal,
 				});
@@ -270,7 +274,7 @@ export const AuthProvider = ({ children }) => {
 
 	const refetchUser = useCallback(async () => {
 		try {
-			const response = await fetch("/api/v1/auth/profile", {
+			const response = await fetchWithSessionRefresh("/api/v1/auth/profile", {
 				credentials: "include",
 			});
 			if (response.ok) {
@@ -449,7 +453,10 @@ export const AuthProvider = ({ children }) => {
 			if (token) {
 				fetchOptions.headers.Authorization = `Bearer ${token}`;
 			}
-			const response = await fetch("/api/v1/auth/profile", fetchOptions);
+			const response = await fetchWithSessionRefresh(
+				"/api/v1/auth/profile",
+				fetchOptions,
+			);
 
 			const data = await response.json();
 
@@ -537,7 +544,7 @@ export const AuthProvider = ({ children }) => {
 			if (token) {
 				fetchOptions.headers.Authorization = `Bearer ${token}`;
 			}
-			const response = await fetch(
+			const response = await fetchWithSessionRefresh(
 				"/api/v1/auth/change-password",
 				fetchOptions,
 			);
@@ -603,12 +610,15 @@ export const AuthProvider = ({ children }) => {
 			if (token) {
 				headers.Authorization = `Bearer ${token}`;
 			}
-			const response = await fetch("/api/v1/release-notes-acceptance/accept", {
-				method: "POST",
-				headers,
-				credentials: "include", // Include cookies for OIDC users
-				body: JSON.stringify({ version }),
-			});
+			const response = await fetchWithSessionRefresh(
+				"/api/v1/release-notes-acceptance/accept",
+				{
+					method: "POST",
+					headers,
+					credentials: "include", // Include cookies for OIDC users
+					body: JSON.stringify({ version }),
+				},
+			);
 
 			const data = await response.json();
 

--- a/frontend/src/hooks/useSessionHeartbeat.js
+++ b/frontend/src/hooks/useSessionHeartbeat.js
@@ -1,0 +1,29 @@
+import { useEffect } from "react";
+import { authAPI } from "../utils/api";
+import { hasPendingInteraction } from "../utils/userActivity";
+
+// Worst case, an interaction is reported this long after it happened, so the
+// interval has to leave room under the smallest inactivity window an operator
+// might set. One minute is a legitimate setting; 30s keeps it safe, and is still
+// a third of what the sidebar's own status poll already costs.
+const HEARTBEAT_INTERVAL_MS = 30 * 1000;
+
+// Keeps an in-use session alive without relying on whatever the current page
+// happens to poll. Pages differ in that respect and some poll nothing at all, so
+// without a beat of its own a user reading one of those screens would be logged
+// out mid-read. It only fires when there has been a real interaction since the
+// last beat, so an unattended tab reports nothing and ages out as configured.
+export function useSessionHeartbeat(enabled) {
+	useEffect(() => {
+		if (!enabled) return undefined;
+		const id = setInterval(() => {
+			if (document.visibilityState === "hidden") return;
+			if (!hasPendingInteraction()) return;
+			authAPI.heartbeat().catch(() => {
+				// A failed beat is not actionable: the response interceptor already
+				// handles an expired session, and the next beat retries.
+			});
+		}, HEARTBEAT_INTERVAL_MS);
+		return () => clearInterval(id);
+	}, [enabled]);
+}

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,4 +1,6 @@
 import axios from "axios";
+import { requestTokenRefresh } from "./sessionRefresh";
+import { consumeInteraction } from "./userActivity";
 
 const API_BASE_URL = import.meta.env.VITE_API_URL || "/api/v1";
 
@@ -42,6 +44,12 @@ api.interceptors.request.use(
 		}
 		config.headers["X-Device-ID"] = deviceId;
 
+		// Only requests that follow a real interaction slide the session
+		// inactivity window. Background polling deliberately goes unmarked.
+		if (consumeInteraction()) {
+			config.headers["X-User-Activity"] = "1";
+		}
+
 		return config;
 	},
 	(error) => {
@@ -49,24 +57,55 @@ api.interceptors.request.use(
 	},
 );
 
+// Endpoints whose own 401 means "these credentials are bad", not "this token
+// aged out", so retrying them behind a refresh would be pointless.
+const isSessionEndpoint = (url) =>
+	url.includes("/auth/login") ||
+	url.includes("/auth/refresh") ||
+	url.includes("/auth/logout");
+
 // Response interceptor
 api.interceptors.response.use(
 	(response) => response,
-	(error) => {
-		if (error.response?.status === 401) {
-			// Don't redirect if we're on the login page or if it's a TFA-related error
-			const currentPath = window.location.pathname;
-			const requestUrl = error.config?.url || "";
-			const isTfaError =
-				requestUrl.includes("/verify-tfa") || requestUrl.includes("/tfa/");
+	async (error) => {
+		if (error.response?.status !== 401) return Promise.reject(error);
 
-			if (currentPath !== "/login" && !isTfaError) {
-				// Dispatch event for AuthContext to handle - avoids race with React updates
-				// that could trigger ErrorBoundary "Something went wrong" before redirect
-				localStorage.removeItem("user");
-				window.dispatchEvent(new CustomEvent("auth:session-expired"));
+		// Don't redirect if we're on the login page or if it's a TFA-related error
+		const currentPath = window.location.pathname;
+		const config = error.config;
+		const requestUrl = config?.url || "";
+		const isTfaError =
+			requestUrl.includes("/verify-tfa") || requestUrl.includes("/tfa/");
+
+		if (currentPath === "/login" || isTfaError) {
+			return Promise.reject(error);
+		}
+
+		// Access tokens expire on a fixed schedule regardless of use, so most 401s
+		// here are an aged-out token rather than a dead session. Trade it for a
+		// fresh one and replay once; the session itself is only gone if that fails.
+		if (
+			config &&
+			!config._sessionRefreshAttempted &&
+			!isSessionEndpoint(requestUrl)
+		) {
+			config._sessionRefreshAttempted = true;
+			try {
+				await requestTokenRefresh();
+				return await api(config);
+			} catch (refreshError) {
+				// Only a 401 proves the session is gone. A network drop, a 5xx, or a
+				// rate limiter that is failing closed says nothing about the session,
+				// and signing the user out over it would turn a blip into a logout.
+				const status = refreshError?.response?.status;
+				if (status && status !== 401) return Promise.reject(error);
 			}
 		}
+
+		// Dispatch event for AuthContext to handle - avoids race with React updates
+		// that could trigger ErrorBoundary "Something went wrong" before redirect
+		localStorage.removeItem("user");
+		window.dispatchEvent(new CustomEvent("auth:session-expired"));
 		return Promise.reject(error);
 	},
 );
@@ -575,6 +614,9 @@ export const authAPI = {
 			lastName,
 		}),
 	subscribeNewsletter: () => api.post("/auth/subscribe-newsletter"),
+	// Carries X-User-Activity when the user has interacted since the last beat.
+	// The auth middleware does the work; the response body is empty.
+	heartbeat: () => api.post("/auth/heartbeat"),
 };
 
 // TFA API

--- a/frontend/src/utils/sessionRefresh.js
+++ b/frontend/src/utils/sessionRefresh.js
@@ -1,0 +1,37 @@
+import axios from "axios";
+
+const API_BASE_URL = import.meta.env.VITE_API_URL || "/api/v1";
+
+// Single-flight: a burst of requests hitting the same expired access token must
+// produce one refresh, not one per request. Shared by the axios instance and the
+// fetch wrapper below so the two paths cannot race each other.
+let refreshInFlight = null;
+
+// Bare axios on purpose - routing this through the shared `api` instance would
+// re-enter its response interceptor and recurse.
+export const requestTokenRefresh = () => {
+	if (!refreshInFlight) {
+		refreshInFlight = axios
+			.post(`${API_BASE_URL}/auth/refresh`, null, { withCredentials: true })
+			.finally(() => {
+				refreshInFlight = null;
+			});
+	}
+	return refreshInFlight;
+};
+
+// Drop-in `fetch` for authenticated endpoints. AuthContext talks to the API with
+// fetch rather than the axios instance, so without this a page load after the
+// access token had expired would send a perfectly live session to the login
+// screen. Retries once; anything still 401 is a genuinely dead session and is
+// returned to the caller to handle.
+export const fetchWithSessionRefresh = async (url, options) => {
+	const response = await fetch(url, options);
+	if (response.status !== 401) return response;
+	try {
+		await requestTokenRefresh();
+	} catch {
+		return response;
+	}
+	return fetch(url, options);
+};

--- a/frontend/src/utils/userActivity.js
+++ b/frontend/src/utils/userActivity.js
@@ -1,0 +1,50 @@
+// Tracks whether a person has actually used the page, as opposed to the app
+// simply making requests. Several screens poll on a timer, so the server cannot
+// treat "a request arrived" as "someone is here" without an unattended tab
+// keeping its own session alive forever.
+//
+// Requests report an interaction by sending the X-User-Activity header, which is
+// the only thing that slides SESSION_INACTIVITY_TIMEOUT_MINUTES.
+
+const MOUSE_MOVE_THROTTLE_MS = 5000;
+
+let lastInteractionAt = 0;
+let lastReportedAt = 0;
+let lastMouseMoveAt = 0;
+
+const mark = () => {
+	lastInteractionAt = Date.now();
+};
+
+// Pointer movement fires continuously; sampling it keeps the listener cheap
+// while still counting "reading a screen with a hand on the mouse" as presence.
+const markMouseMove = () => {
+	const now = Date.now();
+	if (now - lastMouseMoveAt < MOUSE_MOVE_THROTTLE_MS) return;
+	lastMouseMoveAt = now;
+	lastInteractionAt = now;
+};
+
+if (typeof window !== "undefined") {
+	const opts = { passive: true, capture: true };
+	window.addEventListener("mousedown", mark, opts);
+	window.addEventListener("keydown", mark, opts);
+	window.addEventListener("touchstart", mark, opts);
+	window.addEventListener("wheel", mark, opts);
+	window.addEventListener("scroll", mark, opts);
+	window.addEventListener("mousemove", markMouseMove, opts);
+	document.addEventListener("visibilitychange", () => {
+		// Returning to the tab is itself a deliberate act.
+		if (document.visibilityState === "visible") mark();
+	});
+}
+
+export const hasPendingInteraction = () => lastInteractionAt > lastReportedAt;
+
+// consumeInteraction reports and clears the pending flag. Callers must only call
+// it when they are about to send a request that carries the header.
+export const consumeInteraction = () => {
+	if (lastInteractionAt <= lastReportedAt) return false;
+	lastReportedAt = lastInteractionAt;
+	return true;
+};

--- a/server-source-code/internal/handler/auth.go
+++ b/server-source-code/internal/handler/auth.go
@@ -452,29 +452,42 @@ func (h *AuthHandler) VerifyTfa(w http.ResponseWriter, r *http.Request) {
 	h.completeLogin(w, r, user, req.RememberMe)
 }
 
-// setAuthCookiesWithRemember sets cookies; rememberMe uses 30-day refresh token.
-// useLax forces SameSite=Lax (required for OIDC redirects from IdP).
-// browserSessionCookies: when true, both cookies use MaxAge 0 (session cookies) so they are not
-// persisted to disk and are dropped when the browser session ends (close all windows / quit).
-func setAuthCookiesWithRemember(w http.ResponseWriter, r *http.Request, accessToken, refreshToken string, tokenMaxAge int64, rememberMe bool, env string, useLax bool, browserSessionCookies bool) {
-	secure := r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https"
-	sameSite := http.SameSiteLaxMode
+func cookieSameSite(env string, useLax, secure bool) http.SameSite {
 	if !useLax && env == "production" && secure {
-		sameSite = http.SameSiteStrictMode
+		return http.SameSiteStrictMode
 	}
-	tokenCookieMaxAge := int(tokenMaxAge)
+	return http.SameSiteLaxMode
+}
+
+// setAccessCookie writes the access-token cookie. Shared by login and by
+// /auth/refresh. Refresh passes useLax=false: the Lax relaxation exists for the
+// IdP redirect chain at login time, and a refresh is an ordinary same-origin XHR
+// that has no need of it.
+func setAccessCookie(w http.ResponseWriter, r *http.Request, accessToken string, tokenMaxAge int64, env string, useLax, browserSessionCookies bool) {
+	secure := isSecureRequest(r)
+	maxAge := int(tokenMaxAge)
 	if browserSessionCookies {
-		tokenCookieMaxAge = 0
+		maxAge = 0
 	}
 	http.SetCookie(w, &http.Cookie{
 		Name:     "token",
 		Value:    accessToken,
 		Path:     "/",
-		MaxAge:   tokenCookieMaxAge,
+		MaxAge:   maxAge,
 		HttpOnly: true,
 		Secure:   secure && env == "production",
-		SameSite: sameSite,
+		SameSite: cookieSameSite(env, useLax, secure),
 	})
+}
+
+// setAuthCookiesWithRemember sets cookies; rememberMe uses 30-day refresh token.
+// useLax forces SameSite=Lax (required for OIDC redirects from IdP).
+// browserSessionCookies: when true, both cookies use MaxAge 0 (session cookies) so they are not
+// persisted to disk and are dropped when the browser session ends (close all windows / quit).
+func setAuthCookiesWithRemember(w http.ResponseWriter, r *http.Request, accessToken, refreshToken string, tokenMaxAge int64, rememberMe bool, env string, useLax bool, browserSessionCookies bool) {
+	secure := isSecureRequest(r)
+	sameSite := cookieSameSite(env, useLax, secure)
+	setAccessCookie(w, r, accessToken, tokenMaxAge, env, useLax, browserSessionCookies)
 	refreshMaxAge := 7 * 24 * 3600 // 7 days
 	if rememberMe {
 		refreshMaxAge = 30 * 24 * 3600 // 30 days
@@ -1228,6 +1241,102 @@ func (h *AuthHandler) Logout(w http.ResponseWriter, r *http.Request) {
 	}
 	clearAuthCookies(w, r)
 	JSON(w, http.StatusOK, map[string]string{"message": "Logged out"})
+}
+
+// Heartbeat handles POST /auth/heartbeat. It exists purely so the UI has
+// something cheap to call that carries X-User-Activity: the auth middleware does
+// the session lookup, the inactivity check and the last_activity write, so this
+// body has nothing left to do. Pages differ in what they poll, and some poll
+// nothing at all, so without a dedicated beat a user reading a screen would be
+// logged out mid-read on those pages.
+func (h *AuthHandler) Heartbeat(w http.ResponseWriter, _ *http.Request) {
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// Refresh handles POST /auth/refresh. It swaps the refresh_token cookie for a
+// fresh access token on the same session.
+//
+// Without this the access token's lifetime was the real session length: it is
+// absolute from login, no amount of use extended it, and any
+// SESSION_INACTIVITY_TIMEOUT_MINUTES longer than JWT_EXPIRES_IN was unreachable.
+//
+// The refresh token is deliberately not rotated. It is bound to the session row,
+// which several tabs share, and rotating it would make whichever tab lost the
+// race log the user out.
+func (h *AuthHandler) Refresh(w http.ResponseWriter, r *http.Request) {
+	if h.log != nil {
+		h.log.Debug("auth request", "method", r.Method, "path", r.URL.Path)
+	}
+	deny := func(msg string) {
+		clearAuthCookies(w, r)
+		Error(w, http.StatusUnauthorized, msg)
+	}
+
+	c, err := r.Cookie("refresh_token")
+	if err != nil || c.Value == "" {
+		deny("Missing refresh token")
+		return
+	}
+
+	claims := jwt.MapClaims{}
+	t, err := jwt.ParseWithClaims(c.Value, &claims, func(_ *jwt.Token) (interface{}, error) {
+		return []byte(h.cfg.JWTSecret), nil
+	}, jwt.WithValidMethods([]string{"HS256"}))
+	if err != nil || !t.Valid {
+		deny("Invalid refresh token")
+		return
+	}
+	// An access token presented here would otherwise be accepted as a refresh
+	// token, letting a leaked one outlive its own expiry.
+	if typ, _ := claims["typ"].(string); typ != tokenTypeRefresh {
+		deny("Invalid refresh token")
+		return
+	}
+	userID, _ := claims["sub"].(string)
+	if userID == "" {
+		deny("Invalid refresh token")
+		return
+	}
+
+	// GetByRefreshToken already filters on is_revoked and expires_at, so a logged
+	// out or reaped session cannot be refreshed.
+	sess, err := h.sessions.GetByRefreshToken(r.Context(), c.Value)
+	if err != nil || sess == nil || sess.UserID != userID {
+		deny("Session expired")
+		return
+	}
+
+	// Same rule the middleware applies, for the same reason: a refresh is not user
+	// activity, so it must not resurrect a session that has already gone idle.
+	rc := h.resolvedFor(r.Context())
+	if rc != nil && rc.SessionInactivityTimeoutMin > 0 &&
+		time.Since(sess.LastActivity) > time.Duration(rc.SessionInactivityTimeoutMin)*time.Minute {
+		if err := h.sessions.RevokeByID(r.Context(), sess.ID, sess.UserID); err != nil && h.log != nil {
+			h.log.Error("refresh: failed to revoke inactive session", "session_id", sess.ID, "error", err)
+		}
+		deny("Session expired due to inactivity")
+		return
+	}
+
+	user, err := h.users.GetByID(r.Context(), userID)
+	if err != nil || user == nil || !user.IsActive {
+		deny("Session expired")
+		return
+	}
+
+	expiresIn := h.getJwtExpiresInSeconds(r.Context())
+	// Role comes from the database, not the refresh token, so a demotion takes
+	// effect on the next refresh rather than at the end of the refresh window.
+	accessToken, err := h.createAccessToken(user.ID, user.Role, sess.ID, expiresIn)
+	if err != nil {
+		Error(w, http.StatusInternalServerError, "Failed to refresh session")
+		return
+	}
+
+	setAccessCookie(w, r, accessToken, expiresIn, h.cfg.Env, false, h.authBrowserSessionCookies(r.Context()))
+	JSON(w, http.StatusOK, map[string]interface{}{
+		"expires_at": time.Now().Add(time.Duration(expiresIn) * time.Second).Format(time.RFC3339),
+	})
 }
 
 // parseUserAgent extracts browser, OS, and device from user agent string.

--- a/server-source-code/internal/handler/settings.go
+++ b/server-source-code/internal/handler/settings.go
@@ -631,7 +631,24 @@ func (h *SettingsHandler) UpdateEnvironmentConfig(w http.ResponseWriter, r *http
 	}
 	h.invalidateContextCaches(r.Context())
 	slog.Debug("env config update saved", "key", key, "settings_id", s.ID)
-	JSON(w, http.StatusOK, map[string]string{"message": "Saved. Restart the application for changes to take effect."})
+	msg := "Saved. The new value is in effect."
+	if startupOnlyConfigKeys[key] {
+		msg = "Saved. Restart the application for this change to take effect."
+	}
+	JSON(w, http.StatusOK, map[string]string{"message": msg})
+}
+
+// startupOnlyConfigKeys are wired into middleware or the logger when the process
+// boots, so a saved value sits unused until a restart. Everything else resolves
+// per request through ConfigResolver, whose cache this handler has just
+// invalidated, and so applies immediately.
+var startupOnlyConfigKeys = map[string]bool{
+	"CORS_ORIGIN":                 true,
+	"ENABLE_LOGGING":              true,
+	"LOG_LEVEL":                   true,
+	"ENABLE_HSTS":                 true,
+	"TRUST_PROXY":                 true,
+	"DB_TRANSACTION_LONG_TIMEOUT": true,
 }
 
 func orEmpty(s, fallback string) string {

--- a/server-source-code/internal/middleware/auth.go
+++ b/server-source-code/internal/middleware/auth.go
@@ -21,6 +21,22 @@ const UserIDKey contextKey = "user_id"
 const UserRoleKey contextKey = "user_role"
 const SessionIDKey contextKey = "session_id"
 
+// UserActivityHeader marks a request as the direct result of a person using the
+// UI. Only these requests slide the inactivity window. The frontend polls several
+// endpoints on a timer, so treating every authenticated request as activity meant
+// an unattended browser tab kept its own session alive indefinitely and
+// SESSION_INACTIVITY_TIMEOUT_MINUTES never fired.
+const UserActivityHeader = "X-User-Activity"
+
+// userActivity reports whether the caller says this request came from a real
+// interaction. It is a hint about the caller's own session and nothing more: a
+// client that always sent it would only be keeping alive a session it already
+// holds the cookie for. The timeout itself is still checked on every request, so
+// a client that never sends it simply times out.
+func userActivity(r *http.Request) bool {
+	return r.Header.Get(UserActivityHeader) == "1"
+}
+
 // Auth returns a middleware that validates JWT and sets user context.
 // When sessionsStore and resolved are provided and sessionID is in the token,
 // validates session inactivity timeout and updates last_activity.
@@ -101,8 +117,10 @@ func AuthWithSessionCheck(cfg *config.Config, sessionsStore *store.SessionsStore
 					}
 				}
 
-				if err := sessionsStore.UpdateActivity(r.Context(), sessionID); err != nil {
-					slog.Error("auth: failed to update session activity", "session_id", sessionID, "error", err)
+				if userActivity(r) {
+					if err := sessionsStore.UpdateActivity(r.Context(), sessionID); err != nil {
+						slog.Error("auth: failed to update session activity", "session_id", sessionID, "error", err)
+					}
 				}
 			}
 

--- a/server-source-code/internal/middleware/auth_useractivity_test.go
+++ b/server-source-code/internal/middleware/auth_useractivity_test.go
@@ -1,0 +1,43 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestUserActivity_OnlyExactFlagCounts guards the predicate that decides whether
+// a request slides the inactivity window. Anything looser would let the UI's
+// background polling keep an unattended session alive, which is the bug this
+// header was introduced to fix.
+func TestUserActivity_OnlyExactFlagCounts(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		header string
+		set    bool
+		want   bool
+	}{
+		{name: "absent", set: false, want: false},
+		{name: "empty", header: "", set: true, want: false},
+		{name: "one", header: "1", set: true, want: true},
+		{name: "zero", header: "0", set: true, want: false},
+		{name: "true", header: "true", set: true, want: false},
+		{name: "padded", header: " 1", set: true, want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/hosts", nil)
+			if tc.set {
+				req.Header.Set(UserActivityHeader, tc.header)
+			}
+			if got := userActivity(req); got != tc.want {
+				t.Errorf("userActivity(%q set=%v) = %v, want %v", tc.header, tc.set, got, tc.want)
+			}
+		})
+	}
+}

--- a/server-source-code/internal/server/router.go
+++ b/server-source-code/internal/server/router.go
@@ -335,6 +335,10 @@ func NewRouter(ctx context.Context, cfg *config.Config, db *database.DB, rdb *re
 		r.Get("/auth/signup-enabled", authHandler.SignupEnabled)
 		r.With(middleware.RateLimit(redisResolver, cfgResolver, middleware.RateLimitAuth)).Post("/auth/login", authHandler.Login)
 		r.With(middleware.RateLimit(redisResolver, cfgResolver, middleware.RateLimitAuth)).Post("/auth/verify-tfa", authHandler.VerifyTfa)
+		// Unauthenticated by design: it authenticates itself with the refresh_token
+		// cookie, and the caller reaches it precisely because its access token has
+		// expired.
+		r.With(middleware.RateLimit(redisResolver, cfgResolver, middleware.RateLimitAuth)).Post("/auth/refresh", authHandler.Refresh)
 		r.With(middleware.RateLimit(redisResolver, cfgResolver, middleware.RateLimitAuth)).Post("/auth/setup-admin", authHandler.SetupAdmin)
 		r.With(middleware.RateLimit(redisResolver, cfgResolver, middleware.RateLimitAuth)).Post("/auth/signup", authHandler.Signup)
 		if oidcHandler != nil {
@@ -432,6 +436,7 @@ func NewRouter(ctx context.Context, cfg *config.Config, db *database.DB, rdb *re
 			r.Post("/me/billing/sync", billingHandler.PostMyBillingSync(permissionsStore))
 			r.With(middleware.RateLimit(redisResolver, cfgResolver, middleware.RateLimitPassword)).Put("/auth/change-password", authHandler.ChangePassword)
 			r.Post("/auth/logout", authHandler.Logout)
+			r.Post("/auth/heartbeat", authHandler.Heartbeat)
 			r.Get("/auth/sessions", authHandler.GetSessions)
 			r.Delete("/auth/sessions", authHandler.RevokeAllSessions)
 			r.Delete("/auth/sessions/{sessionId}", authHandler.RevokeSession)

--- a/server-source-code/internal/store/settings.go
+++ b/server-source-code/internal/store/settings.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -54,17 +55,23 @@ func (s *SettingsStore) UpdateConfigKey(ctx context.Context, settingsID, key str
 	}
 	switch key {
 	case "MAX_LOGIN_ATTEMPTS":
-		if v, ok := toInt32(value); ok {
-			arg.MaxLoginAttempts = &v
+		v, ok := toInt32(value)
+		if !ok {
+			return fmt.Errorf("%s requires an integer value", key)
 		}
+		arg.MaxLoginAttempts = &v
 	case "LOCKOUT_DURATION_MINUTES":
-		if v, ok := toInt32(value); ok {
-			arg.LockoutDurationMinutes = &v
+		v, ok := toInt32(value)
+		if !ok {
+			return fmt.Errorf("%s requires an integer value", key)
 		}
+		arg.LockoutDurationMinutes = &v
 	case "SESSION_INACTIVITY_TIMEOUT_MINUTES":
-		if v, ok := toInt32(value); ok {
-			arg.SessionInactivityTimeoutMinutes = &v
+		v, ok := toInt32(value)
+		if !ok {
+			return fmt.Errorf("%s requires an integer value", key)
 		}
+		arg.SessionInactivityTimeoutMinutes = &v
 	case "PATCH_RUN_STALL_TIMEOUT_MIN":
 		v, ok := toInt32(value)
 		if !ok {
@@ -92,45 +99,65 @@ func (s *SettingsStore) UpdateConfigKey(ctx context.Context, settingsID, key str
 		}
 		arg.AgentReportsRetentionDays = &v
 	case "TFA_MAX_REMEMBER_SESSIONS":
-		if v, ok := toInt32(value); ok {
-			arg.TfaMaxRememberSessions = &v
+		v, ok := toInt32(value)
+		if !ok {
+			return fmt.Errorf("%s requires an integer value", key)
 		}
+		arg.TfaMaxRememberSessions = &v
 	case "PASSWORD_MIN_LENGTH":
-		if v, ok := toInt32(value); ok {
-			arg.PasswordMinLength = &v
+		v, ok := toInt32(value)
+		if !ok {
+			return fmt.Errorf("%s requires an integer value", key)
 		}
+		arg.PasswordMinLength = &v
 	case "PASSWORD_REQUIRE_UPPERCASE":
-		if v, ok := toBool(value); ok {
-			arg.PasswordRequireUppercase = &v
+		v, ok := toBool(value)
+		if !ok {
+			return fmt.Errorf("%s requires a true/false value", key)
 		}
+		arg.PasswordRequireUppercase = &v
 	case "PASSWORD_REQUIRE_LOWERCASE":
-		if v, ok := toBool(value); ok {
-			arg.PasswordRequireLowercase = &v
+		v, ok := toBool(value)
+		if !ok {
+			return fmt.Errorf("%s requires a true/false value", key)
 		}
+		arg.PasswordRequireLowercase = &v
 	case "PASSWORD_REQUIRE_NUMBER":
-		if v, ok := toBool(value); ok {
-			arg.PasswordRequireNumber = &v
+		v, ok := toBool(value)
+		if !ok {
+			return fmt.Errorf("%s requires a true/false value", key)
 		}
+		arg.PasswordRequireNumber = &v
 	case "PASSWORD_REQUIRE_SPECIAL":
-		if v, ok := toBool(value); ok {
-			arg.PasswordRequireSpecial = &v
+		v, ok := toBool(value)
+		if !ok {
+			return fmt.Errorf("%s requires a true/false value", key)
 		}
+		arg.PasswordRequireSpecial = &v
 	case "ENABLE_HSTS":
-		if v, ok := toBool(value); ok {
-			arg.EnableHsts = &v
+		v, ok := toBool(value)
+		if !ok {
+			return fmt.Errorf("%s requires a true/false value", key)
 		}
+		arg.EnableHsts = &v
 	case "JSON_BODY_LIMIT":
-		if v, ok := toStr(value); ok {
-			arg.JsonBodyLimit = &v
+		v, ok := toStr(value)
+		if !ok {
+			return fmt.Errorf("%s requires a string value", key)
 		}
+		arg.JsonBodyLimit = &v
 	case "AGENT_UPDATE_BODY_LIMIT":
-		if v, ok := toStr(value); ok {
-			arg.AgentUpdateBodyLimit = &v
+		v, ok := toStr(value)
+		if !ok {
+			return fmt.Errorf("%s requires a string value", key)
 		}
+		arg.AgentUpdateBodyLimit = &v
 	case "DB_TRANSACTION_LONG_TIMEOUT":
-		if v, ok := toInt32(value); ok {
-			arg.DbTransactionLongTimeout = &v
+		v, ok := toInt32(value)
+		if !ok {
+			return fmt.Errorf("%s requires an integer value", key)
 		}
+		arg.DbTransactionLongTimeout = &v
 	case "CORS_ORIGIN":
 		v, ok := toStr(value)
 		if !ok {
@@ -138,9 +165,11 @@ func (s *SettingsStore) UpdateConfigKey(ctx context.Context, settingsID, key str
 		}
 		arg.CorsOrigin = &v
 	case "ENABLE_LOGGING":
-		if v, ok := toBool(value); ok {
-			arg.EnableLogging = &v
+		v, ok := toBool(value)
+		if !ok {
+			return fmt.Errorf("%s requires a true/false value", key)
 		}
+		arg.EnableLogging = &v
 	case "LOG_LEVEL":
 		v, ok := toStr(value)
 		if !ok {
@@ -160,17 +189,23 @@ func (s *SettingsStore) UpdateConfigKey(ctx context.Context, settingsID, key str
 		}
 		arg.JwtExpiresIn = &v
 	case "AUTH_BROWSER_SESSION_COOKIES":
-		if v, ok := toBool(value); ok {
-			arg.AuthBrowserSessionCookies = &v
+		v, ok := toBool(value)
+		if !ok {
+			return fmt.Errorf("%s requires a true/false value", key)
 		}
+		arg.AuthBrowserSessionCookies = &v
 	case "MAX_TFA_ATTEMPTS":
-		if v, ok := toInt32(value); ok {
-			arg.MaxTfaAttempts = &v
+		v, ok := toInt32(value)
+		if !ok {
+			return fmt.Errorf("%s requires an integer value", key)
 		}
+		arg.MaxTfaAttempts = &v
 	case "TFA_LOCKOUT_DURATION_MINUTES":
-		if v, ok := toInt32(value); ok {
-			arg.TfaLockoutDurationMinutes = &v
+		v, ok := toInt32(value)
+		if !ok {
+			return fmt.Errorf("%s requires an integer value", key)
 		}
+		arg.TfaLockoutDurationMinutes = &v
 	case "TFA_REMEMBER_ME_EXPIRES_IN":
 		v, ok := toStr(value)
 		if !ok {
@@ -184,41 +219,59 @@ func (s *SettingsStore) UpdateConfigKey(ctx context.Context, settingsID, key str
 		}
 		arg.DefaultUserRole = v
 	case "TRUST_PROXY":
-		if v, ok := toBool(value); ok {
-			arg.TrustProxy = &v
+		v, ok := toBool(value)
+		if !ok {
+			return fmt.Errorf("%s requires a true/false value", key)
 		}
+		arg.TrustProxy = &v
 	case "RATE_LIMIT_WINDOW_MS":
-		if v, ok := toInt32(value); ok {
-			arg.RateLimitWindowMs = &v
+		v, ok := toInt32(value)
+		if !ok {
+			return fmt.Errorf("%s requires an integer value", key)
 		}
+		arg.RateLimitWindowMs = &v
 	case "RATE_LIMIT_MAX":
-		if v, ok := toInt32(value); ok {
-			arg.RateLimitMax = &v
+		v, ok := toInt32(value)
+		if !ok {
+			return fmt.Errorf("%s requires an integer value", key)
 		}
+		arg.RateLimitMax = &v
 	case "AUTH_RATE_LIMIT_WINDOW_MS":
-		if v, ok := toInt32(value); ok {
-			arg.AuthRateLimitWindowMs = &v
+		v, ok := toInt32(value)
+		if !ok {
+			return fmt.Errorf("%s requires an integer value", key)
 		}
+		arg.AuthRateLimitWindowMs = &v
 	case "AUTH_RATE_LIMIT_MAX":
-		if v, ok := toInt32(value); ok {
-			arg.AuthRateLimitMax = &v
+		v, ok := toInt32(value)
+		if !ok {
+			return fmt.Errorf("%s requires an integer value", key)
 		}
+		arg.AuthRateLimitMax = &v
 	case "AGENT_RATE_LIMIT_WINDOW_MS":
-		if v, ok := toInt32(value); ok {
-			arg.AgentRateLimitWindowMs = &v
+		v, ok := toInt32(value)
+		if !ok {
+			return fmt.Errorf("%s requires an integer value", key)
 		}
+		arg.AgentRateLimitWindowMs = &v
 	case "AGENT_RATE_LIMIT_MAX":
-		if v, ok := toInt32(value); ok {
-			arg.AgentRateLimitMax = &v
+		v, ok := toInt32(value)
+		if !ok {
+			return fmt.Errorf("%s requires an integer value", key)
 		}
+		arg.AgentRateLimitMax = &v
 	case "PASSWORD_RATE_LIMIT_WINDOW_MS":
-		if v, ok := toInt32(value); ok {
-			arg.PasswordRateLimitWindowMs = &v
+		v, ok := toInt32(value)
+		if !ok {
+			return fmt.Errorf("%s requires an integer value", key)
 		}
+		arg.PasswordRateLimitWindowMs = &v
 	case "PASSWORD_RATE_LIMIT_MAX":
-		if v, ok := toInt32(value); ok {
-			arg.PasswordRateLimitMax = &v
+		v, ok := toInt32(value)
+		if !ok {
+			return fmt.Errorf("%s requires an integer value", key)
 		}
+		arg.PasswordRateLimitMax = &v
 	default:
 		return errors.New("unknown config key")
 	}


### PR DESCRIPTION
Fixes #918.

`SESSION_INACTIVITY_TIMEOUT_MINUTES` had no observable effect. There were two independent causes.

## 1. Every request counted as activity, including the UI's own polling

`last_activity` was written on every authenticated request. The interface polls on a timer regardless of whether anyone is there: the sidebar alone hits `/ws/status/summary` every 10 seconds on every page, and most pages add a 30 second poll of their own. An unattended browser tab therefore refreshed its own session forever, and the inactivity window never elapsed.

Requests now slide the window only when they carry `X-User-Activity: 1`. The frontend sets that from real interaction (pointer, keyboard, touch, wheel, scroll, and returning to the tab), and a 30 second heartbeat covers screens that poll nothing of their own. The header is a hint about the caller's own session and nothing more, and it is fail-closed: the timeout is still checked on every request, so a client that never sends it simply times out.

## 2. There was no way to renew an access token

No refresh endpoint existed. The `refresh_token` cookie was issued at login and never consumed, so `JWT_EXPIRES_IN` (default `1h`) was the real session length no matter how much the session was used, and any `SESSION_INACTIVITY_TIMEOUT_MINUTES` above it was unreachable. The reporter's `360` could never have worked.

`POST /auth/refresh` now exchanges the `refresh_token` cookie for a new access token on the same session. It re-reads the user's role from the database, applies the same inactivity check so it cannot resurrect a session that has already gone idle, and does not rotate the refresh token, which several tabs share. The Axios interceptor and `AuthContext`'s `fetch` calls both go through one single-flight refresh, so a burst of 401s produces one refresh; only a 401 from the refresh itself ends the session, so a 5xx or a dropped connection no longer signs anyone out.

## 3. Settings and docs

Saving an environment setting whose value would not parse returned "Saved" and silently changed nothing, for 26 of the keys in `UpdateConfigKey`. They now return the same explicit error the validated keys already did. The save message also claimed a restart was required for every key; it now says so only for the six that are genuinely read at boot.

The operator guide said "each authenticated request resets the timer", which was accurate but did not warn that the interface's own refreshes satisfied it, and described token refreshes that did not exist.

## Verification

Ran against a live instance with `SESSION_INACTIVITY_TIMEOUT_MINUTES=1`:

| Scenario | Result |
|---|---|
| Unmarked polling every 10s, nobody present | 401 at t+60s (was 200 forever) |
| Same cadence, marked `X-User-Activity` | 200 throughout |
| 30s heartbeat, unmarked polls in between | alive across 3 minutes |
| Genuinely idle, no requests at all | 401 `Session expired due to inactivity` |

And with `JWT_EXPIRES_IN=1m`, `SESSION_INACTIVITY_TIMEOUT_MINUTES=60`:

| Scenario | Result |
|---|---|
| Poll after the token expired, then refresh, then poll | 401 → 200 → 200 |
| Refresh with no cookie / malformed token / an access token | 401 in all three |
| Refresh on a session already past its inactivity window | 401 `Session expired due to inactivity` |

`make check` and `biome check src/` both pass clean; 177 frontend tests pass. Adds a unit test for the header predicate.

## Notes for reviewers

- Agents and the integration APIs are untouched: they authenticate through `ApiAuth`, not `AuthWithSessionCheck`.
- Anything driving the API with a session JWT outside a browser will now time out on the configured window, since it will not send the header. Automation should use the long-lived API tokens.
- Users will notice they are no longer returned to the login screen every `JWT_EXPIRES_IN`, which is the intended effect of the refresh endpoint.
