### PR TITLE
Re-land the full-height sizing fix that never reached main

### DIFF
--- a/frontend/src/pages/HostDetail.jsx
+++ b/frontend/src/pages/HostDetail.jsx
@@ -1330,7 +1330,7 @@ const HostDetail = () => {
 	const displayUptime = liveUptime || host.system_uptime || null;
 
 	return (
-		<div className="min-h-screen flex flex-col">
+		<div className="min-h-[calc(100vh-var(--app-main-inset))] flex flex-col">
 			{/* Header */}
 			<div className="flex flex-col md:flex-row md:items-start md:justify-between gap-4 mb-4 pb-4 border-b border-secondary-200 dark:border-secondary-600">
 				<div className="flex items-start gap-3">

--- a/frontend/src/pages/Repositories.jsx
+++ b/frontend/src/pages/Repositories.jsx
@@ -332,7 +332,7 @@ const Repositories = () => {
 	}
 
 	return (
-		<div className="min-h-screen flex flex-col">
+		<div className="min-h-[calc(100vh-var(--app-main-inset))] flex flex-col">
 			{/* Delete Confirmation Modal */}
 			{deleteModalData && (
 				<div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">

--- a/frontend/src/pages/compliance/HostDetail.jsx
+++ b/frontend/src/pages/compliance/HostDetail.jsx
@@ -115,7 +115,7 @@ const ComplianceHostDetail = () => {
 
 	if (isLoading) {
 		return (
-			<div className="flex items-center justify-center min-h-screen">
+			<div className="flex items-center justify-center min-h-[calc(100vh-var(--app-main-inset))]">
 				<RefreshCw className="h-8 w-8 animate-spin text-secondary-400" />
 			</div>
 		);

--- a/frontend/src/pages/docker/ContainerDetail.jsx
+++ b/frontend/src/pages/docker/ContainerDetail.jsx
@@ -28,7 +28,7 @@ const ContainerDetail = () => {
 
 	if (isLoading) {
 		return (
-			<div className="flex items-center justify-center min-h-screen">
+			<div className="flex items-center justify-center min-h-[calc(100vh-var(--app-main-inset))]">
 				<RefreshCw className="h-8 w-8 animate-spin text-secondary-400" />
 			</div>
 		);

--- a/frontend/src/pages/docker/HostDetail.jsx
+++ b/frontend/src/pages/docker/HostDetail.jsx
@@ -30,7 +30,7 @@ const HostDetail = () => {
 
 	if (isLoading) {
 		return (
-			<div className="flex items-center justify-center min-h-screen">
+			<div className="flex items-center justify-center min-h-[calc(100vh-var(--app-main-inset))]">
 				<RefreshCw className="h-8 w-8 animate-spin text-secondary-400" />
 			</div>
 		);

--- a/frontend/src/pages/docker/ImageDetail.jsx
+++ b/frontend/src/pages/docker/ImageDetail.jsx
@@ -31,7 +31,7 @@ const ImageDetail = () => {
 
 	if (isLoading) {
 		return (
-			<div className="flex items-center justify-center min-h-screen">
+			<div className="flex items-center justify-center min-h-[calc(100vh-var(--app-main-inset))]">
 				<RefreshCw className="h-8 w-8 animate-spin text-secondary-400" />
 			</div>
 		);

--- a/frontend/src/pages/docker/NetworkDetail.jsx
+++ b/frontend/src/pages/docker/NetworkDetail.jsx
@@ -31,7 +31,7 @@ const NetworkDetail = () => {
 
 	if (isLoading) {
 		return (
-			<div className="flex items-center justify-center min-h-screen">
+			<div className="flex items-center justify-center min-h-[calc(100vh-var(--app-main-inset))]">
 				<RefreshCw className="h-8 w-8 animate-spin text-secondary-400" />
 			</div>
 		);

--- a/frontend/src/pages/docker/VolumeDetail.jsx
+++ b/frontend/src/pages/docker/VolumeDetail.jsx
@@ -28,7 +28,7 @@ const VolumeDetail = () => {
 
 	if (isLoading) {
 		return (
-			<div className="flex items-center justify-center min-h-screen">
+			<div className="flex items-center justify-center min-h-[calc(100vh-var(--app-main-inset))]">
 				<RefreshCw className="h-8 w-8 animate-spin text-secondary-400" />
 			</div>
 		);


### PR DESCRIPTION
Re-lands the fix from #997, which was reported as merged but never reached `main`.

#997 was based on `fix/ui-batch-2` rather than `main`, which was correct at the time, because it uses the `--app-main-inset` token that branch introduced. What went wrong is the merge order: `fix/ui-batch-2` went into `main` first, and #997 then merged into that branch about a minute afterwards. The commit landed on a branch that had already been merged and deleted, so it never travelled any further. GitHub reports the pull request as merged either way.

Verified rather than assumed: `1ac4d3c8` is not an ancestor of `origin/main`, while both of #994's commits are, and the eight affected pages on `main` still carry the original `min-h-screen` sizing.

This is a clean cherry-pick of that commit onto `main`. No changes to it. The `--app-main-inset` token it depends on is present, having arrived with #994.

`Login.jsx` keeps `min-h-screen` deliberately: it renders outside the application shell, so there is no inset to subtract.

Biome clean.

Closes #995
