### PR TITLE
fix(agent): report the container's own uptime inside LXC, not the host's

### DIFF
--- a/agent-source-code/internal/system/system.go
+++ b/agent-source-code/internal/system/system.go
@@ -238,11 +238,14 @@ func (d *Detector) GetSystemInfo() models.SystemInfo {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
+	// Probed once so the uptime string and the boot time cannot disagree.
+	uptime, containerised := containerUptime()
+
 	info := models.SystemInfo{
 		KernelVersion: d.GetKernelVersion(),
 		SELinuxStatus: d.getSELinuxStatus(),
-		SystemUptime:  d.getSystemUptime(ctx),
-		BootTime:      d.getBootTime(ctx),
+		SystemUptime:  d.getSystemUptime(ctx, uptime, containerised),
+		BootTime:      d.getBootTime(ctx, uptime, containerised),
 		LoadAverage:   d.getLoadAverage(ctx),
 	}
 
@@ -373,15 +376,18 @@ func (d *Detector) getSELinuxStatus() string {
 	return constants.SELinuxDisabled
 }
 
-// getSystemUptime gets system uptime
-func (d *Detector) getSystemUptime(ctx context.Context) string {
-	info, err := host.InfoWithContext(ctx)
-	if err != nil {
-		d.logger.WithError(err).Warn("Failed to get uptime")
-		return "Unknown"
+// getSystemUptime gets system uptime. When containerised is set, uptime is the
+// container's own figure from containerUptime and is used in preference to the
+// host's, which is all gopsutil can report.
+func (d *Detector) getSystemUptime(ctx context.Context, uptime time.Duration, containerised bool) string {
+	if !containerised {
+		info, err := host.InfoWithContext(ctx)
+		if err != nil {
+			d.logger.WithError(err).Warn("Failed to get uptime")
+			return "Unknown"
+		}
+		uptime = time.Duration(info.Uptime) * time.Second
 	}
-
-	uptime := time.Duration(info.Uptime) * time.Second
 
 	days := int(uptime.Hours() / 24)
 	hours := int(uptime.Hours()) % 24
@@ -402,7 +408,15 @@ func (d *Detector) getSystemUptime(ctx context.Context) string {
 // instead of clobbering it with a sentinel. Companion to getSystemUptime,
 // which keeps shipping its pre-formatted string for back-compat with
 // pre-boot_time servers.
-func (d *Detector) getBootTime(ctx context.Context) *time.Time {
+//
+// Inside a container the boot instant is derived from the container's own
+// uptime, because gopsutil reports the host's.
+func (d *Detector) getBootTime(ctx context.Context, uptime time.Duration, containerised bool) *time.Time {
+	if containerised {
+		t := time.Now().Add(-uptime).UTC()
+		return &t
+	}
+
 	info, err := host.InfoWithContext(ctx)
 	if err != nil {
 		d.logger.WithError(err).Warn("Failed to get boot time")

--- a/agent-source-code/internal/system/uptime_linux.go
+++ b/agent-source-code/internal/system/uptime_linux.go
@@ -1,0 +1,230 @@
+//go:build linux
+
+package system
+
+import (
+	"bytes"
+	"errors"
+	"math"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// clockTicksPerSecond mirrors the kernel's USER_HZ, the unit /proc/<pid>/stat
+// reports times in. It is 100 on every architecture the agent builds for.
+const clockTicksPerSecond = 100
+
+// virtualisedUptimePath is the mount point lxcfs (and equivalents) bind a
+// container-scoped uptime file over.
+const virtualisedUptimePath = "/proc/uptime"
+
+// maxPlausibleUptime bounds what /proc/uptime is allowed to claim. Anything
+// beyond it means the file is not reporting seconds since boot at all, which a
+// broken lxcfs can produce.
+const maxPlausibleUptime = 100 * 365 * 24 * time.Hour
+
+// procSources locates the files the container-aware uptime probe reads. Held in
+// a struct so tests can point it at a fixture tree.
+type procSources struct {
+	uptime           string
+	mountinfo        string
+	pid1Stat         string
+	pid1Environ      string
+	pid1Cgroup       string
+	systemdContainer string
+	dockerEnv        string
+}
+
+var defaultProcSources = procSources{
+	uptime:           "/proc/uptime",
+	mountinfo:        "/proc/self/mountinfo",
+	pid1Stat:         "/proc/1/stat",
+	pid1Environ:      "/proc/1/environ",
+	pid1Cgroup:       "/proc/1/cgroup",
+	systemdContainer: "/run/systemd/container",
+	dockerEnv:        "/.dockerenv",
+}
+
+// cgroupContainerMarkers are the runtime names that appear in PID 1's cgroup
+// paths inside a container on cgroup v1 hosts. On the host itself PID 1 sits in
+// the root or init scope, so none of these match.
+var cgroupContainerMarkers = []string{"/docker/", "/docker-", "/lxc/", "/lxc-", "/kubepods"}
+
+// containerUptime returns how long the container the agent runs in has been up.
+//
+// gopsutil takes Linux uptime from the sysinfo syscall, which is not namespaced
+// and which lxcfs cannot intercept, so inside an LXC container it reports the
+// Proxmox host's uptime instead of the container's. ok is false when the agent
+// is not containerised, or when the container's own uptime cannot be
+// established, and callers should keep the figure gopsutil gives them.
+func containerUptime() (time.Duration, bool) {
+	return defaultProcSources.containerUptime()
+}
+
+func (p procSources) containerUptime() (time.Duration, bool) {
+	procUptime, err := p.readProcUptime()
+	if err != nil {
+		return 0, false
+	}
+
+	uptimeVirtualised, lxcfsProcMount := p.mountinfoSignals()
+
+	// lxcfs bind-mounts a virtualised /proc/uptime that already reports the
+	// container's own uptime, so take it as-is.
+	if uptimeVirtualised {
+		return procUptime, true
+	}
+
+	if !p.inContainer(lxcfsProcMount) {
+		return 0, false
+	}
+
+	// Without lxcfs, /proc/uptime is the host's. PID 1 in our namespace is the
+	// container's init, and its start time is measured from the host's boot, so
+	// the difference is the container's uptime.
+	start, err := p.readPID1StartTime()
+	if err != nil {
+		return 0, false
+	}
+
+	uptime := procUptime - start
+	if uptime <= 0 {
+		return 0, false
+	}
+
+	return uptime, true
+}
+
+// readProcUptime reads the first field of /proc/uptime, the seconds elapsed
+// since boot.
+func (p procSources) readProcUptime() (time.Duration, error) {
+	data, err := os.ReadFile(p.uptime)
+	if err != nil {
+		return 0, err
+	}
+
+	fields := strings.Fields(string(data))
+	if len(fields) == 0 {
+		return 0, errors.New("empty proc uptime")
+	}
+
+	seconds, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil {
+		return 0, err
+	}
+	// ParseFloat accepts NaN and Inf, neither of which survives the conversion
+	// to a Duration in any useful form.
+	if math.IsNaN(seconds) || math.IsInf(seconds, 0) {
+		return 0, errors.New("non-finite proc uptime")
+	}
+
+	uptime := time.Duration(seconds * float64(time.Second))
+	if uptime <= 0 || uptime > maxPlausibleUptime {
+		return 0, errors.New("implausible proc uptime")
+	}
+
+	return uptime, nil
+}
+
+// mountinfoSignals scans the mount table once for the two things the probe
+// cares about: whether anything is mounted over /proc/uptime, and whether lxcfs
+// is providing a virtualised procfs or sysfs file. Only the latter means we are
+// inside an LXC container: Proxmox runs lxcfs on the host too, but mounts it at
+// /var/lib/lxcfs, outside /proc and /sys.
+func (p procSources) mountinfoSignals() (uptimeVirtualised, lxcfsProcMount bool) {
+	data, err := os.ReadFile(p.mountinfo)
+	if err != nil {
+		return false, false
+	}
+
+	for line := range strings.Lines(string(data)) {
+		// Mount point is the fifth field of a mountinfo record.
+		fields := strings.Fields(line)
+		if len(fields) < 5 {
+			continue
+		}
+		mountPoint := fields[4]
+
+		if mountPoint == virtualisedUptimePath {
+			uptimeVirtualised = true
+		}
+
+		if strings.Contains(line, "lxcfs") &&
+			(strings.HasPrefix(mountPoint, "/proc/") || strings.HasPrefix(mountPoint, "/sys/")) {
+			lxcfsProcMount = true
+		}
+	}
+
+	return uptimeVirtualised, lxcfsProcMount
+}
+
+// inContainer reports whether the agent is running inside a container.
+// lxcfsProcMount comes from mountinfoSignals so the mount table is read once.
+func (p procSources) inContainer(lxcfsProcMount bool) bool {
+	if lxcfsProcMount {
+		return true
+	}
+
+	// systemd records the container type it detected at boot.
+	if data, err := os.ReadFile(p.systemdContainer); err == nil && len(bytes.TrimSpace(data)) > 0 {
+		return true
+	}
+
+	// LXC, systemd-nspawn and podman all export container= to init.
+	if data, err := os.ReadFile(p.pid1Environ); err == nil {
+		for _, entry := range bytes.Split(data, []byte{0}) {
+			if bytes.HasPrefix(entry, []byte("container=")) {
+				return true
+			}
+		}
+	}
+
+	if _, err := os.Stat(p.dockerEnv); err == nil {
+		return true
+	}
+
+	if data, err := os.ReadFile(p.pid1Cgroup); err == nil {
+		for _, marker := range cgroupContainerMarkers {
+			if bytes.Contains(data, []byte(marker)) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// readPID1StartTime returns how long after the host booted PID 1 started.
+func (p procSources) readPID1StartTime() (time.Duration, error) {
+	data, err := os.ReadFile(p.pid1Stat)
+	if err != nil {
+		return 0, err
+	}
+
+	// The second field is the parenthesised executable name and may itself
+	// contain spaces and brackets, so anchor the scan on the final ')'.
+	end := bytes.LastIndexByte(data, ')')
+	if end < 0 || end+2 >= len(data) {
+		return 0, errors.New("malformed proc stat")
+	}
+
+	// starttime is field 22; the two fields before the ')' are already consumed.
+	const startTimeIndex = 19
+
+	fields := strings.Fields(string(data[end+2:]))
+	if len(fields) <= startTimeIndex {
+		return 0, errors.New("proc stat too short")
+	}
+
+	ticks, err := strconv.ParseInt(fields[startTimeIndex], 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	if ticks < 0 {
+		return 0, errors.New("negative start time in proc stat")
+	}
+
+	return time.Duration(ticks) * (time.Second / clockTicksPerSecond), nil
+}

--- a/agent-source-code/internal/system/uptime_linux_test.go
+++ b/agent-source-code/internal/system/uptime_linux_test.go
@@ -1,0 +1,345 @@
+//go:build linux
+
+package system
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// pid1Stat builds a /proc/1/stat line with the given starttime in clock ticks.
+// The comm field deliberately contains a space and brackets, matching processes
+// such as "(sd-pam)" that break naive field splitting.
+func pid1Stat(t *testing.T, startTicks int64) string {
+	t.Helper()
+
+	fields := []string{"1", "(my proc)", "S"}
+	for i := 4; i <= 52; i++ {
+		if i == 22 {
+			fields = append(fields, strconv.FormatInt(startTicks, 10))
+			continue
+		}
+		fields = append(fields, "0")
+	}
+
+	return strings.Join(fields, " ") + "\n"
+}
+
+// writeProcTree lays out a fake procfs and returns sources pointing at it. Only
+// the files named in the map exist; the rest are absent, as they would be on a
+// host that does not run the corresponding runtime.
+func writeProcTree(t *testing.T, files map[string]string) procSources {
+	t.Helper()
+
+	dir := t.TempDir()
+	sources := procSources{
+		uptime:           filepath.Join(dir, "uptime"),
+		mountinfo:        filepath.Join(dir, "mountinfo"),
+		pid1Stat:         filepath.Join(dir, "pid1stat"),
+		pid1Environ:      filepath.Join(dir, "pid1environ"),
+		pid1Cgroup:       filepath.Join(dir, "pid1cgroup"),
+		systemdContainer: filepath.Join(dir, "systemd-container"),
+		dockerEnv:        filepath.Join(dir, "dockerenv"),
+	}
+
+	byName := map[string]string{
+		"uptime":            sources.uptime,
+		"mountinfo":         sources.mountinfo,
+		"pid1stat":          sources.pid1Stat,
+		"pid1environ":       sources.pid1Environ,
+		"pid1cgroup":        sources.pid1Cgroup,
+		"systemd-container": sources.systemdContainer,
+		"dockerenv":         sources.dockerEnv,
+	}
+
+	for name, content := range files {
+		path, ok := byName[name]
+		require.Truef(t, ok, "unknown fixture file %q", name)
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	}
+
+	return sources
+}
+
+func TestContainerUptimeBareHost(t *testing.T) {
+	tests := []struct {
+		name  string
+		files map[string]string
+	}{
+		{
+			// A plain host: no container markers anywhere.
+			name: "no markers",
+			files: map[string]string{
+				"mountinfo":  "23 28 0:21 / /proc rw,nosuid,nodev,noexec,relatime shared:14 - proc proc rw\n",
+				"pid1cgroup": "0::/init.scope\n",
+			},
+		},
+		{
+			// Proxmox runs lxcfs on the hypervisor host as well, mounted at
+			// /var/lib/lxcfs. Only lxcfs over /proc or /sys means we are inside
+			// a container.
+			name: "proxmox host running lxcfs",
+			files: map[string]string{
+				"mountinfo": "23 28 0:21 / /proc rw,nosuid,nodev,noexec,relatime shared:14 - proc proc rw\n" +
+					"48 25 0:44 / /var/lib/lxcfs rw,nosuid,nodev,relatime shared:29 - fuse.lxcfs lxcfs rw,user_id=0,group_id=0\n",
+				"pid1cgroup": "0::/init.scope\n",
+			},
+		},
+		{
+			// The cgroup markers are anchored so a host's own docker service
+			// unit does not read as a container.
+			name: "docker host",
+			files: map[string]string{
+				"pid1cgroup": "0::/init.scope\n",
+				"mountinfo":  "23 28 0:21 / /proc rw,relatime shared:14 - proc proc rw\n",
+			},
+		},
+		{
+			// A mount whose source path is /proc/uptime, rather than its mount
+			// point, does not virtualise anything.
+			name: "near miss mount points",
+			files: map[string]string{
+				"mountinfo": "31 23 0:33 /proc/uptime /mnt/uptime rw,relatime shared:16 - ext4 /dev/sda1 rw\n" +
+					"32 23 0:34 / /proc/uptime2 rw,relatime shared:17 - tmpfs tmpfs rw\n",
+				"pid1cgroup": "0::/init.scope\n",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			files := map[string]string{
+				"uptime":   "864000.00 1000.00\n",
+				"pid1stat": pid1Stat(t, 250),
+			}
+			for name, content := range tt.files {
+				files[name] = content
+			}
+
+			sources := writeProcTree(t, files)
+
+			_, lxcfsProcMount := sources.mountinfoSignals()
+			assert.False(t, sources.inContainer(lxcfsProcMount))
+
+			// Not containerised, so the caller keeps gopsutil's figure.
+			_, ok := sources.containerUptime()
+			assert.False(t, ok)
+		})
+	}
+}
+
+func TestContainerUptimeLXCWithoutLxcfs(t *testing.T) {
+	// Host up 10 days, container init started at day 7: the container has been
+	// up 3 days, not 10.
+	sources := writeProcTree(t, map[string]string{
+		"uptime":            "864000.00 1000.00\n",
+		"mountinfo":         "23 28 0:21 / /proc rw,nosuid,nodev,noexec,relatime shared:14 - proc proc rw\n",
+		"pid1stat":          pid1Stat(t, 604800*clockTicksPerSecond),
+		"systemd-container": "lxc\n",
+	})
+
+	uptime, ok := sources.containerUptime()
+	require.True(t, ok)
+	assert.Equal(t, 72*time.Hour, uptime)
+}
+
+func TestContainerUptimeLXCWithLxcfs(t *testing.T) {
+	// lxcfs virtualises /proc/uptime, so it already reports the container's own
+	// uptime and PID 1's host-relative start time must not be subtracted.
+	sources := writeProcTree(t, map[string]string{
+		"uptime": "259200.00 1000.00\n",
+		"mountinfo": "23 28 0:21 / /proc rw,nosuid,nodev,noexec,relatime shared:14 - proc proc rw\n" +
+			"31 23 0:33 /uptime /proc/uptime rw,nosuid,nodev,relatime shared:16 - fuse.lxcfs lxcfs rw,user_id=0,group_id=0\n",
+		"pid1stat":          pid1Stat(t, 604800*clockTicksPerSecond),
+		"systemd-container": "lxc\n",
+	})
+
+	uptime, ok := sources.containerUptime()
+	require.True(t, ok)
+	assert.Equal(t, 72*time.Hour, uptime)
+}
+
+func TestContainerUptimeDetectionSignals(t *testing.T) {
+	tests := []struct {
+		name  string
+		files map[string]string
+	}{
+		{
+			name: "pid 1 environ",
+			files: map[string]string{
+				"pid1environ": "HOME=/\x00container=lxc\x00TERM=linux\x00",
+			},
+		},
+		{
+			name: "docker env file",
+			files: map[string]string{
+				"dockerenv": "",
+			},
+		},
+		{
+			name: "cgroup v1 path",
+			files: map[string]string{
+				"pid1cgroup": "11:devices:/docker/6a1b2c3d4e5f\n1:name=systemd:/docker/6a1b2c3d4e5f\n",
+			},
+		},
+		{
+			name: "lxcfs virtualising another proc file",
+			files: map[string]string{
+				"mountinfo": "31 23 0:33 /meminfo /proc/meminfo rw,relatime shared:16 - fuse.lxcfs lxcfs rw\n",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			files := map[string]string{
+				"uptime":   "864000.00 1000.00\n",
+				"pid1stat": pid1Stat(t, 604800*clockTicksPerSecond),
+			}
+			for name, content := range tt.files {
+				files[name] = content
+			}
+
+			sources := writeProcTree(t, files)
+
+			_, lxcfsProcMount := sources.mountinfoSignals()
+			assert.True(t, sources.inContainer(lxcfsProcMount))
+
+			uptime, ok := sources.containerUptime()
+			require.True(t, ok)
+			assert.Equal(t, 72*time.Hour, uptime)
+		})
+	}
+}
+
+func TestContainerUptimeRejectsImplausibleValues(t *testing.T) {
+	tests := []struct {
+		name  string
+		files map[string]string
+	}{
+		{
+			name: "pid 1 started after the host booted",
+			files: map[string]string{
+				"uptime":            "3600.00 1000.00\n",
+				"pid1stat":          pid1Stat(t, 7200*clockTicksPerSecond),
+				"systemd-container": "lxc\n",
+			},
+		},
+		{
+			name: "pid 1 stat unreadable",
+			files: map[string]string{
+				"uptime":            "3600.00 1000.00\n",
+				"systemd-container": "lxc\n",
+			},
+		},
+		{
+			name: "proc uptime unreadable",
+			files: map[string]string{
+				"systemd-container": "lxc\n",
+			},
+		},
+		{
+			name: "proc uptime empty",
+			files: map[string]string{
+				"uptime":            "\n",
+				"pid1stat":          pid1Stat(t, 100),
+				"systemd-container": "lxc\n",
+			},
+		},
+		{
+			name: "proc stat truncated",
+			files: map[string]string{
+				"uptime":            "3600.00 1000.00\n",
+				"pid1stat":          "1 (systemd) S 0 1 1\n",
+				"systemd-container": "lxc\n",
+			},
+		},
+		{
+			// A broken lxcfs can emit values that parse but mean nothing. They
+			// must not become a boot time centuries in the past.
+			name: "proc uptime not a number",
+			files: map[string]string{
+				"uptime":    "NaN 1000.00\n",
+				"mountinfo": "31 23 0:33 /uptime /proc/uptime rw,relatime shared:16 - fuse.lxcfs lxcfs rw\n",
+			},
+		},
+		{
+			name: "proc uptime infinite",
+			files: map[string]string{
+				"uptime":    "inf 1000.00\n",
+				"mountinfo": "31 23 0:33 /uptime /proc/uptime rw,relatime shared:16 - fuse.lxcfs lxcfs rw\n",
+			},
+		},
+		{
+			name: "proc uptime beyond any plausible value",
+			files: map[string]string{
+				"uptime":    "1e30 1000.00\n",
+				"mountinfo": "31 23 0:33 /uptime /proc/uptime rw,relatime shared:16 - fuse.lxcfs lxcfs rw\n",
+			},
+		},
+		{
+			name: "proc uptime negative",
+			files: map[string]string{
+				"uptime":    "-3600.00 1000.00\n",
+				"mountinfo": "31 23 0:33 /uptime /proc/uptime rw,relatime shared:16 - fuse.lxcfs lxcfs rw\n",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sources := writeProcTree(t, tt.files)
+
+			_, ok := sources.containerUptime()
+			assert.False(t, ok)
+		})
+	}
+}
+
+func TestReadPID1StartTime(t *testing.T) {
+	sources := writeProcTree(t, map[string]string{
+		"pid1stat": pid1Stat(t, 12345),
+	})
+
+	start, err := sources.readPID1StartTime()
+	require.NoError(t, err)
+	assert.Equal(t, 123450*time.Millisecond, start)
+}
+
+// A comm containing its own brackets is why the parser anchors on the final
+// ')' rather than splitting the line on whitespace.
+func TestReadPID1StartTimeCommWithBrackets(t *testing.T) {
+	stat := strings.Replace(pid1Stat(t, 12345), "(my proc)", "(we(ir)d proc)", 1)
+	sources := writeProcTree(t, map[string]string{"pid1stat": stat})
+
+	start, err := sources.readPID1StartTime()
+	require.NoError(t, err)
+	assert.Equal(t, 123450*time.Millisecond, start)
+}
+
+func TestReadProcUptime(t *testing.T) {
+	sources := writeProcTree(t, map[string]string{
+		"uptime": "1234.56 987.65\n",
+	})
+
+	uptime, err := sources.readProcUptime()
+	require.NoError(t, err)
+	assert.InDelta(t, 1234.56, uptime.Seconds(), 0.001)
+}
+
+// containerUptime must never panic or misreport on the machine running the
+// tests, whatever kind of machine that is.
+func TestContainerUptimeOnRealHost(t *testing.T) {
+	uptime, ok := containerUptime()
+	if !ok {
+		return
+	}
+	assert.Positive(t, uptime)
+}

--- a/agent-source-code/internal/system/uptime_other.go
+++ b/agent-source-code/internal/system/uptime_other.go
@@ -1,0 +1,11 @@
+//go:build !linux
+
+package system
+
+import "time"
+
+// containerUptime is Linux-only; every other platform the agent supports
+// reports its own uptime correctly without help.
+func containerUptime() (time.Duration, bool) {
+	return 0, false
+}

--- a/docs/patchmon-api-integrations-guide.md
+++ b/docs/patchmon-api-integrations-guide.md
@@ -3177,7 +3177,8 @@ Content-Type: application/json
 | `kernelVersion` | string | No | Running kernel version |
 | `installedKernelVersion` | string | No | Installed (on-disk) kernel version |
 | `selinuxStatus` | string | No | SELinux status (`enabled`, `disabled`, or `permissive`) |
-| `systemUptime` | string | No | System uptime |
+| `systemUptime` | string | No | System uptime. Inside a container (Proxmox LXC, Docker) this is the container's own uptime, not the host's |
+| `bootTime` | string | No | Boot instant as a UTC ISO 8601 timestamp. Lets the UI tick uptime live between reports |
 | `loadAverage` | array | No | Load average values |
 | `machineId` | string | No | Machine ID |
 | `needsReboot` | boolean | No | Whether a reboot is required |


### PR DESCRIPTION
Fixes #257

## The bug

An agent running inside a Proxmox LXC container reports the Proxmox host's uptime instead of the container's, as reported in #257 and confirmed by several people since.

## Cause

gopsutil takes Linux uptime from the `sysinfo` syscall. That syscall is not namespaced, and it is not one of the files lxcfs can virtualise, so `host.Info().Uptime` is always the hypervisor host's uptime no matter what the container sees. `host.Info().BootTime` has the same problem whenever lxcfs is not mounted, which is why the live uptime in the UI is wrong too.

## Fix

The agent now resolves the container's own uptime before falling back to gopsutil:

1. If something is mounted over `/proc/uptime` (lxcfs bind-mounts a virtualised file there), that file already reports the container's uptime, so it is used as-is.
2. Otherwise, if the agent is containerised, the uptime is `/proc/uptime` minus PID 1's start time from field 22 of `/proc/1/stat`. Without lxcfs, `/proc/uptime` is the host's, and PID 1 in our namespace is the container's init whose start time is measured from the host's boot, so the difference is the container's own uptime.
3. Container detection consults `/run/systemd/container`, `container=` in PID 1's environment, `/.dockerenv`, container runtime names in PID 1's cgroup paths, and lxcfs mounts under `/proc` or `/sys`.

Both `systemUptime` and `bootTime` are corrected, so the stored value and the live-ticking uptime in the UI agree.

## Blast radius

Deliberately small. Anything that is not clearly a container, and any input that is unreadable or implausible (a PID 1 that started before the host booted, a `/proc/uptime` that parses to NaN, infinity or an absurd value), falls back to exactly the previous gopsutil path. Bare metal and VMs are byte-for-byte unchanged.

The lxcfs signal is scoped to mount points under `/proc` or `/sys` on purpose: Proxmox enables `lxcfs.service` on the hypervisor host too, where it mounts at `/var/lib/lxcfs`, so an unscoped check would misdetect every Proxmox host as a container. The cgroup markers are anchored (`/docker/`, `/docker-`) for the same reason.

`clockTicksPerSecond` is hardcoded to 100, which is `USER_HZ` on every architecture the agent builds for.

## Verification

- 26 table-driven test cases covering LXC with and without lxcfs, Docker, a Proxmox host running lxcfs, a Docker host, near-miss mount points, a `comm` field containing its own brackets, and the full set of implausible inputs.
- `make check` clean on darwin; `golangci-lint` clean for `GOOS=linux`; full test suite passes under `-race` on Linux; cross-compiles on all 11 shipped targets.
- Verified empirically in a container: gopsutil reported 226307s (the host's uptime) while the new probe correctly returned 3.89s for a container that had just started.