### PR TITLE
Stop the Windows agent destroying its own config

### DIFF
--- a/agent-source-code/cmd/patchmon-agent/commands/config.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/config.go
@@ -4,6 +4,7 @@ package commands
 import (
 	"fmt"
 	"net/url"
+	"os"
 	"strings"
 
 	"patchmon-agent/internal/pkgversion"
@@ -110,6 +111,10 @@ func configureCreds(apiID, apiKey, serverURL string) error {
 	}
 
 	if loadErr := cfgManager.LoadError(); loadErr != nil {
+		// The logger writes only to the agent log, and this is the one
+		// deliberately destructive path, so the operator gets it on stderr too.
+		fmt.Fprintf(os.Stderr, "warning: %s could not be parsed (%v) and is being replaced with defaults; any other settings it held are lost\n",
+			cfgManager.GetConfigFile(), loadErr)
 		logger.WithError(loadErr).WithField("path", cfgManager.GetConfigFile()).
 			Warn("Existing config could not be parsed and is being replaced with defaults, any settings it held are lost")
 	}

--- a/agent-source-code/cmd/patchmon-agent/commands/config.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/config.go
@@ -109,6 +109,11 @@ func configureCreds(apiID, apiKey, serverURL string) error {
 		return fmt.Errorf("invalid server URL format. Must start with http:// or https://")
 	}
 
+	if loadErr := cfgManager.LoadError(); loadErr != nil {
+		logger.WithError(loadErr).WithField("path", cfgManager.GetConfigFile()).
+			Warn("Existing config could not be parsed and is being replaced with defaults, any settings it held are lost")
+	}
+
 	if err := cfgManager.SetPatchmonServer(serverURL); err != nil {
 		return fmt.Errorf("failed to save config: %w", err)
 	}

--- a/agent-source-code/cmd/patchmon-agent/commands/report.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/report.go
@@ -396,7 +396,7 @@ func sendIntegrationData() {
 	// Set enabled checker to respect config.yml settings
 	// Load config first to check integration status
 	if err := cfgManager.LoadConfig(); err != nil {
-		logger.WithError(err).Debug("Failed to load config for integration check")
+		logger.WithError(err).Warn("Failed to load config for integration check")
 	}
 	integrationMgr.SetEnabledChecker(func(name string) bool {
 		return cfgManager.IsIntegrationEnabled(name)
@@ -893,7 +893,7 @@ func runScheduledComplianceScan() {
 	logger.Info("Starting scheduled compliance scan")
 
 	if err := cfgManager.LoadConfig(); err != nil {
-		logger.WithError(err).Debug("Failed to load config for scheduled compliance scan")
+		logger.WithError(err).Warn("Failed to load config for scheduled compliance scan")
 	}
 
 	complianceInteg := compliance.New(logger)

--- a/agent-source-code/cmd/patchmon-agent/commands/serve.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/serve.go
@@ -72,6 +72,13 @@ func agentHostKeyCallback() ssh.HostKeyCallback {
 
 // runServiceLoop is the main service loop. stopCh signals shutdown (nil = run forever on Unix)
 func runServiceLoop(stopCh <-chan struct{}) error {
+	// Starting on defaults when the file is present but unparseable means an
+	// empty patchmon_server, so every call fails and the agent reports nothing.
+	// Fail visibly instead of running blind.
+	if err := cfgManager.LoadError(); err != nil {
+		return fmt.Errorf("config file %s could not be read, refusing to start on defaults: %w", cfgManager.GetConfigFile(), err)
+	}
+
 	// When running as Windows service, allow a brief delay for system initialization
 	// (network, filesystem) to be ready after SCM starts the process. This addresses
 	// first-start issues where the report task would not run.

--- a/agent-source-code/internal/config/config.go
+++ b/agent-source-code/internal/config/config.go
@@ -67,15 +67,24 @@ var AvailableIntegrations = []string{
 	// Future: "proxmox", "kubernetes", etc.
 }
 
+// ErrConfigUnreadable is returned by a save when the config file exists but the
+// last load could not parse it. The in-memory config is New()'s defaults at that
+// point, so writing it out would replace the operator's settings, and
+// patchmon_server defaults to empty.
+var ErrConfigUnreadable = errors.New("refusing to overwrite a config file that could not be read")
+
 // Manager handles configuration management
 type Manager struct {
-	// Guards config, credentials and configFile. LoadConfig replaces
+	// Guards config, credentials, configFile and loadErr. LoadConfig replaces
 	// config.Integrations while the service loop and schedulers read it, and a
 	// concurrent map read/write is an unrecoverable runtime fatal.
 	mu          sync.RWMutex
 	config      *models.Config
 	credentials *models.Credentials
 	configFile  string
+	// Set when configFile exists but did not parse. Every automatic save is
+	// refused while it is set.
+	loadErr error
 }
 
 // New creates a new configuration manager
@@ -111,6 +120,15 @@ func (m *Manager) GetConfigFile() string {
 	return m.configFile
 }
 
+// LoadError returns the failure from the last LoadConfig, or nil if the config
+// file parsed or does not exist. A non-nil value means the running config is
+// defaults rather than what is on disk.
+func (m *Manager) LoadError() error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.loadErr
+}
+
 // GetConfig returns the current configuration
 // The returned pointer is a snapshot: LoadConfig swaps in a fresh struct rather
 // than mutating this one.
@@ -135,6 +153,7 @@ func (m *Manager) LoadConfig() error {
 	// Check if config file exists
 	if _, err := os.Stat(m.configFile); errors.Is(err, fs.ErrNotExist) {
 		// Use defaults if config file doesn't exist
+		m.loadErr = nil
 		return nil
 	}
 
@@ -148,6 +167,7 @@ func (m *Manager) LoadConfig() error {
 	// file is intact either side of that window, so the read is retried rather
 	// than failing the load.
 	if err := retryTransientFile(v.ReadInConfig); err != nil {
+		m.loadErr = err
 		return fmt.Errorf("error reading config file: %w", err)
 	}
 
@@ -156,8 +176,10 @@ func (m *Manager) LoadConfig() error {
 	loaded := *m.config
 	loaded.Integrations = nil
 	if err := v.Unmarshal(&loaded); err != nil {
+		m.loadErr = err
 		return fmt.Errorf("error unmarshaling config: %w", err)
 	}
+	m.loadErr = nil
 	m.config = &loaded
 
 	// Handle backward compatibility: set defaults for fields that may not exist in older configs
@@ -398,6 +420,10 @@ func (m *Manager) SaveConfig() error {
 
 // Caller must hold the write lock.
 func (m *Manager) saveConfigLocked() error {
+	if m.loadErr != nil {
+		return fmt.Errorf("%w (%s): %w", ErrConfigUnreadable, m.configFile, m.loadErr)
+	}
+
 	if err := m.setupDirectories(); err != nil {
 		return err
 	}
@@ -518,9 +544,14 @@ func (m *Manager) SetUpdateInterval(interval int) error {
 }
 
 // SetPatchmonServer sets the server URL and saves it.
+//
+// `config set-api` is the documented recovery for a config file the agent
+// cannot parse, so this is the one saver that replaces an unreadable file
+// instead of refusing. The operator asked for the rewrite explicitly.
 func (m *Manager) SetPatchmonServer(serverURL string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	m.loadErr = nil
 	m.config.PatchmonServer = serverURL
 	return m.saveConfigLocked()
 }

--- a/agent-source-code/internal/config/config.go
+++ b/agent-source-code/internal/config/config.go
@@ -73,6 +73,11 @@ var AvailableIntegrations = []string{
 // patchmon_server defaults to empty.
 var ErrConfigUnreadable = errors.New("refusing to overwrite a config file that could not be read")
 
+// ErrConfigEmpty is the load failure for a file that parses but yields nothing.
+// Valid YAML, no settings: a truncated write leaves exactly this, and treating
+// it as a successful load would mean saving defaults back over it.
+var ErrConfigEmpty = errors.New("config file contains no settings")
+
 // Manager handles configuration management
 type Manager struct {
 	// Guards config, credentials, configFile and loadErr. LoadConfig replaces
@@ -169,6 +174,11 @@ func (m *Manager) LoadConfig() error {
 	if err := retryTransientFile(v.ReadInConfig); err != nil {
 		m.loadErr = err
 		return fmt.Errorf("error reading config file: %w", err)
+	}
+
+	if len(v.AllKeys()) == 0 {
+		m.loadErr = ErrConfigEmpty
+		return fmt.Errorf("error reading config file: %w", ErrConfigEmpty)
 	}
 
 	// Swapped in rather than mutated, so readers holding a GetConfig() pointer

--- a/agent-source-code/internal/config/config_unreadable_test.go
+++ b/agent-source-code/internal/config/config_unreadable_test.go
@@ -135,6 +135,45 @@ func TestLoadConfig_ClearsFailureOnceTheFileParses(t *testing.T) {
 	}
 }
 
+// A file that parses to nothing is the same hazard as one that does not parse:
+// LoadConfig would otherwise report success and immediately save its defaults
+// back over it. A truncated write leaves exactly this.
+func TestLoadConfig_EmptyFileIsAFailure(t *testing.T) {
+	t.Parallel()
+
+	for name, content := range map[string]string{
+		"zero bytes":    "",
+		"only comments": "# nothing here\n",
+		"only newlines": "\n\n",
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			dir := t.TempDir()
+			cfgPath := filepath.Join(dir, "config.yml")
+			if err := os.WriteFile(cfgPath, []byte(content), 0o600); err != nil {
+				t.Fatalf("writing test config: %v", err)
+			}
+
+			m := New()
+			m.SetConfigFile(cfgPath)
+			cfg := m.GetConfig()
+			cfg.CredentialsFile = filepath.Join(dir, "credentials.yml")
+			cfg.LogFile = filepath.Join(dir, "agent.log")
+
+			if err := m.LoadConfig(); !errors.Is(err, ErrConfigEmpty) {
+				t.Fatalf("LoadConfig error = %v, want ErrConfigEmpty", err)
+			}
+			after, err := os.ReadFile(cfgPath)
+			if err != nil {
+				t.Fatalf("reading config back: %v", err)
+			}
+			if string(after) != content {
+				t.Fatalf("config file was rewritten:\n%s", after)
+			}
+		})
+	}
+}
+
 // A missing file is not a failure: the agent is meant to start on defaults so
 // that config set-api can create one.
 func TestLoadConfig_MissingFileIsNotAFailure(t *testing.T) {

--- a/agent-source-code/internal/config/config_unreadable_test.go
+++ b/agent-source-code/internal/config/config_unreadable_test.go
@@ -1,0 +1,151 @@
+package config
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// brokenWindowsConfig is what the Windows installer used to write: YAML double
+// quotes around Windows paths. A double-quoted scalar processes backslash
+// escapes, and "\c" is not one of them, so the document does not parse.
+//
+// "\P" is a valid escape (U+2029), which is why this looks so arbitrary: the
+// same quoting corrupts silently on some paths and fails loudly on others.
+const brokenWindowsConfig = `patchmon_server: "https://patchmon.example.net"
+api_version: "v1"
+credentials_file: "C:\ProgramData\PatchMon\credentials.yml"
+log_file: "C:\ProgramData\PatchMon\patchmon-agent.log"
+log_level: "info"
+skip_ssl_verify: false
+`
+
+func newUnreadableManager(t *testing.T) (*Manager, string) {
+	t.Helper()
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yml")
+	if err := os.WriteFile(cfgPath, []byte(brokenWindowsConfig), 0o600); err != nil {
+		t.Fatalf("writing test config: %v", err)
+	}
+
+	m := New()
+	m.SetConfigFile(cfgPath)
+	cfg := m.GetConfig()
+	cfg.CredentialsFile = filepath.Join(dir, "credentials.yml")
+	cfg.LogFile = filepath.Join(dir, "agent.log")
+
+	if err := m.LoadConfig(); err == nil {
+		t.Fatal("LoadConfig accepted a config file with invalid YAML escapes")
+	}
+	return m, cfgPath
+}
+
+func TestLoadConfig_RecordsFailureAndKeepsDefaults(t *testing.T) {
+	t.Parallel()
+	m, _ := newUnreadableManager(t)
+
+	if m.LoadError() == nil {
+		t.Fatal("LoadError is nil after a failed load")
+	}
+	if got := m.GetConfig().PatchmonServer; got != "" {
+		t.Fatalf("PatchmonServer = %q, want the empty default: the file did not parse, so nothing from it should be in memory", got)
+	}
+}
+
+// The regression this whole change exists for: the agent fell back to defaults,
+// then wrote them back over the operator's file, blanking patchmon_server.
+func TestSave_RefusesAfterFailedLoad(t *testing.T) {
+	t.Parallel()
+
+	savers := map[string]func(m *Manager) error{
+		"SetReportOffset":        func(m *Manager) error { return m.SetReportOffset(42) },
+		"SetUpdateInterval":      func(m *Manager) error { return m.SetUpdateInterval(120) },
+		"SetPackageCacheRefresh": func(m *Manager) error { return m.SetPackageCacheRefresh("always", 60) },
+		"SetIntegrationEnabled":  func(m *Manager) error { return m.SetIntegrationEnabled("docker", true) },
+		"SaveConfig":             func(m *Manager) error { return m.SaveConfig() },
+	}
+
+	for name, save := range savers {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			m, cfgPath := newUnreadableManager(t)
+
+			err := save(m)
+			if err == nil {
+				t.Fatal("save succeeded against a config file that could not be read")
+			}
+			if !errors.Is(err, ErrConfigUnreadable) {
+				t.Fatalf("error = %v, want one wrapping ErrConfigUnreadable", err)
+			}
+
+			after, readErr := os.ReadFile(cfgPath)
+			if readErr != nil {
+				t.Fatalf("reading config back: %v", readErr)
+			}
+			if string(after) != brokenWindowsConfig {
+				t.Fatalf("config file was rewritten:\n%s", after)
+			}
+		})
+	}
+}
+
+// config set-api is the documented recovery, so it is the one saver allowed to
+// replace a file the agent cannot parse.
+func TestSetPatchmonServer_RepairsUnreadableConfig(t *testing.T) {
+	t.Parallel()
+	m, cfgPath := newUnreadableManager(t)
+
+	const serverURL = "https://patchmon.example.net"
+	if err := m.SetPatchmonServer(serverURL); err != nil {
+		t.Fatalf("SetPatchmonServer on an unreadable config: %v", err)
+	}
+	if m.LoadError() != nil {
+		t.Fatalf("LoadError still set after a repair: %v", m.LoadError())
+	}
+
+	fresh := New()
+	fresh.SetConfigFile(cfgPath)
+	if err := fresh.LoadConfig(); err != nil {
+		t.Fatalf("repaired config still does not parse: %v", err)
+	}
+	if got := fresh.GetConfig().PatchmonServer; got != serverURL {
+		t.Fatalf("PatchmonServer = %q, want %q", got, serverURL)
+	}
+	if fresh.LoadError() != nil {
+		t.Fatalf("LoadError set after a successful load: %v", fresh.LoadError())
+	}
+}
+
+func TestLoadConfig_ClearsFailureOnceTheFileParses(t *testing.T) {
+	t.Parallel()
+	m, cfgPath := newUnreadableManager(t)
+
+	if err := os.WriteFile(cfgPath, []byte(testConfigYAML), 0o600); err != nil {
+		t.Fatalf("rewriting test config: %v", err)
+	}
+	if err := m.LoadConfig(); err != nil {
+		t.Fatalf("LoadConfig on a valid file: %v", err)
+	}
+	if m.LoadError() != nil {
+		t.Fatalf("LoadError = %v, want nil after a successful load", m.LoadError())
+	}
+	if err := m.SetReportOffset(42); err != nil {
+		t.Fatalf("saving after recovery: %v", err)
+	}
+}
+
+// A missing file is not a failure: the agent is meant to start on defaults so
+// that config set-api can create one.
+func TestLoadConfig_MissingFileIsNotAFailure(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.SetConfigFile(filepath.Join(t.TempDir(), "config.yml"))
+
+	if err := m.LoadConfig(); err != nil {
+		t.Fatalf("LoadConfig with no file present: %v", err)
+	}
+	if m.LoadError() != nil {
+		t.Fatalf("LoadError = %v, want nil when the file simply does not exist", m.LoadError())
+	}
+}

--- a/docs/patchmon-operator-guide.md
+++ b/docs/patchmon-operator-guide.md
@@ -4649,6 +4649,19 @@ On Linux, these files are owned by root and set to `600` permissions (read/write
 | **Log File** | Linux: `/etc/patchmon/logs/patchmon-agent.log`  Windows: `C:\ProgramData\PatchMon\patchmon-agent.log` | Agent log output |
 | **Cron File** | `/etc/cron.d/patchmon-agent` | Scheduled reporting (fallback for non-systemd systems) |
 
+#### Quoting Windows paths
+
+YAML treats a backslash inside **double** quotes as the start of an escape sequence, so a double-quoted Windows path is either rejected or silently altered. `"C:\ProgramData\PatchMon\credentials.yml"` fails to parse, because `\c` is not a valid escape. `"C:\ProgramData\PatchMon\Notes"` is worse: it parses, but `\N` is a valid escape and becomes a control character, so the path you get is not the path you wrote.
+
+Use single quotes, or no quotes at all, for any value containing a backslash:
+
+```yaml
+credentials_file: 'C:\ProgramData\PatchMon\credentials.yml'
+log_file: C:\ProgramData\PatchMon\patchmon-agent.log
+```
+
+If `config.yml` cannot be parsed, the agent refuses to start rather than falling back to its built-in defaults, and writes the parse error to the agent log. This is deliberate: an agent running on defaults has no server URL, so it reports nothing, and its first save would overwrite your file with those defaults. Repair the file, or run `patchmon-agent.exe config set-api <API_ID> <API_KEY> <SERVER_URL>` to write a fresh one.
+
 ### Full Configuration Reference
 
 Below is a complete `config.yml` with all available parameters, their defaults, and descriptions:

--- a/docs/patchmon-operator-guide.md
+++ b/docs/patchmon-operator-guide.md
@@ -4660,7 +4660,11 @@ credentials_file: 'C:\ProgramData\PatchMon\credentials.yml'
 log_file: C:\ProgramData\PatchMon\patchmon-agent.log
 ```
 
-If `config.yml` cannot be parsed, the agent refuses to start rather than falling back to its built-in defaults, and writes the parse error to the agent log. This is deliberate: an agent running on defaults has no server URL, so it reports nothing, and its first save would overwrite your file with those defaults. Repair the file, or run `patchmon-agent.exe config set-api <API_ID> <API_KEY> <SERVER_URL>` to write a fresh one.
+If `config.yml` cannot be parsed, the agent **service** refuses to start rather than falling back to its built-in defaults, and writes the parse error to the agent log. This is deliberate: an agent running on defaults has no server URL, so it reports nothing, and its first save would overwrite your file with those defaults. One-off commands such as `report` and `ping`, including the cron fallback on hosts without systemd, still run, but they will fail against that empty server URL.
+
+The same applies to a `config.yml` that is present but empty, which is what a write interrupted by a full disk or a power cut leaves behind.
+
+To recover, repair the file, or run `patchmon-agent config set-api <API_ID> <API_KEY> <SERVER_URL>` (`patchmon-agent.exe` on Windows) to write a fresh one. Note that this writes a complete new file, so any other settings the old one held are lost.
 
 ### Full Configuration Reference
 

--- a/server-source-code/go.mod
+++ b/server-source-code/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
 	github.com/swaggo/http-swagger v1.3.4
 	github.com/wwt/guac v1.3.2
+	go.yaml.in/yaml/v3 v3.0.5
 	golang.org/x/crypto v0.54.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/text v0.40.0
@@ -53,7 +54,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.39.0 // indirect
 	go.opentelemetry.io/otel/trace v1.39.0 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
-	go.yaml.in/yaml/v3 v3.0.5 // indirect
 	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect

--- a/server-source-code/go.sum
+++ b/server-source-code/go.sum
@@ -124,8 +124,6 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pquerna/otp v1.5.0 h1:NMMR+WrmaqXU4EzdGJEE1aUUI0AMRzsp96fFFWNPwxs=
 github.com/pquerna/otp v1.5.0/go.mod h1:dkJfzwRKNiegxyNb54X/3fLwhCynbMspSyWKnvi1AEg=
-github.com/redis/go-redis/v9 v9.21.0 h1:FPBE4hhbAke+TLmcY3WkpbDffJEomdqPn3HYiqAtL9E=
-github.com/redis/go-redis/v9 v9.21.0/go.mod h1:v/M13XI1PVCDcm01VtPFOADfZtHf8YW3baQf57KlIkA=
 github.com/redis/go-redis/v9 v9.22.0 h1:laDvpYXTJtZLloinw1fA5Kqd6HAEH2XKxOkG/PDq2F0=
 github.com/redis/go-redis/v9 v9.22.0/go.mod h1:y2g0Wj8rQvuK0ELM+oxSudcLtC09JScs98I/X9gRWY4=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=

--- a/server-source-code/internal/agents/patchmon_install_windows.ps1
+++ b/server-source-code/internal/agents/patchmon_install_windows.ps1
@@ -146,10 +146,10 @@ skip_ssl_verify: $($SkipSslVerify.ToString().ToLower())
     if ($content) {
         # Repair paths written double-quoted by an earlier installer, which left
         # the file unparseable and the agent running on defaults.
-        $doubleQuotedPath = "(?m)^(\s*)(patchmon_server|api_version|credentials_file|log_file|log_level)\s*:\s*`"([^`"]*\\[^`"]*)`"\s*$"
+        $doubleQuotedPath = '(?m)^([ \t]*)(patchmon_server|api_version|credentials_file|log_file|log_level)[ \t]*:[ \t]*"([^"]*\\[^"]*)"([ \t]*(?:#[^\r\n]*)?)(\r?)$'
         $content = [regex]::Replace($content, $doubleQuotedPath, {
             param($m)
-            "$($m.Groups[1].Value)$($m.Groups[2].Value): '$($m.Groups[3].Value -replace "'", "''")'"
+            "$($m.Groups[1].Value)$($m.Groups[2].Value): '$($m.Groups[3].Value -replace "'", "''")'$($m.Groups[4].Value)$($m.Groups[5].Value)"
         })
 
         if ($content -match "skip_ssl_verify\s*:\s*(true|false)") {

--- a/server-source-code/internal/agents/patchmon_install_windows.ps1
+++ b/server-source-code/internal/agents/patchmon_install_windows.ps1
@@ -128,12 +128,15 @@ Remove-Item -Path $tempPath -Force
 $configFile = Join-Path $ConfigPath "config.yml"
 if (-not (Test-Path $configFile)) {
     Write-Host "Creating default configuration file..." -ForegroundColor Yellow
+    # Single-quoted YAML scalars. A double-quoted scalar processes backslash
+    # escapes, so a Windows path either fails to parse ("\c" in \credentials.yml)
+    # or is silently mangled ("\P" is a valid escape for U+2029).
     $configContent = @"
-patchmon_server: "$ServerURL"
-api_version: "v1"
-credentials_file: "$ConfigPath\credentials.yml"
-log_file: "$ConfigPath\patchmon-agent.log"
-log_level: "info"
+patchmon_server: '$($ServerURL -replace "'", "''")'
+api_version: 'v1'
+credentials_file: '$($ConfigPath -replace "'", "''")\credentials.yml'
+log_file: '$($ConfigPath -replace "'", "''")\patchmon-agent.log'
+log_level: 'info'
 skip_ssl_verify: $($SkipSslVerify.ToString().ToLower())
 "@
     Set-Content -Path $configFile -Value $configContent -Encoding UTF8
@@ -141,6 +144,14 @@ skip_ssl_verify: $($SkipSslVerify.ToString().ToLower())
     # Config exists - update skip_ssl_verify to match server settings
     $content = Get-Content -Path $configFile -Raw -ErrorAction SilentlyContinue
     if ($content) {
+        # Repair paths written double-quoted by an earlier installer, which left
+        # the file unparseable and the agent running on defaults.
+        $doubleQuotedPath = "(?m)^(\s*)(patchmon_server|api_version|credentials_file|log_file|log_level)\s*:\s*`"([^`"]*\\[^`"]*)`"\s*$"
+        $content = [regex]::Replace($content, $doubleQuotedPath, {
+            param($m)
+            "$($m.Groups[1].Value)$($m.Groups[2].Value): '$($m.Groups[3].Value -replace "'", "''")'"
+        })
+
         if ($content -match "skip_ssl_verify\s*:\s*(true|false)") {
             $content = $content -replace "skip_ssl_verify\s*:\s*(true|false)", "skip_ssl_verify: $($SkipSslVerify.ToString().ToLower())"
         } else {

--- a/server-source-code/internal/agents/windows_config_test.go
+++ b/server-source-code/internal/agents/windows_config_test.go
@@ -72,6 +72,76 @@ func TestWindowsInstallScriptGeneratesParseableConfig(t *testing.T) {
 	}
 }
 
+// The repair branch rewrites a config an older installer left double-quoted, so
+// a host that is already broken recovers on re-run. No test executes PowerShell,
+// but the pattern itself is RE2-compatible and is lifted from the script rather
+// than restated, so a change there is a change here.
+func TestWindowsInstallScriptRepairPattern(t *testing.T) {
+	re := regexp.MustCompile(extractRepairPattern(t, string(PatchmonWindowsInstallScript)))
+	const repl = "${1}${2}: '${3}'${4}${5}"
+
+	for name, c := range map[string]struct{ in, want string }{
+		"repairs a broken path": {
+			"credentials_file: \"C:\\ProgramData\\PatchMon\\credentials.yml\"\n",
+			"credentials_file: 'C:\\ProgramData\\PatchMon\\credentials.yml'\n",
+		},
+		"preserves CRLF": {
+			"log_file: \"C:\\a\\b.log\"\r\n",
+			"log_file: 'C:\\a\\b.log'\r\n",
+		},
+		"preserves indentation and a trailing comment": {
+			"  log_file: \"C:\\a\\b.log\"  # note\n",
+			"  log_file: 'C:\\a\\b.log'  # note\n",
+		},
+		"leaves an already single-quoted path alone": {
+			"log_file: 'C:\\a\\b.log'\n",
+			"log_file: 'C:\\a\\b.log'\n",
+		},
+		"leaves a double-quoted value with no backslash alone": {
+			"patchmon_server: \"https://patchmon.example.net\"\n",
+			"patchmon_server: \"https://patchmon.example.net\"\n",
+		},
+		"leaves an unrelated key alone": {
+			"some_other_path: \"C:\\a\\b\"\n",
+			"some_other_path: \"C:\\a\\b\"\n",
+		},
+		"does not touch skip_ssl_verify": {
+			"skip_ssl_verify: false\n",
+			"skip_ssl_verify: false\n",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := re.ReplaceAllString(c.in, repl); got != c.want {
+				t.Errorf("got  %q\nwant %q", got, c.want)
+			}
+		})
+	}
+
+	// The whole point is that the repaired document parses.
+	broken := "patchmon_server: \"https://patchmon.example.net\"\n" +
+		"credentials_file: \"C:\\ProgramData\\PatchMon\\credentials.yml\"\n" +
+		"log_file: \"C:\\ProgramData\\PatchMon\\patchmon-agent.log\"\n"
+	var out struct {
+		CredentialsFile string `yaml:"credentials_file"`
+	}
+	if err := yaml.Unmarshal([]byte(re.ReplaceAllString(broken, repl)), &out); err != nil {
+		t.Fatalf("repaired config does not parse: %v", err)
+	}
+	if want := `C:\ProgramData\PatchMon\credentials.yml`; out.CredentialsFile != want {
+		t.Errorf("credentials_file = %q, want %q", out.CredentialsFile, want)
+	}
+}
+
+func extractRepairPattern(t *testing.T, script string) string {
+	t.Helper()
+	re := regexp.MustCompile(`(?m)^\s*\$doubleQuotedPath = '(.*)'\s*$`)
+	m := re.FindStringSubmatch(script)
+	if m == nil {
+		t.Fatal("could not find the $doubleQuotedPath assignment in patchmon_install_windows.ps1")
+	}
+	return m[1]
+}
+
 func extractConfigHereString(t *testing.T, script string) string {
 	t.Helper()
 	re := regexp.MustCompile(`(?s)\$configContent = @"\r?\n(.*?)\r?\n"@`)

--- a/server-source-code/internal/agents/windows_config_test.go
+++ b/server-source-code/internal/agents/windows_config_test.go
@@ -1,0 +1,83 @@
+package agents
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	yaml "go.yaml.in/yaml/v3"
+)
+
+// The installer builds config.yml from a PowerShell here-string. This lifts that
+// block out of the script, substitutes what PowerShell would interpolate, and
+// parses the result with the same YAML library the agent uses.
+//
+// Guards issue #884: the block used to double-quote the Windows paths, and a
+// double-quoted YAML scalar processes backslash escapes. "\c" in
+// \credentials.yml is not a valid escape, so config.yml never parsed, the agent
+// fell back to defaults, and the first save wrote those defaults back over it,
+// blanking patchmon_server.
+func TestWindowsInstallScriptGeneratesParseableConfig(t *testing.T) {
+	const (
+		serverURL  = "https://patchmon.example.net"
+		configPath = `C:\ProgramData\PatchMon`
+	)
+
+	block := extractConfigHereString(t, string(PatchmonWindowsInstallScript))
+
+	// What PowerShell resolves at run time. $ConfigPath and $ServerURL are piped
+	// through a -replace that doubles any single quote.
+	subs := strings.NewReplacer(
+		`$($ServerURL -replace "'", "''")`, serverURL,
+		`$($ConfigPath -replace "'", "''")`, configPath,
+		`$($SkipSslVerify.ToString().ToLower())`, "false",
+	)
+	rendered := subs.Replace(block)
+
+	// Anything left means the script changed shape and the substitutions above
+	// are stale. Without this the leftovers would parse as ordinary scalars and
+	// the test would pass while checking nothing.
+	if strings.Contains(rendered, "$") {
+		t.Fatalf("unsubstituted PowerShell in the config block, update this test:\n%s", rendered)
+	}
+
+	var got struct {
+		PatchmonServer  string `yaml:"patchmon_server"`
+		APIVersion      string `yaml:"api_version"`
+		CredentialsFile string `yaml:"credentials_file"`
+		LogFile         string `yaml:"log_file"`
+		LogLevel        string `yaml:"log_level"`
+		SkipSSLVerify   bool   `yaml:"skip_ssl_verify"`
+	}
+	if err := yaml.Unmarshal([]byte(rendered), &got); err != nil {
+		t.Fatalf("generated config.yml does not parse: %v\n%s", err, rendered)
+	}
+
+	// Exact matches, because the failure mode this guards is silent corruption
+	// as much as it is a parse error: "\P" is a valid escape and decodes to
+	// U+2029, so a double-quoted path can survive parsing and still be wrong.
+	for _, c := range []struct{ name, got, want string }{
+		{"patchmon_server", got.PatchmonServer, serverURL},
+		{"api_version", got.APIVersion, "v1"},
+		{"credentials_file", got.CredentialsFile, configPath + `\credentials.yml`},
+		{"log_file", got.LogFile, configPath + `\patchmon-agent.log`},
+		{"log_level", got.LogLevel, "info"},
+	} {
+		if c.got != c.want {
+			t.Errorf("%s = %q, want %q", c.name, c.got, c.want)
+		}
+	}
+	if got.SkipSSLVerify {
+		t.Error("skip_ssl_verify = true, want false")
+	}
+}
+
+func extractConfigHereString(t *testing.T, script string) string {
+	t.Helper()
+	re := regexp.MustCompile(`(?s)\$configContent = @"\r?\n(.*?)\r?\n"@`)
+	m := re.FindStringSubmatch(script)
+	if m == nil {
+		t.Fatal(`could not find the '$configContent = @"' here-string in patchmon_install_windows.ps1`)
+	}
+	return m[1]
+}


### PR DESCRIPTION
The Windows installer wrote `config.yml` with its paths in double quotes:

```yaml
credentials_file: "C:\ProgramData\PatchMon\credentials.yml"
```

A double-quoted YAML scalar processes backslash escapes. `\c` is not one, so the document failed to parse. The agent's load error was swallowed, it ran on `New()`'s defaults whose `patchmon_server` is empty, and the first save on the startup path wrote that whole default struct back over the operator's file. That is the reset in the report.

The quoting is worse than it first looks, because it does not fail consistently. `\P` and `\N` **are** valid YAML escapes (U+2029 and U+0085), so a Windows path in double quotes can parse cleanly and still not be the path that was written. That is why the fix is single-quoted scalars, which process no escapes at all, rather than escaping the backslashes and leaving the same trap for the next path someone adds.

## Three layers

**1. Stop generating it.** The installer emits single-quoted scalars. Re-running it over an existing config also repairs a file left double-quoted by an earlier version, so a host that is already broken recovers without hand-editing.

**2. Stop the destruction.** `config.Manager` records the load failure, and every automatic save refuses while it stands. A file the agent cannot read is never replaced by the defaults it fell back to.

`config set-api` stays able to write, since it is the documented recovery and the operator is asking for the rewrite explicitly. It now warns first, on stderr as well as the log, that any other settings the old file held are being lost.

**3. Stop running blind.** The service returns instead of starting. An agent on defaults has no server URL, so it reports nothing, and previously said so only in one warning line in a log nobody reads. The load error is deliberately still non-fatal at the Cobra level, so the recovery command keeps working.

## Also fixed, found in review

The same destruction was reachable with no parse error at all. An empty `config.yml`, or one holding only comments, is valid YAML: the read succeeds, the unmarshal leaves the defaults untouched, and `LoadConfig`'s own normalising save then writes `patchmon_server: ""` back over it. A write interrupted by a full disk or a power cut leaves exactly that. A file that exists but yields no keys is now a load failure too.

Three smaller ones from the same review: the recovery warning previously went only to the agent log, because the logger's sink is redirected at startup; two mid-run load failures were logged at debug, so a config that stopped parsing produced downstream save warnings with no stated cause; and the installer's repair pattern consumed the trailing carriage return, so repairing a CRLF file rewrote line endings it had no business touching, and it skipped any line carrying a trailing comment.

## Tests

Both new suites fail against the previous code, so they discriminate rather than decorate.

`windows_config_test.go` lifts the here-string out of the `.ps1`, substitutes what PowerShell would interpolate, and parses the result with the same YAML library the agent uses. It asserts nothing is left unsubstituted, so a rename of the block fails the test loudly instead of quietly checking nothing. A second test does the same for the repair pattern.

`config_unreadable_test.go` covers every saver rather than only the one that caused the report, and asserts the file is byte-identical afterwards.

The repair pattern was also run through a real PowerShell regex engine, not only Go's, and confirmed to preserve indentation, trailing comments and CRLF while leaving correct lines untouched.

## Not verified

Nobody has run the installer end to end on a genuine Windows PowerShell 5.1 host. Both constructs used are long-standing 5.1 idioms and the script already depends on several .NET types, so the risk is low, but one smoke test before release would close it out.

Closes #884
