### PR TITLE
chore: require dashboard approval for Renovate PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["config:recommended"]
+	"extends": ["config:recommended"],
+	"dependencyDashboardApproval": true
 }


### PR DESCRIPTION
## What

Adds `dependencyDashboardApproval: true` to `renovate.json`.

## Why

Renovate currently opens dependency update PRs on its own, which adds review noise to the queue. With this change it keeps scanning and keeps reporting, but stops raising PRs unprompted.

## Effect

- Every available update is listed on the Dependency Dashboard issue with a checkbox.
- A PR is only created when a maintainer ticks that checkbox.
- Any Renovate PRs currently open will be closed on the next run after this merges.
- Takes effect only once this is on `main`, since Renovate reads its config from the default branch.

## Note on security updates

`config:recommended` enables `vulnerabilityAlerts`, and those PRs are gated by this setting too. If we would rather have CVE fixes keep raising automatically while everything else waits for approval, we can follow up with:

```json
"vulnerabilityAlerts": { "dependencyDashboardApproval": false }
```

Left out of this PR deliberately so the behaviour change here is a single, easily reverted knob.