### PR TITLE
Give the stalled compliance scan sweep a usable index

### DIFF
--- a/server-source-code/internal/migrate/migrations/000046_v2-0-4_compliance_scans_stalled_index.down.sql
+++ b/server-source-code/internal/migrate/migrations/000046_v2-0-4_compliance_scans_stalled_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_compliance_scans_stalled;

--- a/server-source-code/internal/migrate/migrations/000046_v2-0-4_compliance_scans_stalled_index.up.sql
+++ b/server-source-code/internal/migrate/migrations/000046_v2-0-4_compliance_scans_stalled_index.up.sql
@@ -1,0 +1,35 @@
+-- Index for the stalled compliance scan sweep (compliance-scan-cleanup task)
+-- and the two read paths that share its predicate.
+--
+-- compliance_scans carries only one non-primary-key index:
+-- idx_compliance_scans_host_profile_completed, a partial unique index
+-- WHERE status = 'completed'. The sweep's predicate is the opposite case
+-- (non-terminal scans), so that index is never a candidate for it and every
+-- sweep tick is a sequential scan. This was cheap while the sweep ran daily;
+-- migration cf895d4c (fixing #996) raised it to hourly, a 24x increase in
+-- scan frequency against a table that also never prunes 'failed' rows.
+--
+-- The partial predicate below is written to match the sweep's WHERE clause
+-- exactly (same OR expression), not simplified to `status = 'running'`, so
+-- Postgres's predicate implication check has a literal match to reason from
+-- and the index is guaranteed usable rather than merely likely usable. It
+-- also covers ListActiveComplianceScans and ListStalledComplianceScansWithDetails,
+-- which share the same non-terminal predicate. 'failed' rows are deliberately
+-- excluded from the index (not just filtered by the query) so index growth
+-- stays bounded to the small number of scans genuinely in flight, even as
+-- unpruned failed rows accumulate in the base table.
+--
+-- Plain CREATE INDEX, not CONCURRENTLY: golang-migrate's postgres driver
+-- (v4.19.1, internal/migrate/migrate.go) executes each migration's SQL body
+-- as a single statement with no explicit BEGIN/COMMIT wrapping in Go, but
+-- confirming from first principles whether that guarantees CONCURRENTLY is
+-- safe here depends on connection/protocol details this repo doesn't pin
+-- down anywhere, and getting it wrong leaves a dirty schema_migrations row
+-- needing manual recovery. compliance_scans is low-volume (per-host,
+-- per-profile scan records, not a hot ingest path), matching the same
+-- lock-vs-risk call already made for a larger table in migration 000041.
+-- Idempotent: safe to rerun.
+
+CREATE INDEX IF NOT EXISTS idx_compliance_scans_stalled
+    ON compliance_scans (started_at)
+    WHERE status = 'running' OR (completed_at IS NULL AND status != 'failed');

--- a/server-source-code/internal/sqlc/schema/schema.sql
+++ b/server-source-code/internal/sqlc/schema/schema.sql
@@ -594,6 +594,13 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_compliance_scans_host_profile_completed
 ON compliance_scans (host_id, profile_id)
 WHERE status = 'completed';
 
+-- Serves the stalled-scan sweep and its matching read paths (ListActiveComplianceScans,
+-- ListStalledComplianceScansWithDetails). Predicate mirrors those queries' WHERE clause
+-- exactly so the partial index is provably usable; see migration 000046.
+CREATE INDEX IF NOT EXISTS idx_compliance_scans_stalled
+ON compliance_scans (started_at)
+WHERE status = 'running' OR (completed_at IS NULL AND status != 'failed');
+
 -- compliance_rules
 CREATE TABLE IF NOT EXISTS compliance_rules (
     id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::TEXT,


### PR DESCRIPTION
#998 raised the stalled-compliance-scan sweep from daily to hourly, a 24x increase in how often it runs. This gives that sweep an index it can actually use.

## Why the existing index could not serve it

The sweep runs:

```sql
UPDATE compliance_scans
SET status = 'failed', completed_at = NOW(), error_message = $2
WHERE (status = 'running' OR (completed_at IS NULL AND status != 'failed'))
  AND started_at < $1;
```

The only non-primary-key index on the table was `idx_compliance_scans_host_profile_completed`, a partial unique index on `(host_id, profile_id) WHERE status = 'completed'`. Its predicate is the exact complement of what the sweep looks for, so it was never a candidate and every tick was a sequential scan.

Two read paths share the same predicate and benefit equally: `GET /compliance/scans/stalled` and `GET /compliance/scans/active`.

## The index

```sql
CREATE INDEX IF NOT EXISTS idx_compliance_scans_stalled
    ON compliance_scans (started_at)
    WHERE status = 'running' OR (completed_at IS NULL AND status != 'failed');
```

Single column, because the partial predicate already narrows to non-terminal rows. The predicate is written to match the query's `WHERE` clause literally rather than simplified to `status = 'running'`, so the planner's implication proof is a trivial self-match instead of having to reason through the `OR`.

`failed` rows are excluded from the index itself. They are never pruned from the table, so this keeps the index bounded as that population grows.

## On CONCURRENTLY

Plain `CREATE INDEX`, deliberately. `golang-migrate` runs a migration body through a single `ExecContext`, and whether a lone `CREATE INDEX CONCURRENTLY` survives that depends on simple-query-protocol semantics that are not pinned down anywhere here. Getting it wrong leaves a dirty `schema_migrations` row needing manual recovery. This table holds scan-execution records rather than high-volume ingest, so the brief lock during build is acceptable. Migration 000041 made the same trade on a larger table.

`DATABASE.md` updated.
