### PR TITLE
fix(ui): make Refresh refresh the whole screen, not one query

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -269,6 +269,33 @@ npm run test:run                # Run Vitest suite
 
 **All frontend PRs must pass `npx biome check src/` with zero errors and zero warnings** before being submitted.
 
+### Frontend data fetching and refresh
+
+Server state is held by TanStack Query. The client defaults in `src/main.jsx` are
+`staleTime: 60s` and `refetchOnWindowFocus: true`. Those two move together: focus and mount
+refetching only act on queries that are already stale, so raising `staleTime` back to several
+minutes quietly turns both off for the whole app. Guard tests in
+`src/__tests__/pageRefresh.test.jsx` will fail the build if either is changed that way.
+
+If you add a page or a Refresh button:
+
+1. **Use `usePageRefresh(keys)` from `src/hooks/usePageRefresh.js`.** Pass every query key the
+   screen renders from, not just the main one. Pages commonly mount ten or more queries, and a
+   button bound to a single `refetch()` refreshes one panel while the rest keep showing cached
+   values. The hook also drives the spinner from all the keys, so it keeps turning until the
+   slowest panel lands. Keys match by prefix, so `["hosts"]` covers `["hosts", params]`.
+2. **Invalidate the whole scope a mutation affects.** Host membership changes go through
+   `invalidateHostScope()` in `src/utils/queryScopes.js`, because the sidebar counters and the
+   dashboard cards read the same rows under different keys. Add to that helper rather than
+   listing keys at each call site.
+3. **Do not hydrate a form from query data unconditionally.** An effect of the shape
+   `useEffect(() => setForm(data), [data])` discards whatever the user has typed as soon as a
+   refetch lands. Guard it on the component's dirty flag, and clear that flag in the mutation's
+   `onSuccess` so the saved values re-hydrate.
+4. **Prefer focus refetching over polling.** A `refetchInterval` runs against every open tab and
+   does not fire while a tab is in the background. Reserve it for genuinely live data, and keep an
+   eye on how expensive the endpoint is.
+
 ### Database schema changes
 
 If you change the database schema:

--- a/frontend/src/__tests__/pageRefresh.test.jsx
+++ b/frontend/src/__tests__/pageRefresh.test.jsx
@@ -1,0 +1,346 @@
+import fs from "node:fs";
+import path from "node:path";
+import {
+	QueryClient,
+	QueryClientProvider,
+	useQuery,
+} from "@tanstack/react-query";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useGlobalRefresh, usePageRefresh } from "../hooks/usePageRefresh";
+import { HOST_SCOPE_KEYS, invalidateHostScope } from "../utils/queryScopes";
+
+/**
+ * The Refresh buttons used to be bound to a single query's refetch(), so a page
+ * built from a dozen queries refreshed one panel and left the rest showing
+ * cached values. Users learned to reload the browser instead. These tests pin
+ * the two properties that fix has to keep: a refresh reaches every key the
+ * screen renders, and the spinner reflects all of them rather than the first.
+ */
+
+const makeClient = () =>
+	new QueryClient({
+		defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+	});
+
+const wrapperFor = (queryClient) => {
+	const Wrapper = ({ children }) => (
+		<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+	);
+	return Wrapper;
+};
+
+// A promise the test releases by hand, so a fetch can be held mid-flight.
+const deferred = () => {
+	let resolve;
+	const promise = new Promise((r) => {
+		resolve = r;
+	});
+	return { promise, resolve };
+};
+
+// Mount real observers alongside the hook. usePageRefresh does not subscribe to
+// anything itself, and invalidateQueries only refetches queries that have an
+// active observer, so a harness without useQuery would test nothing.
+// `specs` is a fixed-length literal per test, so the hook count is stable.
+const harness = (specs, keys) => () => {
+	const queries = specs.map((spec) =>
+		useQuery({ queryKey: spec.key, queryFn: spec.fn }),
+	);
+	return { queries, ...usePageRefresh(keys) };
+};
+
+describe("usePageRefresh", () => {
+	it("invalidates every key it is given, not just the first", async () => {
+		const queryClient = makeClient();
+		const spy = vi.spyOn(queryClient, "invalidateQueries");
+
+		const { result } = renderHook(
+			() => usePageRefresh([["hosts"], ["hostCounts"], ["dashboardStats"]]),
+			{ wrapper: wrapperFor(queryClient) },
+		);
+
+		await act(async () => {
+			await result.current.refresh();
+		});
+
+		expect(spy.mock.calls.map(([filters]) => filters.queryKey)).toEqual([
+			["hosts"],
+			["hostCounts"],
+			["dashboardStats"],
+		]);
+	});
+
+	it("matches paginated keys by prefix, the way the pages declare them", async () => {
+		const queryClient = makeClient();
+		await queryClient.prefetchQuery({
+			queryKey: ["hosts", { page: 2, search: "web" }],
+			queryFn: () => "page-2",
+		});
+		await queryClient.prefetchQuery({
+			queryKey: ["packages"],
+			queryFn: () => "packages",
+		});
+
+		const { result } = renderHook(() => usePageRefresh([["hosts"]]), {
+			wrapper: wrapperFor(queryClient),
+		});
+
+		await act(async () => {
+			await result.current.refresh();
+		});
+
+		const state = Object.fromEntries(
+			queryClient
+				.getQueryCache()
+				.findAll()
+				.map((q) => [JSON.stringify(q.queryKey), q.state.isInvalidated]),
+		);
+		expect(state['["hosts",{"page":2,"search":"web"}]']).toBe(true);
+		expect(state['["packages"]']).toBe(false);
+	});
+
+	it("keeps isRefreshing true until the slowest key settles", async () => {
+		const queryClient = makeClient();
+		// First call resolves immediately so both queries mount; the refresh
+		// then holds the slow one open.
+		let slowCall = 0;
+		const slowRefetch = deferred();
+
+		const { result } = renderHook(
+			harness(
+				[
+					{ key: ["fast"], fn: () => "fast" },
+					{
+						key: ["slow"],
+						fn: () => (slowCall++ === 0 ? "slow" : slowRefetch.promise),
+					},
+				],
+				[["fast"], ["slow"]],
+			),
+			{ wrapper: wrapperFor(queryClient) },
+		);
+
+		await waitFor(() =>
+			expect(queryClient.getQueryData(["slow"])).toBe("slow"),
+		);
+		expect(result.current.isRefreshing).toBe(false);
+
+		act(() => {
+			result.current.refresh();
+		});
+		await waitFor(() => expect(result.current.isRefreshing).toBe(true));
+
+		// The fast query landing must not stop the spinner.
+		await waitFor(() =>
+			expect(queryClient.isFetching({ queryKey: ["fast"] })).toBe(0),
+		);
+		expect(result.current.isRefreshing).toBe(true);
+
+		await act(async () => {
+			slowRefetch.resolve("slow-again");
+			await slowRefetch.promise;
+		});
+		await waitFor(() => expect(result.current.isRefreshing).toBe(false));
+	});
+
+	it("ignores background polls, so the button does not spin on a timer", async () => {
+		// Several screens poll on a refetchInterval. Counting those fetches made
+		// the button spin and disable itself with no user action, worst of all
+		// in the sidebar, which never unmounts. Only fetches a refresh caused
+		// should count.
+		const queryClient = makeClient();
+		let call = 0;
+		const poll = deferred();
+		const refreshFetch = deferred();
+
+		const { result } = renderHook(
+			harness(
+				[
+					{
+						key: ["wsStatusSummary"],
+						fn: () => {
+							call += 1;
+							if (call === 1) return "initial";
+							if (call === 2) return poll.promise;
+							return refreshFetch.promise;
+						},
+					},
+				],
+				[["wsStatusSummary"]],
+			),
+			{ wrapper: wrapperFor(queryClient) },
+		);
+
+		await waitFor(() =>
+			expect(queryClient.getQueryData(["wsStatusSummary"])).toBe("initial"),
+		);
+
+		// A poll: a plain refetch, exactly what a refetchInterval tick fires.
+		act(() => {
+			result.current.queries[0].refetch();
+		});
+		await waitFor(() =>
+			expect(queryClient.isFetching({ queryKey: ["wsStatusSummary"] })).toBe(1),
+		);
+		expect(result.current.isRefreshing).toBe(false);
+
+		await act(async () => {
+			poll.resolve("polled");
+			await poll.promise;
+		});
+
+		// A refresh, by contrast, does count.
+		act(() => {
+			result.current.refresh();
+		});
+		await waitFor(() => expect(result.current.isRefreshing).toBe(true));
+		await act(async () => {
+			refreshFetch.resolve("refreshed");
+			await refreshFetch.promise;
+		});
+		await waitFor(() => expect(result.current.isRefreshing).toBe(false));
+	});
+
+	it("ignores queries outside its key set", async () => {
+		const queryClient = makeClient();
+		queryClient.setQueryDefaults(["unrelated"], {
+			queryFn: () => new Promise(() => {}),
+		});
+
+		const { result } = renderHook(() => usePageRefresh([["hosts"]]), {
+			wrapper: wrapperFor(queryClient),
+		});
+
+		queryClient.prefetchQuery({ queryKey: ["unrelated"] });
+		await new Promise((r) => setTimeout(r, 10));
+
+		expect(result.current.isRefreshing).toBe(false);
+	});
+});
+
+describe("useGlobalRefresh", () => {
+	it("invalidates the whole cache, which is what the sidebar control promises", async () => {
+		const queryClient = makeClient();
+		await queryClient.prefetchQuery({
+			queryKey: ["navigationStats"],
+			queryFn: () => 1,
+		});
+		await queryClient.prefetchQuery({
+			queryKey: ["dashboardStats"],
+			queryFn: () => 2,
+		});
+
+		const { result } = renderHook(() => useGlobalRefresh(), {
+			wrapper: wrapperFor(queryClient),
+		});
+		await act(async () => {
+			await result.current.refresh();
+		});
+
+		const invalidated = queryClient
+			.getQueryCache()
+			.findAll()
+			.every((q) => q.state.isInvalidated);
+		expect(invalidated).toBe(true);
+	});
+});
+
+describe("save-then-rehydrate ordering", () => {
+	/**
+	 * AlertSettings derives its dirty flag by comparing local form state to the
+	 * server copy, so it can only drop local state once the cache holds the
+	 * saved values. Clearing it while the cache is still pre-save re-hydrates
+	 * the form from stale data and then wedges it dirty against what arrives
+	 * next, which silently reverts the save. The fix depends on
+	 * invalidateQueries resolving only after the refetch has landed.
+	 */
+	it("invalidateQueries resolves only after the refetch has settled", async () => {
+		const queryClient = makeClient();
+		let served = "before-save";
+
+		renderHook(
+			harness(
+				[{ key: ["alert-config"], fn: () => served }],
+				[["alert-config"]],
+			),
+			{ wrapper: wrapperFor(queryClient) },
+		);
+		await waitFor(() =>
+			expect(queryClient.getQueryData(["alert-config"])).toBe("before-save"),
+		);
+
+		served = "after-save";
+		await act(async () => {
+			await queryClient.invalidateQueries({ queryKey: ["alert-config"] });
+		});
+
+		// If this were still "before-save", AlertSettings clearing its local
+		// state at this point would re-hydrate the form from the pre-save
+		// values and then wedge it dirty, silently reverting the save.
+		expect(queryClient.getQueryData(["alert-config"])).toBe("after-save");
+	});
+});
+
+describe("host scope invalidation", () => {
+	it("covers the sidebar counters, which no mutation used to touch", async () => {
+		const queryClient = makeClient();
+		const spy = vi.spyOn(queryClient, "invalidateQueries");
+
+		await invalidateHostScope(queryClient);
+
+		const keys = spy.mock.calls.map(([filters]) =>
+			JSON.stringify(filters.queryKey),
+		);
+		// These three are the ones that were previously missing: adding or
+		// deleting a host left the sidebar badge and the dashboard cards stale
+		// until the browser was reloaded.
+		expect(keys).toContain('["hostCounts"]');
+		expect(keys).toContain('["navigationStats"]');
+		expect(keys).toContain('["hostFilterOptions"]');
+	});
+});
+
+describe("source tree", () => {
+	const SRC = path.resolve(__dirname, "..");
+
+	const read = (relative) => fs.readFileSync(path.join(SRC, relative), "utf8");
+
+	it("does not disable focus refetching globally", () => {
+		// Focus refetch is the mechanism that makes returning to a tab show
+		// current data. Turning it off in the client defaults silently reverts
+		// the fix for every query in the app at once.
+		const main = read("main.jsx");
+		expect(main).not.toMatch(/refetchOnWindowFocus:\s*false/);
+	});
+
+	it("keeps the default staleTime low enough for focus refetch to fire", () => {
+		// Both focus and mount refetching only act on stale queries, so a long
+		// default staleTime makes them no-ops. Five minutes is what the bug
+		// report was actually about.
+		const main = read("main.jsx");
+		const match = main.match(/staleTime:\s*([0-9*\s]+),/);
+		expect(match).not.toBeNull();
+		// biome-ignore lint/security/noGlobalEval: arithmetic literal from our own source
+		const staleTime = eval(match[1]);
+		expect(staleTime).toBeLessThanOrEqual(60 * 1000);
+	});
+
+	it("every host-scope key is a real array key", () => {
+		for (const key of HOST_SCOPE_KEYS) {
+			expect(Array.isArray(key)).toBe(true);
+			expect(key.length).toBeGreaterThan(0);
+		}
+	});
+
+	it("the Docker refresh no longer falls back to a full browser reload", () => {
+		// Its per-tab dispatch ended in window.location.reload(), and refreshed
+		// only the active tab's list while leaving the stat cards alone. One
+		// ["docker"] prefix covers every tab and the cards.
+		// (Profile.jsx reloads on Discord unlink, which is a genuine full-page
+		// reset of auth state, not a refresh fallback.)
+		const docker = read("pages/Docker.jsx");
+		expect(docker).not.toMatch(/window\.location\.reload/);
+		expect(docker).toMatch(/usePageRefresh/);
+	});
+});

