### PR TITLE
Three UI fixes: group picker clipping, Windows install command, modal behind the sidebar

### DIFF
--- a/frontend/src/components/AddHostWizard.jsx
+++ b/frontend/src/components/AddHostWizard.jsx
@@ -10,6 +10,7 @@ import {
 	hostGroupsAPI,
 	settingsAPI,
 } from "../utils/api";
+import ModalPortal from "./ui/ModalPortal";
 
 const STEPS = [
 	{ key: 1, label: "Choose OS" },
@@ -319,8 +320,8 @@ const AddHostWizard = ({ isOpen, onClose, onSuccess }) => {
 		</div>
 	);
 
-	return (
-		<div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+	const modal = (
+		<div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-[120] p-4">
 			<div className="bg-white dark:bg-secondary-800 rounded-lg p-4 sm:p-6 w-full max-w-lg max-h-[90vh] overflow-y-auto">
 				<div className="flex justify-between items-center mb-2">
 					<h3 className="text-lg font-medium text-secondary-900 dark:text-white">
@@ -713,6 +714,8 @@ const AddHostWizard = ({ isOpen, onClose, onSuccess }) => {
 			</div>
 		</div>
 	);
+
+	return <ModalPortal>{modal}</ModalPortal>;
 };
 
 export default AddHostWizard;

--- a/frontend/src/components/InlineMultiGroupEdit.jsx
+++ b/frontend/src/components/InlineMultiGroupEdit.jsx
@@ -1,5 +1,12 @@
 import { Check, ChevronDown, Edit2, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { anchorVertically, clampHorizontally } from "../utils/popoverPosition";
+
+// Roughly one option row, used only to decide whether the list would rather
+// open upwards. The rendered height is capped by maxHeight either way.
+const OPTION_HEIGHT = 36;
+const LIST_PADDING = 8;
+const MIN_DROPDOWN_WIDTH = 200;
 
 const InlineMultiGroupEdit = ({
 	value = [], // Array of group IDs
@@ -18,6 +25,7 @@ const InlineMultiGroupEdit = ({
 		top: 0,
 		left: 0,
 		width: 0,
+		maxHeight: 240,
 	});
 	const dropdownRef = useRef(null);
 	const buttonRef = useRef(null);
@@ -38,15 +46,19 @@ const InlineMultiGroupEdit = ({
 
 	// Calculate dropdown position
 	const calculateDropdownPosition = useCallback(() => {
-		if (buttonRef.current) {
-			const rect = buttonRef.current.getBoundingClientRect();
-			setDropdownPosition({
-				top: rect.bottom + window.scrollY + 4,
-				left: rect.left + window.scrollX,
-				width: rect.width,
-			});
-		}
-	}, []);
+		if (!buttonRef.current) return;
+		const rect = buttonRef.current.getBoundingClientRect();
+		const width = Math.max(rect.width, MIN_DROPDOWN_WIDTH);
+		const desiredHeight =
+			Math.max(options.length, 1) * OPTION_HEIGHT + LIST_PADDING;
+		const { top, maxHeight } = anchorVertically(rect, desiredHeight);
+		setDropdownPosition({
+			top,
+			left: clampHorizontally(rect.left, width),
+			width,
+			maxHeight,
+		});
+	}, [options.length]);
 
 	// Close dropdown when clicking outside
 	useEffect(() => {
@@ -60,11 +72,13 @@ const InlineMultiGroupEdit = ({
 			calculateDropdownPosition();
 			document.addEventListener("mousedown", handleClickOutside);
 			window.addEventListener("resize", calculateDropdownPosition);
-			window.addEventListener("scroll", calculateDropdownPosition);
+			// Capture phase so a scroll inside the table, not just the window,
+			// keeps the dropdown pinned to its trigger.
+			window.addEventListener("scroll", calculateDropdownPosition, true);
 			return () => {
 				document.removeEventListener("mousedown", handleClickOutside);
 				window.removeEventListener("resize", calculateDropdownPosition);
-				window.removeEventListener("scroll", calculateDropdownPosition);
+				window.removeEventListener("scroll", calculateDropdownPosition, true);
 			};
 		}
 	}, [isOpen, calculateDropdownPosition]);
@@ -171,12 +185,12 @@ const InlineMultiGroupEdit = ({
 
 						{isOpen && (
 							<div
-								className="fixed z-50 bg-white dark:bg-secondary-800 border border-secondary-300 dark:border-secondary-600 rounded-md shadow-lg max-h-60 overflow-auto"
+								className="fixed z-50 bg-white dark:bg-secondary-800 border border-secondary-300 dark:border-secondary-600 rounded-md shadow-lg overflow-auto"
 								style={{
 									top: `${dropdownPosition.top}px`,
 									left: `${dropdownPosition.left}px`,
 									width: `${dropdownPosition.width}px`,
-									minWidth: "200px",
+									maxHeight: `${Math.min(dropdownPosition.maxHeight, 240)}px`,
 								}}
 							>
 								<div className="py-1">

--- a/frontend/src/components/ui/ModalPortal.jsx
+++ b/frontend/src/components/ui/ModalPortal.jsx
@@ -1,0 +1,11 @@
+import { createPortal } from "react-dom";
+
+// The main content wrapper in Layout carries `relative z-10`, which makes it a
+// stacking context. Anything rendered inside it is painted below the desktop
+// sidebar (z-[100]) no matter how high its own z-index goes, so a modal wide
+// enough to reach under the sidebar loses that strip of itself. Portalling to
+// the body takes the modal out of that stacking context; the overlay then only
+// has to out-rank the sidebar, which the z-[120] tier does.
+const ModalPortal = ({ children }) => createPortal(children, document.body);
+
+export default ModalPortal;

--- a/frontend/src/pages/Reporting.jsx
+++ b/frontend/src/pages/Reporting.jsx
@@ -48,11 +48,18 @@ import {
 	formatDate,
 	formatRelativeTime,
 } from "../utils/api";
+import { anchorVertically } from "../utils/popoverPosition";
 import { NotificationPanel } from "./settings/AlertChannels";
 import { AlertSettings } from "./settings/AlertSettings";
 
 // System-only actions that should not appear in user-facing menus
 const SYSTEM_ONLY_ACTIONS = new Set(["created", "updated"]);
+
+// Approximate row metrics for the actions menu, used only to decide whether it
+// would rather open upwards. The rendered height is capped either way.
+const ACTION_HEIGHT = 36;
+const SECTION_HEADING_HEIGHT = 24;
+const MENU_PADDING = 8;
 
 // Assignment filter values that are not a specific user id
 const ASSIGNMENT_PRESETS = new Set([
@@ -120,7 +127,11 @@ const Reporting = () => {
 	const [selectedAlert, setSelectedAlert] = useState(null);
 	const [showAlertModal, setShowAlertModal] = useState(false);
 	const [openActionMenu, setOpenActionMenu] = useState(null);
-	const [menuPosition, setMenuPosition] = useState({ top: 0, right: 0 });
+	const [menuPosition, setMenuPosition] = useState({
+		top: 0,
+		right: 0,
+		maxHeight: 0,
+	});
 	const menuButtonRefs = useRef({});
 	const [selectedAlerts, setSelectedAlerts] = useState(new Set());
 	const [activeTab, setActiveTab] = useState(
@@ -593,16 +604,25 @@ const Reporting = () => {
 	};
 
 	// Calculate menu position based on button location
-	const calculateMenuPosition = useCallback((alertId) => {
-		const buttonRef = menuButtonRefs.current[alertId];
-		if (buttonRef) {
+	const calculateMenuPosition = useCallback(
+		(alertId) => {
+			const buttonRef = menuButtonRefs.current[alertId];
+			if (!buttonRef) return;
 			const rect = buttonRef.getBoundingClientRect();
+			const desiredHeight =
+				(workflowActions.length + resolutionActions.length) * ACTION_HEIGHT +
+				(workflowActions.length > 0 ? SECTION_HEADING_HEIGHT : 0) +
+				(resolutionActions.length > 0 ? SECTION_HEADING_HEIGHT : 0) +
+				MENU_PADDING;
+			const { top, maxHeight } = anchorVertically(rect, desiredHeight);
 			setMenuPosition({
-				top: rect.bottom + window.scrollY + 4,
-				right: window.innerWidth - rect.right + window.scrollX,
+				top,
+				right: Math.max(0, window.innerWidth - rect.right),
+				maxHeight,
 			});
-		}
-	}, []);
+		},
+		[workflowActions.length, resolutionActions.length],
+	);
 
 	// Update menu position when menu opens
 	useEffect(() => {
@@ -1310,10 +1330,11 @@ const Reporting = () => {
 							/>
 							<div
 								data-menu-id={openActionMenu}
-								className="fixed z-50 w-48 bg-white dark:bg-secondary-800 rounded-md shadow-lg border border-secondary-200 dark:border-secondary-600"
+								className="fixed z-50 w-48 bg-white dark:bg-secondary-800 rounded-md shadow-lg border border-secondary-200 dark:border-secondary-600 overflow-y-auto"
 								style={{
 									top: `${menuPosition.top}px`,
 									right: `${menuPosition.right}px`,
+									maxHeight: `${menuPosition.maxHeight}px`,
 								}}
 								onClick={(e) => e.stopPropagation()}
 							>

--- a/frontend/src/pages/hostdetail/CredentialsModal.jsx
+++ b/frontend/src/pages/hostdetail/CredentialsModal.jsx
@@ -9,6 +9,7 @@ import {
 	X,
 } from "lucide-react";
 import { useEffect, useId, useState } from "react";
+import ModalPortal from "../../components/ui/ModalPortal";
 import { adminHostsAPI, settingsAPI } from "../../utils/api";
 import WaitingForConnection from "./WaitingForConnection";
 
@@ -179,8 +180,8 @@ const CredentialsModal = ({ host, isOpen, onClose, plaintextApiKey }) => {
 		);
 	}
 
-	return (
-		<div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+	const modal = (
+		<div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-[120] p-4">
 			<div className="bg-white dark:bg-secondary-800 rounded-lg p-4 md:p-6 w-full max-w-4xl max-h-[90vh] overflow-y-auto">
 				<div className="flex justify-between items-center mb-4 gap-3">
 					<h3 className="text-base md:text-lg font-medium text-secondary-900 dark:text-white truncate">
@@ -509,6 +510,8 @@ const CredentialsModal = ({ host, isOpen, onClose, plaintextApiKey }) => {
 			</div>
 		</div>
 	);
+
+	return <ModalPortal>{modal}</ModalPortal>;
 };
 
 export default CredentialsModal;

--- a/frontend/src/pages/hostdetail/WaitingForConnection.jsx
+++ b/frontend/src/pages/hostdetail/WaitingForConnection.jsx
@@ -2,6 +2,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { CheckCircle, Copy, Download, RefreshCw, Wifi, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import ModalPortal from "../../components/ui/ModalPortal";
 import { dashboardAPI } from "../../utils/api";
 
 // Check if host has received initial report (has system info beyond "unknown")
@@ -180,8 +181,8 @@ const WaitingForConnection = ({
 		}
 	};
 
-	return (
-		<div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+	const modal = (
+		<div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-[120] p-4">
 			<div className="bg-white dark:bg-secondary-800 rounded-lg p-6 w-full max-w-md">
 				<div className="flex justify-between items-center mb-6">
 					<h3 className="text-lg font-medium text-secondary-900 dark:text-white">
@@ -331,6 +332,8 @@ const WaitingForConnection = ({
 			</div>
 		</div>
 	);
+
+	return <ModalPortal>{modal}</ModalPortal>;
 };
 
 export default WaitingForConnection;

--- a/frontend/src/utils/popoverPosition.js
+++ b/frontend/src/utils/popoverPosition.js
@@ -1,0 +1,37 @@
+// Placement helpers for popovers that escape a clipping ancestor by using
+// `position: fixed`. Fixed coordinates are viewport relative, so the popover
+// has to be clamped to the viewport as well: anchoring it below its trigger
+// unconditionally puts it out of reach for any trigger near the window bottom,
+// and page scroll offsets must not be added at all.
+
+const GAP = 4;
+const MARGIN = 8;
+const MIN_HEIGHT = 120;
+
+// Returns the viewport `top` for a popover anchored to `rect`, plus the
+// `maxHeight` it may occupy there. It opens downwards whenever that side fits
+// or is the roomier one, and flips above otherwise. `maxHeight` is always the
+// real space on the chosen side, so an inaccurate `desiredHeight` can only
+// change which way it opens, never leave content unreachable.
+export const anchorVertically = (rect, desiredHeight) => {
+	const spaceBelow = window.innerHeight - rect.bottom - GAP - MARGIN;
+	const spaceAbove = rect.top - GAP - MARGIN;
+
+	if (spaceBelow >= desiredHeight || spaceBelow >= spaceAbove) {
+		return {
+			top: rect.bottom + GAP,
+			maxHeight: Math.max(spaceBelow, MIN_HEIGHT),
+		};
+	}
+
+	const height = Math.min(desiredHeight, Math.max(spaceAbove, MIN_HEIGHT));
+	return {
+		top: Math.max(MARGIN, rect.top - GAP - height),
+		maxHeight: Math.max(spaceAbove, MIN_HEIGHT),
+	};
+};
+
+// Keeps a popover of `width` inside the window when its trigger sits close to
+// the right edge.
+export const clampHorizontally = (left, width) =>
+	Math.max(MARGIN, Math.min(left, window.innerWidth - width - MARGIN));

--- a/server-source-code/internal/handler/hosts.go
+++ b/server-source-code/internal/handler/hosts.go
@@ -1302,6 +1302,7 @@ func hostToResponse(h *models.Host, groups []models.HostGroup) map[string]interf
 		"docker_enabled": h.DockerEnabled, "compliance_enabled": h.ComplianceEnabled,
 		"package_manager": h.PackageManager, "primary_interface": h.PrimaryInterface,
 		"awaiting_post_patch_report_run_id": h.AwaitingPostPatchReportRunID,
+		"expected_platform":                 h.ExpectedPlatform,
 	}
 	hg := make([]map[string]interface{}, len(groups))
 	for i, g := range groups {

--- a/server-source-code/internal/store/dashboard.go
+++ b/server-source-code/internal/store/dashboard.go
@@ -752,6 +752,10 @@ func (s *DashboardStore) GetHostDetail(ctx context.Context, hostID string, histo
 		"dns_servers": dnsServers, "network_interfaces": networkInterfaces,
 		"disk_details": diskDetails, "load_average": loadAverage,
 		"host_group_memberships": hg, "primary_interface": host.PrimaryInterface,
+		// Until the agent checks in, os_type is "unknown", so the install
+		// command the UI offers can only come from the platform picked at
+		// creation time.
+		"expected_platform": host.ExpectedPlatform,
 	}
 
 	stats, _ := d.Queries.GetHostPackageStats(ctx, hostID)


### PR DESCRIPTION
Three UI bugs from 2.0.2, one commit each.

Closes #1005
Closes #1004
Closes #1002

## #1005, group picker cut off at the bottom of the window

The group picker in the host list, and the actions menu on an alert row, both anchor themselves under their trigger with `position: fixed`. Both added `window.scrollY` to a rect that is already viewport relative, and neither checked whether the menu would fit. Open the picker on the last row of a list that reaches the bottom of the window and the menu is drawn past the window edge, with the groups at the end of it unreachable and nothing to scroll.

Placement now goes through a small shared helper. A menu opens downwards when that side fits or is the roomier one and flips above otherwise, and it is always given the height actually available on the side it picked, so a wrong height estimate can only change which way it opens, never leave an option out of reach. The picker is also clamped to the right window edge, and both menus now listen for scroll in the capture phase, so scrolling the table rather than the window keeps the menu on its trigger.

| Measured at 1280 x 800, last row of a 14 host list | Before | After |
|---|---|---|
| Menu bottom vs window bottom | 919 vs 800 | 657 vs 800 |
| Drawn past the window edge | 119px | 0px |
| Opens above the trigger when it will not fit below | no | yes |
| Last group in the list actually clickable | no | yes |

## #1004, Windows host offered the Linux install command

A host created through the wizard but never installed still has `os_type` "unknown", so the only record of which platform it is is `expected_platform`, chosen at creation time. Neither the dashboard host detail response nor `hostToResponse` carried that field, so the host setup modal fell through to its Linux branch and offered a `curl | sudo sh` one-liner for a Windows box. Both responses now include it.

| Command shown after Regenerate | |
|---|---|
| Before | `curl -s "https://.../api/v1/hosts/install" -H "X-API-ID: ..." \| sudo sh` |
| After | `Invoke-WebRequest -Uri "https://.../api/v1/hosts/install?os=windows" -Headers @{...} -UseBasicParsing -OutFile ...` |

The Windows only options, SSL bypass and the curl alternative, come back with it.

## #1002, host setup modal behind the sidebar

The main content wrapper is `relative z-10`, which makes it a stacking context, so everything the router renders is painted at layer 10 whatever its own z-index says. The desktop sidebar is a sibling at `z-[100]`. A modal wide enough to reach the sidebar strip therefore loses that part of itself, and raising the modal's own z-index cannot fix it. Its backdrop stopped at the sidebar too, so the nav links stayed clickable underneath an open modal.

A new `ModalPortal` renders into `document.body`, which takes the modal out of that stacking context. The overlay then only has to out-rank the sidebar, which the `z-[120]` tier already used by the confirm dialog does. Applied to the three modals in the host setup flow: `AddHostWizard`, `CredentialsModal` and `WaitingForConnection`.

| Measured at 1106 x 934, sidebar pinned open | Before | After |
|---|---|---|
| Sidebar paints over the modal | yes, left 151px | no |
| Sidebar links clickable behind the open modal | yes | no |

## Verification

Driven in a headless browser against production builds of `main` and of this branch, with the API stubbed so the same fixtures reach both. Every number in the tables above is measured from the live DOM rather than read off the diff. `make check` and `biome check src/` are clean, and the frontend builds.

Narrow modals that never reach the sidebar are left in tree at `z-50`; the portal pattern and when to reach for it are written up in the internal UI design system notes alongside the popover placement rules.