--- a/frontend/src/components/AddHostWizard.jsx
+++ b/frontend/src/components/AddHostWizard.jsx
@@ -10,6 +10,7 @@ import {
 	hostGroupsAPI,
 	settingsAPI,
 } from "../utils/api";
+import { invalidateHostScope } from "../utils/queryScopes";
 import ModalPortal from "./ui/ModalPortal";
 
 const STEPS = [
@@ -143,7 +144,7 @@ const AddHostWizard = ({ isOpen, onClose, onSuccess }) => {
 				if (status?.connected && connectionStage === "waiting") {
 					setConnectionStage("connected");
 					queryClient.invalidateQueries({ queryKey: ["host", createdHost.id] });
-					queryClient.invalidateQueries({ queryKey: ["hosts"] });
+					invalidateHostScope(queryClient);
 				}
 				if (
 					status?.connected &&
@@ -211,7 +212,7 @@ const AddHostWizard = ({ isOpen, onClose, onSuccess }) => {
 			});
 			setTimeout(() => {
 				queryClient.invalidateQueries({ queryKey: ["host", createdHost.id] });
-				queryClient.invalidateQueries({ queryKey: ["hosts"] });
+				invalidateHostScope(queryClient);
 			}, 2000);
 		}, 300);
 	}, [

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -34,6 +34,7 @@ import { useColorTheme } from "../contexts/ColorThemeContext";
 import { useSettings } from "../contexts/SettingsContext";
 import SidebarContext from "../contexts/SidebarContext";
 import { useUpdateNotification } from "../contexts/UpdateNotificationContext";
+import { useGlobalRefresh } from "../hooks/usePageRefresh";
 import { alertsAPI, dashboardAPI, settingsAPI, versionAPI } from "../utils/api";
 import { isRenderableAvatarSrc } from "../utils/avatar";
 import { resolveLogoPath } from "../utils/logoPaths";
@@ -170,17 +171,17 @@ const Layout = ({ children }) => {
 	const userMenuRef = useRef(null);
 
 	// Fetch cheap navigation counters; full dashboard stats are page-local.
-	const {
-		data: stats,
-		refetch,
-		isFetching,
-	} = useQuery({
+	const { data: stats } = useQuery({
 		queryKey: ["navigationStats"],
 		queryFn: () => dashboardAPI.getNavigationStats().then((res) => res.data),
 		enabled: canViewDashboard(),
-		staleTime: 5 * 60 * 1000, // Data stays fresh for 5 minutes
-		refetchOnWindowFocus: false, // Don't refetch when window regains focus
 	});
+
+	// Layout never unmounts, so this control sat next to a timestamp it reset
+	// while refetching only the three sidebar counters. Everything the user was
+	// actually looking at kept its cached values, which is what taught people to
+	// reload the browser instead. Refresh every active query.
+	const { refresh: refreshAll, isRefreshing } = useGlobalRefresh();
 
 	// Fetch settings for favicon, logos, and alerts_enabled (public endpoint works for all users)
 	const { data: settings } = useQuery({
@@ -199,8 +200,6 @@ const Layout = ({ children }) => {
 		queryKey: ["hostCounts"],
 		queryFn: () => dashboardAPI.getHostCounts().then((res) => res.data),
 		enabled: canViewHostsAllowed,
-		staleTime: 5 * 60 * 1000, // Data stays fresh for 5 minutes
-		refetchOnWindowFocus: false,
 	});
 
 	// Live WebSocket connection count for the Hosts sidebar badge. Shares its
@@ -216,7 +215,6 @@ const Layout = ({ children }) => {
 		enabled: canViewHostsAllowed,
 		refetchInterval: 10000,
 		staleTime: 10000,
-		refetchOnWindowFocus: true,
 	});
 
 	// Fetch alert stats for Reporting badge (only if user can view reports and alerts are enabled)
@@ -1554,13 +1552,13 @@ const Layout = ({ children }) => {
 												</span>
 												<button
 													type="button"
-													onClick={() => refetch()}
-													disabled={isFetching}
+													onClick={() => refreshAll()}
+													disabled={isRefreshing}
 													className="p-1 hover:bg-secondary-100 dark:hover:bg-secondary-700 rounded flex-shrink-0 disabled:opacity-50"
-													title="Refresh data"
+													title="Refresh all data"
 												>
 													<RefreshCw
-														className={`h-3 w-3 ${isFetching ? "animate-spin" : ""}`}
+														className={`h-3 w-3 ${isRefreshing ? "animate-spin" : ""}`}
 													/>
 												</button>
 											</div>
@@ -1601,13 +1599,13 @@ const Layout = ({ children }) => {
 										<div className="flex flex-col items-center py-1 border-t border-secondary-200 dark:border-secondary-700">
 											<button
 												type="button"
-												onClick={() => refetch()}
-												disabled={isFetching}
+												onClick={() => refreshAll()}
+												disabled={isRefreshing}
 												className="p-1 hover:bg-secondary-100 dark:hover:bg-secondary-700 rounded disabled:opacity-50"
-												title={`Refresh data - Updated: ${formatRelativeTimeShort(stats.lastUpdated)}`}
+												title={`Refresh all data - Updated: ${formatRelativeTimeShort(stats.lastUpdated)}`}
 											>
 												<RefreshCw
-													className={`h-3 w-3 ${isFetching ? "animate-spin" : ""}`}
+													className={`h-3 w-3 ${isRefreshing ? "animate-spin" : ""}`}
 												/>
 											</button>
 										</div>

--- a/frontend/src/components/compliance/ComplianceSettings.jsx
+++ b/frontend/src/components/compliance/ComplianceSettings.jsx
@@ -39,15 +39,14 @@ const ComplianceSettings = () => {
 		staleTime: 30 * 60 * 1000,
 	});
 
+	// Never hydrate over unsaved edits: a refetch would otherwise discard them.
 	useEffect(() => {
-		if (settings) {
-			setFormData({
-				defaultComplianceMode: settings.default_compliance_mode || "on-demand",
-				complianceScanInterval: settings.compliance_scan_interval || 1440,
-			});
-			setIsDirty(false);
-		}
-	}, [settings]);
+		if (!settings || isDirty) return;
+		setFormData({
+			defaultComplianceMode: settings.default_compliance_mode || "on-demand",
+			complianceScanInterval: settings.compliance_scan_interval || 1440,
+		});
+	}, [settings, isDirty]);
 
 	const updateMutation = useMutation({
 		mutationFn: (data) => settingsAPI.update(data).then((res) => res.data),

--- a/frontend/src/components/settings/AgentUpdatesTab.jsx
+++ b/frontend/src/components/settings/AgentUpdatesTab.jsx
@@ -91,20 +91,18 @@ const AgentUpdatesTab = () => {
 	const windowsRemoveCommand = (extraArgs = "") =>
 		`Invoke-WebRequest -Uri "${serverUrl}/api/v1/hosts/remove?os=windows" -UseBasicParsing -OutFile "$env:TEMP\\patchmon-remove.ps1"; powershell.exe -ExecutionPolicy Bypass -File "$env:TEMP\\patchmon-remove.ps1"${extraArgs}`;
 
-	// Update form data when settings are loaded
+	// Hydrate the form from the server, but never over unsaved edits: any
+	// refetch (returning to the tab, a sibling tab's save, a reconnect) would
+	// otherwise discard whatever the user had typed.
 	useEffect(() => {
-		if (settings) {
-			const newFormData = {
-				updateInterval: settings.update_interval || 60,
-				autoUpdate: settings.auto_update || false,
-				packageCacheRefreshMode:
-					settings.package_cache_refresh_mode || "always",
-				packageCacheRefreshMaxAge: settings.package_cache_refresh_max_age || 60,
-			};
-			setFormData(newFormData);
-			setIsDirty(false);
-		}
-	}, [settings]);
+		if (!settings || isDirty) return;
+		setFormData({
+			updateInterval: settings.update_interval || 60,
+			autoUpdate: settings.auto_update || false,
+			packageCacheRefreshMode: settings.package_cache_refresh_mode || "always",
+			packageCacheRefreshMaxAge: settings.package_cache_refresh_max_age || 60,
+		});
+	}, [settings, isDirty]);
 
 	// Update settings mutation
 	const updateSettingsMutation = useMutation({

--- a/frontend/src/components/settings/ProtocolUrlTab.jsx
+++ b/frontend/src/components/settings/ProtocolUrlTab.jsx
@@ -32,19 +32,18 @@ const ProtocolUrlTab = () => {
 		staleTime: 0, // Always fetch fresh data
 	});
 
-	// Update form data when settings are loaded
+	// Hydrate the form from the server, but never over unsaved edits: any
+	// refetch (returning to the tab, a sibling tab's save, a reconnect) would
+	// otherwise discard whatever the user had typed.
 	useEffect(() => {
-		if (settings) {
-			const newFormData = {
-				serverProtocol: settings.server_protocol || "http",
-				serverHost: settings.server_host || "localhost",
-				serverPort: settings.server_port || 3001,
-				ignoreSslSelfSigned: settings.ignore_ssl_self_signed === true,
-			};
-			setFormData(newFormData);
-			setIsDirty(false);
-		}
-	}, [settings]);
+		if (!settings || isDirty) return;
+		setFormData({
+			serverProtocol: settings.server_protocol || "http",
+			serverHost: settings.server_host || "localhost",
+			serverPort: settings.server_port || 3001,
+			ignoreSslSelfSigned: settings.ignore_ssl_self_signed === true,
+		});
+	}, [settings, isDirty]);
 
 	// Update settings mutation
 	const updateSettingsMutation = useMutation({

--- a/frontend/src/components/settings/UsersTab.jsx
+++ b/frontend/src/components/settings/UsersTab.jsx
@@ -92,16 +92,14 @@ const UsersTab = () => {
 		queryFn: () => settingsAPI.get().then((res) => res.data),
 	});
 
-	// Update signup form data when settings are loaded
+	// Never hydrate over unsaved edits: a refetch would otherwise discard them.
 	useEffect(() => {
-		if (settings) {
-			setSignupFormData({
-				signupEnabled: settings.signup_enabled === true,
-				defaultUserRole: settings.default_user_role || "user",
-			});
-			setIsSignupDirty(false);
-		}
-	}, [settings]);
+		if (!settings || isSignupDirty) return;
+		setSignupFormData({
+			signupEnabled: settings.signup_enabled === true,
+			defaultUserRole: settings.default_user_role || "user",
+		});
+	}, [settings, isSignupDirty]);
 
 	// Delete user mutation
 	const deleteUserMutation = useMutation({

--- a/frontend/src/hooks/usePageRefresh.js
+++ b/frontend/src/hooks/usePageRefresh.js
@@ -1,0 +1,74 @@
+import { useIsFetching, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useMemo } from "react";
+
+// Prefix comparison for the spinner's filter, so ["hosts"] covers the paginated
+// ["hosts", params] entry. This is not TanStack's own hashing: it compares
+// JSON.stringify output, which is insertion-ordered, whereas TanStack sorts
+// object keys. Every prefix declared in the app is strings-only, where the two
+// agree. Keep it that way; an object inside a prefix would make the spinner and
+// the invalidation disagree.
+const matchesPrefix = (queryKey, prefix) => {
+	if (!Array.isArray(queryKey) || queryKey.length < prefix.length) return false;
+	return prefix.every(
+		(part, i) => JSON.stringify(queryKey[i]) === JSON.stringify(part),
+	);
+};
+
+// Only queries a refresh actually invalidated count towards the spinner.
+// Several screens poll on a timer, and counting those made the button spin and
+// disable itself every 10s on its own — worst of all in the sidebar, which
+// never unmounts. Invalidation sets this flag and the refetch clears it, so it
+// marks exactly the window a refresh is responsible for.
+const isRefreshFetch = (query) => query.state.isInvalidated;
+
+// A Refresh button has to mean "refresh this screen". Binding it to a single
+// query's refetch() left every other panel on the page showing whatever it had
+// cached, which is why a browser reload was the only thing that reliably worked.
+//
+// Pass every key the screen renders from. `isRefreshing` counts all of them, so
+// the spinner keeps turning until the slowest panel lands rather than stopping
+// when the first one does.
+export function usePageRefresh(keys) {
+	const queryClient = useQueryClient();
+
+	// Callers pass literal arrays, so identity changes every render. Serialising
+	// keeps the callback and the fetch filter stable.
+	const signature = JSON.stringify(keys);
+	// biome-ignore lint/correctness/useExhaustiveDependencies: signature is the stable form of keys
+	const stableKeys = useMemo(() => keys, [signature]);
+
+	const isRefreshing =
+		useIsFetching({
+			predicate: (query) =>
+				isRefreshFetch(query) &&
+				stableKeys.some((key) => matchesPrefix(query.queryKey, key)),
+		}) > 0;
+
+	const refresh = useCallback(
+		() =>
+			Promise.all(
+				stableKeys.map((key) =>
+					queryClient.invalidateQueries({ queryKey: key }),
+				),
+			),
+		[queryClient, stableKeys],
+	);
+
+	return { refresh, isRefreshing };
+}
+
+// The sidebar control sits outside any page, so it cannot know which keys the
+// current route uses. Invalidating everything active is both what its position
+// promises and cheap in practice: only mounted queries refetch, the rest are
+// merely marked stale for their next mount.
+export function useGlobalRefresh() {
+	const queryClient = useQueryClient();
+	const isRefreshing = useIsFetching({ predicate: isRefreshFetch }) > 0;
+	const refresh = useCallback(
+		() => queryClient.invalidateQueries(),
+		[queryClient],
+	);
+	return { refresh, isRefreshing };
+}
+
+export { matchesPrefix };

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -6,12 +6,31 @@ import App from "./App.jsx";
 import "./index.css";
 
 // Create a client for React Query
+//
+// Focus refetching is on: v5's focusManager listens for visibilitychange only,
+// so this fires when someone actually returns to the tab, not on every click in
+// the window. It is the cheapest way to keep a screen current, because it is
+// bounded by human tab-switching rather than a timer.
+//
+// staleTime has to stay well under the time a user is away for that to mean
+// anything: both focus and mount refetching only act on queries that are already
+// stale, so the previous 5 minutes made both close to no-ops.
+//
+// Mount refetching, not focus, is the larger multiplier here, since it fires on
+// every route change past the stale mark. That is the intent for monitoring
+// data, but it makes an expensive aggregate expensive per navigation, so any
+// query heavy enough to notice sets a longer staleTime of its own and says why
+// (see packageTrends in Dashboard.jsx). A Refresh button still forces those.
+//
+// None of this touches session lifetime. The inactivity window only slides on
+// requests carrying X-User-Activity, which utils/api.js attaches only after a
+// real interaction, so background refetching is invisible to the session.
 const queryClient = new QueryClient({
 	defaultOptions: {
 		queries: {
-			refetchOnWindowFocus: false,
+			refetchOnWindowFocus: true,
 			retry: 1,
-			staleTime: 5 * 60 * 1000, // 5 minutes
+			staleTime: 60 * 1000, // 1 minute
 		},
 	},
 });

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -83,6 +83,7 @@ import {
 import { useAuth } from "../contexts/AuthContext";
 import { useTheme } from "../contexts/ThemeContext";
 import { useToast } from "../contexts/ToastContext";
+import { usePageRefresh } from "../hooks/usePageRefresh";
 import {
 	adminUsersAPI,
 	alertsAPI,
@@ -113,6 +114,20 @@ ChartJS.register(
 // update-status chart reaches the same list through the `filter` its segment
 // carries, rather than through this constant.
 const ERRORED_HOSTS_FILTER = "inactive";
+
+// Every monitoring query the dashboard renders. Card layout and preferences are
+// deliberately absent: refreshing the data must not reshuffle a layout the user
+// is part-way through editing.
+const DASHBOARD_REFRESH_KEYS = [
+	["dashboardStats"],
+	["packageTrends"],
+	["dashboardRecentUsers"],
+	["dashboardRecentCollection"],
+	["compliance-dashboard"],
+	["patching-dashboard"],
+	["alerts"],
+	["alert-stats"],
+];
 
 // Drag-to-resize handle on the right edge of a card in edit mode
 const CARD_RESIZE_PIXELS_PER_COLUMN = 40;
@@ -401,13 +416,15 @@ const Dashboard = () => {
 		isLoading,
 		error,
 		refetch,
-		isFetching,
 	} = useQuery({
 		queryKey: ["dashboardStats"],
 		queryFn: () => dashboardAPI.getStats().then((res) => res.data),
-		staleTime: 5 * 60 * 1000, // Data stays fresh for 5 minutes
-		refetchOnWindowFocus: false, // Don't refetch when window regains focus
 	});
+
+	// The header button refreshes the whole screen, not just this query.
+	const { refresh: refreshDashboard, isRefreshing } = usePageRefresh(
+		DASHBOARD_REFRESH_KEYS,
+	);
 
 	// Package trends data query
 	const {
@@ -426,8 +443,11 @@ const Dashboard = () => {
 			}
 			return dashboardAPI.getPackageTrends(params).then((res) => res.data);
 		},
-		staleTime: 5 * 60 * 1000, // 5 minutes
-		refetchOnWindowFocus: false,
+		// Deliberately above the 60s default. This aggregates up to a year of
+		// system_statistics with no server-side cache, and the series is
+		// day-granular, so refetching it on every remount past a minute costs a
+		// lot and can change nothing. The Refresh button still forces it.
+		staleTime: 5 * 60 * 1000,
 	});
 
 	// Fetch user's dashboard preferences (must be fetched before recentUsers query)
@@ -471,7 +491,6 @@ const Dashboard = () => {
 		queryKey: ["compliance-dashboard"],
 		queryFn: () => complianceAPI.getDashboard().then((res) => res.data),
 		staleTime: 60 * 1000,
-		refetchOnWindowFocus: false,
 		enabled:
 			has_view_hosts &&
 			is_any_compliance_card_enabled &&
@@ -2351,13 +2370,13 @@ const Dashboard = () => {
 					</button>
 					<button
 						type="button"
-						onClick={() => refetch()}
-						disabled={isFetching}
+						onClick={() => refreshDashboard()}
+						disabled={isRefreshing}
 						className="btn-outline flex items-center gap-2 min-h-[44px] min-w-[44px] justify-center"
 						title="Refresh dashboard data"
 					>
 						<RefreshCw
-							className={`h-4 w-4 ${isFetching ? "animate-spin" : ""}`}
+							className={`h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`}
 						/>
 					</button>
 				</div>

--- a/frontend/src/pages/Docker.jsx
+++ b/frontend/src/pages/Docker.jsx
@@ -20,8 +20,13 @@ import {
 import { Fragment, useEffect, useMemo, useState } from "react";
 import { Link, useLocation, useSearchParams } from "react-router-dom";
 import { useToast } from "../contexts/ToastContext";
+import { usePageRefresh } from "../hooks/usePageRefresh";
 import api, { formatError } from "../utils/api";
 import { generateRegistryLink, getSourceDisplayName } from "../utils/docker";
+
+// Every tab's data plus the stat cards live under this prefix, so one key
+// covers the lot. The per-tab dispatch this replaces never refreshed the cards.
+const DOCKER_REFRESH_KEYS = [["docker"]];
 
 const VALID_DOCKER_TABS = [
 	"stacks",
@@ -42,6 +47,8 @@ const Docker = () => {
 	const [activeTab, setActiveTab] = useState(
 		VALID_DOCKER_TABS.includes(urlTab) ? urlTab : "stacks",
 	);
+	const { refresh: refreshDocker, isRefreshing } =
+		usePageRefresh(DOCKER_REFRESH_KEYS);
 
 	// Sync tab only on actual URL navigation (not in-page tab clicks)
 	useEffect(() => {
@@ -73,11 +80,7 @@ const Docker = () => {
 	});
 
 	// Fetch containers
-	const {
-		data: containersData,
-		isLoading: containersLoading,
-		refetch: refetchContainers,
-	} = useQuery({
+	const { data: containersData, isLoading: containersLoading } = useQuery({
 		queryKey: ["docker", "containers", statusFilter],
 		queryFn: async () => {
 			const params = new URLSearchParams();
@@ -90,11 +93,7 @@ const Docker = () => {
 	});
 
 	// Fetch images
-	const {
-		data: imagesData,
-		isLoading: imagesLoading,
-		refetch: refetchImages,
-	} = useQuery({
+	const { data: imagesData, isLoading: imagesLoading } = useQuery({
 		queryKey: ["docker", "images", sourceFilter],
 		queryFn: async () => {
 			const params = new URLSearchParams();
@@ -590,20 +589,14 @@ const Docker = () => {
 				<div className="flex items-center gap-3">
 					<button
 						type="button"
-						onClick={() => {
-							// Trigger refresh based on active tab
-							if (activeTab === "stacks") refetchContainers();
-							else if (activeTab === "containers") refetchContainers();
-							else if (activeTab === "images") refetchImages();
-							else if (activeTab === "volumes") refetchVolumes();
-							else if (activeTab === "networks") refetchNetworks();
-							else if (activeTab === "hosts") refetchHosts();
-							else window.location.reload();
-						}}
+						onClick={() => refreshDocker()}
+						disabled={isRefreshing}
 						className="btn-outline flex items-center justify-center p-2"
 						title="Refresh data"
 					>
-						<RefreshCw className="h-4 w-4" />
+						<RefreshCw
+							className={`h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`}
+						/>
 					</button>
 				</div>
 			</div>

--- a/frontend/src/pages/HostDetail.jsx
+++ b/frontend/src/pages/HostDetail.jsx
@@ -64,6 +64,7 @@ import UpgradeRequiredContent from "../components/UpgradeRequiredContent";
 import { getRequiredTier } from "../constants/tiers";
 import { useAuth } from "../contexts/AuthContext";
 import { useToast } from "../contexts/ToastContext";
+import { usePageRefresh } from "../hooks/usePageRefresh";
 import { useTick } from "../hooks/useTick";
 import {
 	adminHostsAPI,
@@ -78,6 +79,7 @@ import {
 import { complianceAPI } from "../utils/complianceApi";
 import { OSIcon } from "../utils/osIcons.jsx";
 import { patchingAPI } from "../utils/patchingApi";
+import { invalidateHostScope } from "../utils/queryScopes";
 import AgentActivityTab from "./hostdetail/AgentActivityTab";
 import CredentialsModal from "./hostdetail/CredentialsModal";
 import DeleteConfirmationModal from "./hostdetail/DeleteConfirmationModal";
@@ -212,7 +214,6 @@ const HostDetail = () => {
 		isLoading,
 		error,
 		refetch,
-		isFetching,
 	} = useQuery({
 		queryKey: ["host", hostId, historyPage, historyLimit],
 		queryFn: () =>
@@ -222,9 +223,29 @@ const HostDetail = () => {
 					offset: historyPage * historyLimit,
 				})
 				.then((res) => res.data),
-		staleTime: 5 * 60 * 1000, // 5 minutes - data stays fresh longer
-		refetchOnWindowFocus: false, // Don't refetch when window regains focus
 	});
+
+	// The tabs on this page (packages, integrations, compliance, Docker,
+	// patching) each own their query, so refreshing only the host record left
+	// whichever tab was open showing stale rows.
+	const hostRefreshKeys = useMemo(
+		() => [
+			["host", hostId],
+			// Not covered by ["host", hostId] — the key is a different string, so
+			// it does not prefix-match. The Activity tab polls every 30s, which
+			// is what made the omission easy to miss.
+			["host-activity", hostId],
+			["host-repositories", hostId],
+			["host-integrations", hostId],
+			["compliance-latest", hostId],
+			["compliance-setup-status", hostId],
+			["docker", "host", hostId],
+			["patching-runs", hostId],
+		],
+		[hostId],
+	);
+	const { refresh: refreshHost, isRefreshing } =
+		usePageRefresh(hostRefreshKeys);
 
 	// Fetch global settings to check if auto-update master toggle is enabled
 	// Try public endpoint first (works for all users), fallback to full settings if user has permissions
@@ -290,7 +311,6 @@ const HostDetail = () => {
 		queryKey: ["host-repositories", hostId],
 		queryFn: () => repositoryAPI.getByHost(hostId).then((res) => res.data),
 		staleTime: 5 * 60 * 1000, // 5 minutes - data stays fresh longer
-		refetchOnWindowFocus: false, // Don't refetch when window regains focus
 		enabled: !!hostId,
 	});
 
@@ -299,7 +319,6 @@ const HostDetail = () => {
 		queryKey: ["host-groups"],
 		queryFn: () => hostGroupsAPI.list().then((res) => res.data),
 		staleTime: 5 * 60 * 1000, // 5 minutes - data stays fresh longer
-		refetchOnWindowFocus: false, // Don't refetch when window regains focus
 	});
 
 	// Tab change handler. Mirror "activity" into ?tab= so the new merged tab is
@@ -422,7 +441,7 @@ const HostDetail = () => {
 	const deleteHostMutation = useMutation({
 		mutationFn: (hostId) => adminHostsAPI.delete(hostId),
 		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: ["hosts"] });
+			invalidateHostScope(queryClient);
 			navigate("/hosts");
 		},
 	});
@@ -708,7 +727,6 @@ const HostDetail = () => {
 		queryFn: () =>
 			adminHostsAPI.getIntegrations(hostId).then((res) => res.data),
 		staleTime: 30 * 1000, // 30 seconds
-		refetchOnWindowFocus: false,
 		enabled: !!hostId, // Always fetch to control tab visibility
 	});
 
@@ -721,7 +739,6 @@ const HostDetail = () => {
 				.then((res) => res.data)
 				.catch(() => null),
 		staleTime: 2 * 60 * 1000, // 2 minutes
-		refetchOnWindowFocus: false,
 		enabled:
 			!!hostId &&
 			!!integrationsData?.data?.integrations?.compliance &&
@@ -746,7 +763,6 @@ const HostDetail = () => {
 				}
 				return false; // Stop polling when done
 			},
-			refetchOnWindowFocus: false,
 			// Also fetched while compliance is disabled, so the page can tell
 			// whether the scanning tools are still installed on the host.
 			enabled: !!hostId && hasModule("compliance"),
@@ -902,7 +918,6 @@ const HostDetail = () => {
 				.getHostDetail(hostId, { include: "docker" })
 				.then((res) => res.data?.docker),
 		staleTime: 30 * 1000,
-		refetchOnWindowFocus: false,
 		enabled:
 			!!hostId &&
 			(activeTab === "docker" || integrationsData?.data?.integrations?.docker),
@@ -1452,13 +1467,13 @@ const HostDetail = () => {
 						</button>
 						<button
 							type="button"
-							onClick={() => refetch()}
-							disabled={isFetching}
+							onClick={() => refreshHost()}
+							disabled={isRefreshing}
 							className="btn-outline flex items-center justify-center p-2 text-sm"
-							title="Refresh dashboard"
+							title="Refresh host data"
 						>
 							<RefreshCw
-								className={`h-4 w-4 ${isFetching ? "animate-spin" : ""}`}
+								className={`h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`}
 							/>
 						</button>
 						<button

--- a/frontend/src/pages/Hosts.jsx
+++ b/frontend/src/pages/Hosts.jsx
@@ -44,6 +44,7 @@ import InlineEdit from "../components/InlineEdit";
 import InlineMultiGroupEdit from "../components/InlineMultiGroupEdit";
 import InlineToggle from "../components/InlineToggle";
 import Tooltip from "../components/ui/Tooltip";
+import { usePageRefresh } from "../hooks/usePageRefresh";
 import { useTick } from "../hooks/useTick";
 import {
 	adminHostsAPI,
@@ -57,6 +58,17 @@ import {
 } from "../utils/api";
 import { deriveReportingState } from "../utils/hostStatus";
 import { getOSDisplayName, OSIcon } from "../utils/osIcons.jsx";
+import { invalidateHostScope } from "../utils/queryScopes";
+
+// Everything the page renders, not just the table: the stat cards, the filter
+// dropdowns and the connection badge each have their own query.
+const HOSTS_REFRESH_KEYS = [
+	["hosts"],
+	["hostCounts"],
+	["hostFilterOptions"],
+	["hostGroups"],
+	["wsStatusSummary"],
+];
 
 const HOSTS_PAGE_SIZE_OPTIONS = [25, 50, 100, 200, 500];
 const HOSTS_DEFAULT_PAGE_SIZE = 50;
@@ -469,15 +481,18 @@ const Hosts = () => {
 		isLoading,
 		error,
 		refetch,
-		isFetching,
 	} = useQuery({
 		queryKey: ["hosts", hostsQueryParams],
 		queryFn: () =>
 			dashboardAPI.getHosts(hostsQueryParams).then((res) => res.data),
 		placeholderData: keepPreviousData,
-		staleTime: 5 * 60 * 1000, // Data stays fresh for 5 minutes
-		refetchOnWindowFocus: false, // Don't refetch when window regains focus
 	});
+
+	// The stat cards and the filter dropdowns come from their own queries, so a
+	// button bound only to the table left them showing counts that disagreed
+	// with the rows underneath.
+	const { refresh: refreshHosts, isRefreshing } =
+		usePageRefresh(HOSTS_REFRESH_KEYS);
 
 	const hostsPage = useMemo(() => {
 		if (Array.isArray(hostsResponse)) {
@@ -562,14 +577,11 @@ const Hosts = () => {
 		queryKey: ["hostFilterOptions"],
 		queryFn: () => dashboardAPI.getHostFilterOptions().then((res) => res.data),
 		staleTime: 5 * 60 * 1000,
-		refetchOnWindowFocus: false,
 	});
 
 	const { data: hostCounts } = useQuery({
 		queryKey: ["hostCounts"],
 		queryFn: () => dashboardAPI.getHostCounts().then((res) => res.data),
-		staleTime: 5 * 60 * 1000,
-		refetchOnWindowFocus: false,
 	});
 
 	const { data: wsStatusSummary } = useQuery({
@@ -577,7 +589,6 @@ const Hosts = () => {
 		queryFn: () => dashboardAPI.getWsStatusSummary().then((res) => res.data),
 		refetchInterval: 10000,
 		staleTime: 10000,
-		refetchOnWindowFocus: false,
 	});
 
 	// host_down alert config drives the WS pill amber→red threshold (seconds).
@@ -776,7 +787,7 @@ const Hosts = () => {
 	const bulkDeleteMutation = useMutation({
 		mutationFn: (hostIds) => adminHostsAPI.deleteBulk(hostIds),
 		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: ["hosts"] });
+			invalidateHostScope(queryClient);
 			setSelectedHosts([]);
 			setShowBulkDeleteModal(false);
 		},
@@ -1776,13 +1787,13 @@ const Hosts = () => {
 				<div className="flex items-center gap-3">
 					<button
 						type="button"
-						onClick={() => refetch()}
-						disabled={isFetching}
+						onClick={() => refreshHosts()}
+						disabled={isRefreshing}
 						className="btn-outline flex items-center justify-center p-2"
 						title="Refresh hosts data"
 					>
 						<RefreshCw
-							className={`h-4 w-4 ${isFetching ? "animate-spin" : ""}`}
+							className={`h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`}
 						/>
 					</button>
 					<button

--- a/frontend/src/pages/PackageDetail.jsx
+++ b/frontend/src/pages/PackageDetail.jsx
@@ -26,6 +26,7 @@ import { Link, useNavigate, useParams } from "react-router-dom";
 import PatchWizard from "../components/PatchWizard";
 import { useAuth } from "../contexts/AuthContext";
 import { useToast } from "../contexts/ToastContext";
+import { usePageRefresh } from "../hooks/usePageRefresh";
 import { formatRelativeTime, packagesAPI } from "../utils/api";
 
 function formatRepoName(name) {
@@ -118,8 +119,6 @@ const PackageDetail = () => {
 		queryKey: ["package", decodedPackageId],
 		queryFn: () =>
 			packagesAPI.getById(decodedPackageId).then((res) => res.data),
-		staleTime: 5 * 60 * 1000,
-		refetchOnWindowFocus: false,
 		enabled: !!decodedPackageId,
 	});
 
@@ -128,7 +127,6 @@ const PackageDetail = () => {
 		data: hostsData,
 		isLoading: isLoadingHosts,
 		error: hostsError,
-		refetch: refetchHosts,
 	} = useQuery({
 		queryKey: [
 			"package-hosts",
@@ -148,8 +146,6 @@ const PackageDetail = () => {
 				})
 				.then((res) => res.data),
 		placeholderData: keepPreviousData,
-		staleTime: 5 * 60 * 1000,
-		refetchOnWindowFocus: false,
 		enabled: !!decodedPackageId,
 	});
 
@@ -212,10 +208,16 @@ const PackageDetail = () => {
 		navigate(`/hosts/${hostId}`);
 	};
 
-	const handleRefresh = () => {
-		refetchPackage();
-		refetchHosts();
-	};
+	const packageRefreshKeys = useMemo(
+		() => [
+			["package", decodedPackageId],
+			["package-hosts", decodedPackageId],
+			["package-activity", decodedPackageId],
+		],
+		[decodedPackageId],
+	);
+	const { refresh: handleRefresh, isRefreshing } =
+		usePageRefresh(packageRefreshKeys);
 
 	if (isLoadingPackage) {
 		return (
@@ -301,14 +303,12 @@ const PackageDetail = () => {
 				</div>
 				<button
 					type="button"
-					onClick={handleRefresh}
-					disabled={isLoadingPackage || isLoadingHosts}
+					onClick={() => handleRefresh()}
+					disabled={isRefreshing}
 					className="btn-outline flex items-center gap-2 text-sm sm:text-base self-start sm:self-auto"
 				>
 					<RefreshCw
-						className={`h-4 w-4 ${
-							isLoadingPackage || isLoadingHosts ? "animate-spin" : ""
-						}`}
+						className={`h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`}
 					/>
 					Refresh
 				</button>

--- a/frontend/src/pages/Packages.jsx
+++ b/frontend/src/pages/Packages.jsx
@@ -30,7 +30,16 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import PatchWizard from "../components/PatchWizard";
 import { useAuth } from "../contexts/AuthContext";
 import { useToast } from "../contexts/ToastContext";
+import { usePageRefresh } from "../hooks/usePageRefresh";
 import { dashboardAPI, packagesAPI } from "../utils/api";
+
+// The table, the stat cards and the host filter are three separate queries.
+const PACKAGES_REFRESH_KEYS = [
+	["packages"],
+	["dashboardStats"],
+	["packagesHostStats"],
+	["packageCategories"],
+];
 
 const PACKAGES_PAGE_SIZE_OPTIONS = [25, 50, 100, 200];
 
@@ -194,7 +203,6 @@ const Packages = () => {
 		isLoading,
 		error,
 		refetch,
-		isFetching,
 	} = useQuery({
 		queryKey: [
 			"packages",
@@ -236,7 +244,6 @@ const Packages = () => {
 		},
 		placeholderData: keepPreviousData,
 		staleTime: 5 * 60 * 1000, // Data stays fresh for 5 minutes
-		refetchOnWindowFocus: false, // Don't refetch when window regains focus
 	});
 
 	// Extract packages from the response and normalise the data structure
@@ -261,24 +268,20 @@ const Packages = () => {
 	const endIndex = Math.min(startIndex + packages.length, totalPackages);
 
 	// Fetch dashboard stats for card counts (consistent with homepage)
-	const { data: dashboardStats, refetch: refetchDashboardStats } = useQuery({
+	const { data: dashboardStats } = useQuery({
 		queryKey: ["dashboardStats"],
 		queryFn: () => dashboardAPI.getStats().then((res) => res.data),
-		staleTime: 5 * 60 * 1000, // Data stays fresh for 5 minutes
-		refetchOnWindowFocus: false, // Don't refetch when window regains focus
 	});
 
 	const { data: categories = [] } = useQuery({
 		queryKey: ["packageCategories"],
 		queryFn: () => packagesAPI.getCategories().then((res) => res.data),
 		staleTime: 5 * 60 * 1000,
-		refetchOnWindowFocus: false,
 	});
 
-	// Handle refresh - refetch all related data
-	const handleRefresh = async () => {
-		await Promise.all([refetch(), refetchDashboardStats()]);
-	};
+	const { refresh: handleRefresh, isRefreshing } = usePageRefresh(
+		PACKAGES_REFRESH_KEYS,
+	);
 
 	// Post-submit UX for the Patch all wizard. The wizard now owns the server
 	// call; this handler only routes the user to the right place afterwards.
@@ -348,7 +351,6 @@ const Packages = () => {
 				.then((res) => res.data),
 		enabled: isHostScoped,
 		staleTime: 60 * 1000,
-		refetchOnWindowFocus: false,
 	});
 
 	const selectHostFilter = (value) => {
@@ -738,15 +740,15 @@ const Packages = () => {
 						)}
 					<button
 						type="button"
-						onClick={handleRefresh}
-						disabled={isFetching}
+						onClick={() => handleRefresh()}
+						disabled={isRefreshing}
 						className="btn-outline flex items-center gap-2"
 						title="Refresh packages and statistics data"
 					>
 						<RefreshCw
-							className={`h-4 w-4 ${isFetching ? "animate-spin" : ""}`}
+							className={`h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`}
 						/>
-						{isFetching ? "Refreshing..." : "Refresh"}
+						{isRefreshing ? "Refreshing..." : "Refresh"}
 					</button>
 				</div>
 			</div>

--- a/frontend/src/pages/Repositories.jsx
+++ b/frontend/src/pages/Repositories.jsx
@@ -27,7 +27,12 @@ import {
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
+import { usePageRefresh } from "../hooks/usePageRefresh";
 import { dashboardAPI, repositoryAPI } from "../utils/api";
+
+// The summary cards read from their own query, so refreshing the table alone
+// left the counts above it unchanged.
+const REPOSITORIES_REFRESH_KEYS = [["repositories"], ["repository-stats"]];
 
 const REPOSITORIES_PAGE_SIZE_OPTIONS = [25, 50, 100, 200];
 const REPOSITORIES_DEFAULT_PAGE_SIZE = 50;
@@ -145,13 +150,15 @@ const Repositories = () => {
 		data: repositoriesResponse,
 		isLoading,
 		error,
-		refetch,
-		isFetching,
 	} = useQuery({
 		queryKey: ["repositories", repoQueryParams],
 		queryFn: () => repositoryAPI.list(repoQueryParams).then((res) => res.data),
 		placeholderData: keepPreviousData,
 	});
+
+	const { refresh: refreshRepositories, isRefreshing } = usePageRefresh(
+		REPOSITORIES_REFRESH_KEYS,
+	);
 	const repositories = repositoriesResponse?.items || [];
 	const totalRepositories = repositoriesResponse?.total || 0;
 	const totalPages = Math.max(1, Math.ceil(totalRepositories / pageSize));
@@ -422,15 +429,15 @@ const Repositories = () => {
 				<div className="flex items-center gap-3">
 					<button
 						type="button"
-						onClick={() => refetch()}
-						disabled={isFetching}
+						onClick={() => refreshRepositories()}
+						disabled={isRefreshing}
 						className="btn-outline flex items-center gap-2"
 						title="Refresh repositories data"
 					>
 						<RefreshCw
-							className={`h-4 w-4 ${isFetching ? "animate-spin" : ""}`}
+							className={`h-4 w-4 ${isRefreshing ? "animate-spin" : ""}`}
 						/>
-						{isFetching ? "Refreshing..." : "Refresh"}
+						{isRefreshing ? "Refreshing..." : "Refresh"}
 					</button>
 				</div>
 			</div>

--- a/frontend/src/pages/settings/AlertSettings.jsx
+++ b/frontend/src/pages/settings/AlertSettings.jsx
@@ -229,25 +229,33 @@ const AlertSettings = () => {
 
 	const bulkUpdateMutation = useMutation({
 		mutationFn: (configs) => alertsAPI.bulkUpdateAlertConfig(configs),
-		onSuccess: () => {
-			queryClient.invalidateQueries({ queryKey: ["alert-config"] });
+		onSuccess: async () => {
+			// Await the refetch before dropping local state. isDirty here is
+			// derived by comparing local to server, so clearing it while the
+			// cache still held pre-save values would re-hydrate the form from
+			// them, then wedge it dirty against the values that arrive after.
+			await queryClient.invalidateQueries({ queryKey: ["alert-config"] });
+			// Now that the cache is fresh, dropping local state lets the effect
+			// re-hydrate unconditionally, including any value the server
+			// normalised on the way in.
+			setLocalConfigs(null);
 			toast.success("Settings applied");
 		},
 		onError: (err) =>
 			toast.error(err.response?.data?.error || "Failed to apply"),
 	});
 
-	useEffect(() => {
-		if (alertConfigs && Array.isArray(alertConfigs)) {
-			setLocalConfigs(alertConfigs.map((c) => ({ ...c })));
-		}
-	}, [alertConfigs]);
-
 	const isDirty =
 		localConfigs &&
 		alertConfigs &&
 		(localConfigs.length !== alertConfigs.length ||
 			localConfigs.some((lc, i) => !configsEqual(lc, alertConfigs[i])));
+
+	// Never hydrate over unsaved edits: a refetch would otherwise discard them.
+	useEffect(() => {
+		if (!alertConfigs || !Array.isArray(alertConfigs) || isDirty) return;
+		setLocalConfigs(alertConfigs.map((c) => ({ ...c })));
+	}, [alertConfigs, isDirty]);
 
 	useEffect(() => {
 		if (!isDirty) return;

--- a/frontend/src/pages/settings/DiscordSettings.jsx
+++ b/frontend/src/pages/settings/DiscordSettings.jsx
@@ -25,6 +25,7 @@ const DiscordSettings = () => {
 		discord_redirect_uri: "",
 		discord_button_text: "Login with Discord",
 	});
+	const [isDirty, setIsDirty] = useState(false);
 
 	// Fetch Discord settings
 	const { data: settings, isLoading: settingsLoading } = useQuery({
@@ -32,15 +33,16 @@ const DiscordSettings = () => {
 		queryFn: () => discordAPI.getSettings().then((res) => res.data),
 	});
 
-	// Sync form from server when settings load
+	// Sync form from server, but never over unsaved edits: a refetch would
+	// otherwise discard whatever the user had typed.
 	useEffect(() => {
-		if (!settings) return;
+		if (!settings || isDirty) return;
 		setForm({
 			discord_client_id: settings.discord_client_id || "",
 			discord_redirect_uri: settings.discord_redirect_uri || "",
 			discord_button_text: settings.discord_button_text || "Login with Discord",
 		});
-	}, [settings]);
+	}, [settings, isDirty]);
 
 	// Update settings mutation
 	const updateMutation = useMutation({
@@ -48,6 +50,7 @@ const DiscordSettings = () => {
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: ["discordSettings"] });
 			setSecretInput("");
+			setIsDirty(false);
 		},
 	});
 
@@ -58,6 +61,7 @@ const DiscordSettings = () => {
 	};
 
 	const handleFieldChange = (field, value) => {
+		setIsDirty(true);
 		setForm((prev) => ({ ...prev, [field]: value }));
 	};
 

--- a/frontend/src/pages/settings/OidcSettings.jsx
+++ b/frontend/src/pages/settings/OidcSettings.jsx
@@ -69,6 +69,7 @@ const OidcSettings = () => {
 	const [showSetupGuide, setShowSetupGuide] = useState(false);
 
 	// Local form state - only saved when user clicks Apply
+	const [isDirty, setIsDirty] = useState(false);
 	const [form, setForm] = useState({
 		oidc_issuer_url: "",
 		oidc_client_id: "",
@@ -117,9 +118,10 @@ const OidcSettings = () => {
 		});
 	}, [rolesData]);
 
-	// Sync form from server when settings load; pre-fill redirect URI from callback_url when empty
+	// Sync form from server; pre-fill redirect URI from callback_url when empty.
+	// Never hydrate over unsaved edits: a refetch would otherwise discard them.
 	useEffect(() => {
-		if (!settings) return;
+		if (!settings || isDirty) return;
 		setForm({
 			oidc_issuer_url: settings.oidc_issuer_url || "",
 			oidc_client_id: settings.oidc_client_id || "",
@@ -138,7 +140,7 @@ const OidcSettings = () => {
 			oidc_auto_create_users: settings.oidc_auto_create_users ?? true,
 			oidc_enforce_https: settings.oidc_enforce_https ?? true,
 		});
-	}, [settings]);
+	}, [settings, isDirty]);
 
 	// Update settings mutation
 	const updateMutation = useMutation({
@@ -146,6 +148,7 @@ const OidcSettings = () => {
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: ["oidcSettings"] });
 			setSecretInput("");
+			setIsDirty(false);
 			toast.success("OIDC settings saved");
 		},
 		onError: (err) => {
@@ -158,6 +161,8 @@ const OidcSettings = () => {
 		mutationFn: () => oidcAPI.importFromEnv(),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: ["oidcSettings"] });
+			// The imported values are meant to land in the form, so drop the guard.
+			setIsDirty(false);
 			toast.success("OIDC settings imported from .env");
 		},
 		onError: (err) => {
@@ -172,6 +177,7 @@ const OidcSettings = () => {
 	};
 
 	const handleFieldChange = (field, value) => {
+		setIsDirty(true);
 		setForm((prev) => ({ ...prev, [field]: value }));
 	};
 

--- a/frontend/src/utils/queryScopes.js
+++ b/frontend/src/utils/queryScopes.js
@@ -1,0 +1,22 @@
+// Adding or removing a host changes more than the host list. The sidebar
+// badges, the Hosts page stat cards and the dashboard totals are all derived
+// from the same rows, and each lives under its own query key.
+//
+// Those keys were previously left out of every mutation's invalidation set, and
+// because Layout never unmounts and does not refetch on focus, the sidebar count
+// stayed wrong until the browser was reloaded. Invalidate the whole scope
+// through this helper so the list cannot drift again.
+export const HOST_SCOPE_KEYS = [
+	["hosts"],
+	["hostCounts"],
+	["navigationStats"],
+	["hostFilterOptions"],
+	["dashboardStats"],
+];
+
+export const invalidateHostScope = (queryClient) =>
+	Promise.all(
+		HOST_SCOPE_KEYS.map((queryKey) =>
+			queryClient.invalidateQueries({ queryKey }),
+		),
+	);


### PR DESCRIPTION
## Problem

The Refresh buttons often appear to do nothing, and a full browser reload is the only reliable way to bring in new data.

They were bound to the `refetch` of the **first** `useQuery` on the page, while pages mount ten to thirteen queries. Everything else kept rendering a five-minute-old snapshot.

Three independent causes:

1. **One-query buttons.** Dashboard refreshed 1 of its 13 queries. Hosts refreshed the table but not the stat cards, filter dropdowns or connection badge. Host detail refreshed the host record but none of the tabs. Docker refreshed the active tab's list but not the stat cards, and ended its dispatch in `window.location.reload()`.
2. **Focus refetching was off globally** with a five-minute `staleTime`, so returning to a tab refetched nothing. `refetchInterval` also does not fire in a backgrounded tab, so a tab left alone came back showing everything as it was when it lost focus.
3. **Three queries had no refetch trigger at all.** `hostCounts`, `navigationStats` and `hostFilterOptions` appeared in zero `invalidateQueries` calls anywhere in the app, and `Layout` never unmounts. Adding or deleting a host updated the table but left the sidebar badge wrong for the life of the tab.

The sidebar control was the most misleading: it refetched three counters and reset an "Updated" timestamp that reads `NOW()` from the server, so it looked like it had refreshed the page while nothing the user was looking at had changed.

## Change

- **`hooks/usePageRefresh.js`** — `usePageRefresh(keys)` invalidates every key a screen renders from and derives `isRefreshing` from all of them. This also fixes a second-order bug: the spinner previously stopped when the first query landed while other panels were still loading. Background polls are excluded, so the button does not spin on a timer.
- **`useGlobalRefresh()`** for the sidebar, which sits outside any page and cannot know the route's keys.
- **`utils/queryScopes.js`** — `invalidateHostScope()` so host membership changes reach the counters. The set lives in one place so it cannot drift again.
- **Client defaults** — `refetchOnWindowFocus: true`, `staleTime: 60s`. These move together: focus and mount refetching only act on queries that are already stale, so leaving `staleTime` at five minutes would have made both no-ops.
- **Form protection** — enabling focus refetch meant a settings form could be overwritten mid-edit, since each hydrated local state from query data on every change. Those effects now skip while dirty and re-hydrate once a save clears the flag.
- **Docs** - `CONTRIBUTING.md` gains a "Frontend data fetching and refresh" section, so the rules live somewhere a contributor will find them rather than only in code comments and guard tests.

## Behaviour notes

`packageTrends` keeps an explicit five-minute `staleTime`. It aggregates up to a year of `system_statistics` with no server-side cache and the series is day-granular, so remount-refetching it every minute costs a lot and can change nothing. The Refresh button still forces it.

`AlertSettings` needed different handling from the other forms: its dirty flag is *derived* by comparing local state to the server copy, so it awaits the refetch before dropping local state. Clearing it earlier re-hydrated the form from pre-save values and then wedged it dirty against the values that arrived next, which silently reverted the save on the following Apply.

## Session timeout

Unaffected, and this was checked rather than assumed. The inactivity window only slides on requests carrying `X-User-Activity`, which the request interceptor attaches only after a real interaction. Background refetching is invisible to the session, so an unattended tab still ages out on schedule. Focus refetch does mark an interaction, but that is already true today via the 30s heartbeat, so it is not a change.

## Testing

- `frontend/src/__tests__/pageRefresh.test.jsx` — 12 new tests covering prefix matching, multi-key invalidation, spinner behaviour across slow and fast queries, poll exclusion, and the save-then-rehydrate ordering. Verified non-vacuous by reverting the fix and confirming the relevant test fails.
- Source-tree guards that fail the build if the global focus-refetch default is disabled again or `staleTime` is raised past the point where focus refetch stops firing, since both are one-line changes that would silently undo this for the whole app.
- Full suite: 189 passed, 3 skipped. `biome check` clean. `vite build` passes.
