### PR TITLE
fix(compliance): resolve OpenSCAP package names against the archive

### DIFF
--- a/agent-source-code/cmd/patchmon-agent/commands/report.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/report.go
@@ -903,7 +903,10 @@ func runScheduledComplianceScan() {
 	})
 
 	if !complianceInteg.IsAvailable() {
-		logger.Debug("Compliance scanning not available on this system, skipping scheduled scan")
+		// Info, not Debug: at the default level this was the only outcome that
+		// printed nothing at all after "Starting scheduled compliance scan", so
+		// a host with no scanner was indistinguishable from a hung scan.
+		logger.Info("Compliance scanning not available on this system (no scanner or no SCAP content), skipping scheduled scan")
 		return
 	}
 

--- a/agent-source-code/internal/integrations/compliance/openscap.go
+++ b/agent-source-code/internal/integrations/compliance/openscap.go
@@ -309,125 +309,37 @@ func (s *OpenSCAPScanner) EnsureInstalled() error {
 		"NEEDRESTART_SUSPEND=1",
 	)
 
+	var scannerErr error
 	switch s.osInfo.Family {
 	case "debian":
-		// Ubuntu/Debian - always update and upgrade to get latest content
-		s.logger.Info("Installing/upgrading OpenSCAP on Debian-based system...")
-
-		// Update package cache first (with timeout)
-		updateCmd := exec.CommandContext(ctx, "apt-get", "update", "-qq")
-		updateCmd.Env = nonInteractiveEnv
-		if err := updateCmd.Run(); err != nil {
-			// Ignore errors on update - non-critical
-			_ = err
-		}
-
-		// Build package list - openscap-common is required for Ubuntu 24.04+
-		packages := []string{"openscap-scanner", "openscap-common"}
-
-		// SSG content: ssg-base + ssg-debderived provide Ubuntu content; on Debian we need ssg-debian for ssg-debian10/11/12/13-ds.xml
-		ssgPackages := []string{"ssg-debderived", "ssg-base"}
-		if s.osInfo.Name == "debian" {
-			ssgPackages = append(ssgPackages, "ssg-debian")
-		}
-
-		// Install core OpenSCAP packages first
-		installArgs := append([]string{"install", "-y", "-qq",
-			"-o", "Dpkg::Options::=--force-confdef",
-			"-o", "Dpkg::Options::=--force-confold"}, packages...)
-		installCmd := exec.CommandContext(ctx, "apt-get", installArgs...)
-		installCmd.Env = nonInteractiveEnv
-		output, err := installCmd.CombinedOutput()
-		if err != nil {
-			if ctx.Err() == context.DeadlineExceeded {
-				s.logger.Warn("OpenSCAP installation timed out after 5 minutes")
-				return fmt.Errorf("installation timed out after 5 minutes")
-			}
-			s.logger.WithError(err).WithField("output", logutil.Sanitize(string(output))).Warn("Failed to install OpenSCAP core packages")
-			// Truncate output for error message
-			outputStr := string(output)
-			if len(outputStr) > 500 {
-				outputStr = outputStr[:500] + "... (truncated)"
-			}
-			return fmt.Errorf("failed to install OpenSCAP: %w - %s", err, outputStr)
-		}
-		s.logger.Info("OpenSCAP core packages installed successfully")
-
-		// Try to install SSG content packages (best effort - may fail on Ubuntu 24.04+)
-		ssgArgs := append([]string{"install", "-y", "-qq",
-			"-o", "Dpkg::Options::=--force-confdef",
-			"-o", "Dpkg::Options::=--force-confold"}, ssgPackages...)
-		ssgCmd := exec.CommandContext(ctx, "apt-get", ssgArgs...)
-		ssgCmd.Env = nonInteractiveEnv
-		ssgOutput, ssgErr := ssgCmd.CombinedOutput()
-		if ssgErr != nil {
-			s.logger.WithField("output", logutil.Sanitize(string(ssgOutput))).Warn("SSG content packages not available or failed to install. CIS scanning may have limited functionality.")
-		} else {
-			s.logger.Info("SSG content packages installed successfully")
-
-			// Explicitly upgrade to ensure we have the latest SCAP content
-			upgradePkgs := []string{"ssg-base", "ssg-debderived"}
-			if s.osInfo.Name == "debian" {
-				upgradePkgs = append(upgradePkgs, "ssg-debian")
-			}
-			upgradeCmd := exec.CommandContext(ctx, "apt-get", append([]string{"install", "--only-upgrade", "-y", "-qq",
-				"-o", "Dpkg::Options::=--force-confdef",
-				"-o", "Dpkg::Options::=--force-confold"}, upgradePkgs...)...)
-			upgradeCmd.Env = nonInteractiveEnv
-			upgradeOutput, upgradeErr := upgradeCmd.CombinedOutput()
-			if upgradeErr != nil {
-				s.logger.WithField("output", logutil.Sanitize(string(upgradeOutput))).Debug("Package upgrade returned non-zero (may already be latest)")
-			} else {
-				s.logger.Info("SCAP content packages upgraded to latest version")
-			}
-		}
-
+		scannerErr = s.installDebian(ctx, nonInteractiveEnv)
 	case "rhel":
-		// RHEL/CentOS/Rocky/Alma/Fedora
-		s.logger.Info("Installing/upgrading OpenSCAP on RHEL-based system...")
-		var installCmd *exec.Cmd
-		if _, err := exec.LookPath("dnf"); err == nil {
-			installCmd = exec.CommandContext(ctx, "dnf", "install", "-y", "-q", "openscap-scanner", "scap-security-guide")
-		} else {
-			installCmd = exec.CommandContext(ctx, "yum", "install", "-y", "-q", "openscap-scanner", "scap-security-guide")
-		}
-		output, err := installCmd.CombinedOutput()
-		if err != nil {
-			if ctx.Err() == context.DeadlineExceeded {
-				s.logger.Warn("OpenSCAP installation timed out after 5 minutes")
-				return fmt.Errorf("installation timed out after 5 minutes")
-			}
-			s.logger.WithError(err).WithField("output", logutil.Sanitize(string(output))).Warn("Failed to install OpenSCAP")
-			outputStr := string(output)
-			if len(outputStr) > 500 {
-				outputStr = outputStr[:500] + "... (truncated)"
-			}
-			return fmt.Errorf("failed to install OpenSCAP: %w - %s", err, outputStr)
-		}
-
+		scannerErr = s.installRHEL(ctx)
 	case "suse":
-		// SLES/openSUSE
-		s.logger.Info("Installing/upgrading OpenSCAP on SUSE-based system...")
-		installCmd := exec.CommandContext(ctx, "zypper", "--non-interactive", "install", "openscap-utils", "scap-security-guide")
-		output, err := installCmd.CombinedOutput()
-		if err != nil {
-			if ctx.Err() == context.DeadlineExceeded {
-				s.logger.Warn("OpenSCAP installation timed out after 5 minutes")
-				return fmt.Errorf("installation timed out after 5 minutes")
-			}
-			s.logger.WithError(err).WithField("output", logutil.Sanitize(string(output))).Warn("Failed to install OpenSCAP")
-			outputStr := string(output)
-			if len(outputStr) > 500 {
-				outputStr = outputStr[:500] + "... (truncated)"
-			}
-			return fmt.Errorf("failed to install OpenSCAP: %w - %s", err, outputStr)
-		}
-
+		scannerErr = s.installSUSE(ctx)
 	default:
-		return fmt.Errorf("unsupported OS family: %s (OS: %s)", s.osInfo.Family, s.osInfo.Name)
+		// Alpine, Arch and FreeBSD land here. Alpine does package an openscap
+		// apk, but no SSG datastream exists for any of the three, on the distro
+		// or on the PatchMon server, so a scanner would have nothing to scan
+		// against. Say that rather than emit a bare family name.
+		platform := strings.TrimSpace(s.osInfo.Name + " " + s.osInfo.Version)
+		if platform == "" {
+			platform = "this platform (no /etc/os-release)"
+		}
+		return fmt.Errorf("compliance scanning is not supported on %s: no SCAP content is published for it", platform)
 	}
 
-	s.logger.Info("OpenSCAP installed/upgraded successfully")
+	if scannerErr != nil {
+		// A failed package transaction is only fatal when it leaves no scanner
+		// behind. Where oscap ended up present anyway, the content steps below
+		// and the caller's server sync can still complete the install.
+		if _, lookErr := exec.LookPath(oscapBinary); lookErr != nil {
+			return scannerErr
+		}
+		s.logger.WithError(scannerErr).Warn("Package install reported a failure but the oscap binary is present; continuing")
+	} else {
+		s.logger.Info("OpenSCAP installed/upgraded successfully")
+	}
 
 	// On Debian 12+, if no content file or content doesn't match OS version (e.g. only ssg-debian11 on Debian 13), try GitHub SSG
 	if s.osInfo.Family == "debian" && s.osInfo.Name == "debian" {
@@ -471,6 +383,207 @@ func (s *OpenSCAPScanner) EnsureInstalled() error {
 	// Check for content version mismatch
 	s.checkContentCompatibility()
 
+	return nil
+}
+
+// truncateOutput trims command output to a length usable in an error message.
+//
+// Sanitised, not just truncated: this string is embedded in a returned error
+// that callers log and the UI renders, so it carries the same log-injection
+// risk as the adjacent log field.
+func truncateOutput(b []byte) string {
+	out := logutil.Sanitize(string(b))
+	if len(out) > 500 {
+		return out[:500] + "... (truncated)"
+	}
+	return out
+}
+
+// aptCandidate reports whether apt has an installable candidate for pkg.
+//
+// The OpenSCAP package names changed between releases: bookworm and noble ship
+// openscap-scanner plus openscap-common, while buster and jammy only ever
+// provided libopenscap8, and bullseye has neither. Asking the archive is the
+// only way to pick the right set without a release table that goes stale. A
+// name apt does not know prints nothing at all; a name it knows but cannot
+// install prints "(none)".
+func aptCandidate(ctx context.Context, env []string, pkg string) bool {
+	cmd := exec.CommandContext(ctx, "apt-cache", "policy", pkg)
+	cmd.Env = env
+	out, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	return policyHasCandidate(string(out))
+}
+
+// policyHasCandidate parses `apt-cache policy` output.
+func policyHasCandidate(out string) bool {
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "Candidate:") {
+			continue
+		}
+		v := strings.TrimSpace(strings.TrimPrefix(line, "Candidate:"))
+		return v != "" && v != "(none)"
+	}
+	return false
+}
+
+// debianScannerSets lists the package sets that provide the oscap binary, most
+// current first.
+var debianScannerSets = [][]string{
+	{"openscap-scanner", "openscap-common"}, // Debian 12+, Ubuntu 24.04+
+	{"libopenscap8"},                        // Debian 10, Ubuntu up to 22.04
+}
+
+// debianScannerSet returns the first set whose members are all installable, or
+// nil when the archive provides no scanner at all.
+func debianScannerSet(available func(string) bool) []string {
+	for _, set := range debianScannerSets {
+		ok := true
+		for _, p := range set {
+			if !available(p) {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			return set
+		}
+	}
+	return nil
+}
+
+// aptAvailable filters pkgs down to those apt can install.
+func aptAvailable(ctx context.Context, env []string, pkgs []string) []string {
+	out := make([]string, 0, len(pkgs))
+	for _, p := range pkgs {
+		if aptCandidate(ctx, env, p) {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// aptInstall runs a non-interactive install, optionally restricted to upgrades.
+func aptInstall(ctx context.Context, env []string, onlyUpgrade bool, pkgs ...string) ([]byte, error) {
+	args := []string{"install", "-y", "-qq",
+		"-o", "Dpkg::Options::=--force-confdef",
+		"-o", "Dpkg::Options::=--force-confold"}
+	if onlyUpgrade {
+		args = append(args, "--only-upgrade")
+	}
+	cmd := exec.CommandContext(ctx, "apt-get", append(args, pkgs...)...)
+	cmd.Env = env
+	return cmd.CombinedOutput()
+}
+
+// installDebian installs the scanner and, separately and best effort, the SSG
+// content packages. The two are separate transactions because content is
+// recoverable from the PatchMon server and the scanner is not.
+func (s *OpenSCAPScanner) installDebian(ctx context.Context, env []string) error {
+	s.logger.Info("Installing/upgrading OpenSCAP on Debian-based system...")
+
+	updateCmd := exec.CommandContext(ctx, "apt-get", "update", "-qq")
+	updateCmd.Env = env
+	if err := updateCmd.Run(); err != nil {
+		// Ignore errors on update - non-critical
+		_ = err
+	}
+
+	packages := debianScannerSet(func(p string) bool { return aptCandidate(ctx, env, p) })
+	if packages == nil {
+		// Debian 11 is the live case: openscap was removed before bullseye
+		// released. Worded as "none found" rather than "none exists" because
+		// aptCandidate also returns false when apt-cache itself cannot answer,
+		// and the apt-get update above deliberately ignores its own failure.
+		return fmt.Errorf("found no installable OpenSCAP package for %s %s (looked for openscap-scanner with openscap-common, then libopenscap8); "+
+			"on Debian 11 there is none to find, otherwise check that the package cache is current and the mirrors are reachable",
+			s.osInfo.Name, s.osInfo.Version)
+	}
+
+	output, err := aptInstall(ctx, env, false, packages...)
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			s.logger.Warn("OpenSCAP installation timed out after 5 minutes")
+			return fmt.Errorf("installation timed out after 5 minutes")
+		}
+		s.logger.WithError(err).WithField("output", logutil.Sanitize(string(output))).Warn("Failed to install OpenSCAP core packages")
+		return fmt.Errorf("failed to install OpenSCAP: %w - %s", err, truncateOutput(output))
+	}
+	s.logger.WithField("packages", strings.Join(packages, " ")).Info("OpenSCAP core packages installed successfully")
+
+	// ssg-base and ssg-debderived carry Ubuntu content; Debian needs ssg-debian
+	// for ssg-debian10/11/12/13-ds.xml. Ubuntu packages none of them.
+	ssgPackages := []string{"ssg-debderived", "ssg-base"}
+	if s.osInfo.Name == "debian" {
+		ssgPackages = append(ssgPackages, "ssg-debian")
+	}
+	ssgPackages = aptAvailable(ctx, env, ssgPackages)
+	if len(ssgPackages) == 0 {
+		s.logger.Info("No SSG content packages in this archive; content will be synced from the PatchMon server")
+		return nil
+	}
+
+	ssgOutput, ssgErr := aptInstall(ctx, env, false, ssgPackages...)
+	if ssgErr != nil {
+		s.logger.WithField("output", logutil.Sanitize(string(ssgOutput))).Warn("SSG content packages failed to install. CIS scanning may have limited functionality.")
+		return nil
+	}
+	s.logger.Info("SSG content packages installed successfully")
+
+	upgradeOutput, upgradeErr := aptInstall(ctx, env, true, ssgPackages...)
+	if upgradeErr != nil {
+		s.logger.WithField("output", logutil.Sanitize(string(upgradeOutput))).Debug("Package upgrade returned non-zero (may already be latest)")
+	} else {
+		s.logger.Info("SCAP content packages upgraded to latest version")
+	}
+	return nil
+}
+
+func (s *OpenSCAPScanner) installRHEL(ctx context.Context) error {
+	s.logger.Info("Installing/upgrading OpenSCAP on RHEL-based system...")
+
+	pm := "yum"
+	if _, err := exec.LookPath("dnf"); err == nil {
+		pm = "dnf"
+	}
+
+	output, err := exec.CommandContext(ctx, pm, "install", "-y", "-q", "openscap-scanner").CombinedOutput()
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			s.logger.Warn("OpenSCAP installation timed out after 5 minutes")
+			return fmt.Errorf("installation timed out after 5 minutes")
+		}
+		s.logger.WithError(err).WithField("output", logutil.Sanitize(string(output))).Warn("Failed to install OpenSCAP")
+		return fmt.Errorf("failed to install OpenSCAP: %w - %s", err, truncateOutput(output))
+	}
+
+	ssgOutput, ssgErr := exec.CommandContext(ctx, pm, "install", "-y", "-q", "scap-security-guide").CombinedOutput()
+	if ssgErr != nil {
+		s.logger.WithField("output", logutil.Sanitize(string(ssgOutput))).Warn("scap-security-guide not available; content will be synced from the PatchMon server")
+	}
+	return nil
+}
+
+func (s *OpenSCAPScanner) installSUSE(ctx context.Context) error {
+	s.logger.Info("Installing/upgrading OpenSCAP on SUSE-based system...")
+
+	output, err := exec.CommandContext(ctx, "zypper", "--non-interactive", "install", "openscap-utils").CombinedOutput()
+	if err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			s.logger.Warn("OpenSCAP installation timed out after 5 minutes")
+			return fmt.Errorf("installation timed out after 5 minutes")
+		}
+		s.logger.WithError(err).WithField("output", logutil.Sanitize(string(output))).Warn("Failed to install OpenSCAP")
+		return fmt.Errorf("failed to install OpenSCAP: %w - %s", err, truncateOutput(output))
+	}
+
+	ssgOutput, ssgErr := exec.CommandContext(ctx, "zypper", "--non-interactive", "install", "scap-security-guide").CombinedOutput()
+	if ssgErr != nil {
+		s.logger.WithField("output", logutil.Sanitize(string(ssgOutput))).Warn("scap-security-guide not available; content will be synced from the PatchMon server")
+	}
 	return nil
 }
 

--- a/agent-source-code/internal/integrations/compliance/openscap_content_test.go
+++ b/agent-source-code/internal/integrations/compliance/openscap_content_test.go
@@ -1,6 +1,7 @@
 package compliance
 
 import (
+	"strings"
 	"testing"
 
 	"patchmon-agent/pkg/models"
@@ -84,6 +85,96 @@ func TestPickSSGFile(t *testing.T) {
 			}
 			if got := s.pickSSGFile(tt.available); got != tt.want {
 				t.Fatalf("pickSSGFile() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPolicyHasCandidate(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		want bool
+	}{
+		{
+			name: "installable",
+			out:  "openscap-scanner:\n  Installed: (none)\n  Candidate: 1.3.7+dfsg-1+deb12u1\n  Version table:\n",
+			want: true,
+		},
+		{
+			// A name apt knows but cannot install, which is how bookworm reports
+			// libopenscap8.
+			name: "known but no candidate",
+			out:  "libopenscap8:\n  Installed: (none)\n  Candidate: (none)\n  Version table:\n",
+			want: false,
+		},
+		{
+			// A name apt does not know at all produces no output whatsoever, and
+			// still exits zero.
+			name: "unknown package",
+			out:  "",
+			want: false,
+		},
+		{
+			name: "already installed",
+			out:  "libopenscap8:\n  Installed: 1.2.17-0.1ubuntu7.22.04.3\n  Candidate: 1.2.17-0.1ubuntu7.22.04.3\n",
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := policyHasCandidate(tt.out); got != tt.want {
+				t.Fatalf("policyHasCandidate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDebianScannerSet(t *testing.T) {
+	tests := []struct {
+		name      string
+		available []string
+		want      []string
+	}{
+		{
+			name:      "bookworm and noble",
+			available: []string{"openscap-scanner", "openscap-common", "ssg-base"},
+			want:      []string{"openscap-scanner", "openscap-common"},
+		},
+		{
+			name:      "jammy has only the library package",
+			available: []string{"libopenscap8"},
+			want:      []string{"libopenscap8"},
+		},
+		{
+			name:      "buster has both, newest wins",
+			available: []string{"libopenscap8", "openscap-scanner", "openscap-common"},
+			want:      []string{"openscap-scanner", "openscap-common"},
+		},
+		{
+			// A partial modern set must not be selected: installing
+			// openscap-scanner without openscap-common fails the transaction.
+			name:      "partial modern set falls through",
+			available: []string{"openscap-scanner", "libopenscap8"},
+			want:      []string{"libopenscap8"},
+		},
+		{
+			name:      "bullseye packages no scanner at all",
+			available: nil,
+			want:      nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			avail := make(map[string]bool, len(tt.available))
+			for _, p := range tt.available {
+				avail[p] = true
+			}
+			got := debianScannerSet(func(p string) bool { return avail[p] })
+			if strings.Join(got, " ") != strings.Join(tt.want, " ") {
+				t.Fatalf("debianScannerSet() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/docs/patchmon-admin-guide.md
+++ b/docs/patchmon-admin-guide.md
@@ -3009,10 +3009,31 @@ Compliance scanning on a host needs OpenSCAP (`oscap` binary) installed and the 
 2. On next Apply Pending Config, the agent receives the new integration state and reports that the scanner is not installed.
 3. From the Host Detail Compliance tab, click **Install Scanner**. The UI calls `POST /api/v1/compliance/install-scanner/{hostId}`.
 4. The server enqueues an install task. The worker sends an install message to the agent.
-5. The agent installs `openscap-scanner` (via `apt` / `dnf`) and downloads SSG content from the server via `GET /api/v1/compliance/ssg-content/{filename}`. Progress events are reported back to Redis and surfaced in the UI via `GET /compliance/install-job/{hostId}`, which returns the current state (`waiting`, `active`, `completed`) plus a per-step message and progress percent.
+5. The agent installs the OpenSCAP scanner with the host's own package manager, then downloads SSG content from the server via `GET /api/v1/compliance/ssg-content/{filename}`. Progress events are reported back to Redis and surfaced in the UI via `GET /compliance/install-job/{hostId}`, which returns the current state plus a per-step message and progress percent. The states are `none` (no install has been requested), `waiting`, `active`, `completed`, `failed`, and `unknown` when the job can no longer be found. A `failed` state also carries an `error` field with the reason.
 6. When the install completes, the Run Scan button becomes active.
 
+The scanner package name is not the same on every release, so the agent asks the archive which one it has rather than assuming. Debian 12 and newer, and Ubuntu 24.04 and newer, provide `openscap-scanner` plus `openscap-common`; Debian 10 and Ubuntu 22.04 provide `libopenscap8` instead. RHEL-family hosts use `openscap-scanner` and SUSE hosts use `openscap-utils`.
+
+Content is handled separately from the scanner, and a host that gets one without the other is not a failure. Ubuntu packages no SSG content at all, so on Ubuntu the datastream always comes from the PatchMon server. The install only fails outright when the host ends up with no working `oscap` binary.
+
 Install can be cancelled mid-flight from the same UI via `POST /api/v1/compliance/install-scanner/{hostId}/cancel`.
+
+#### Platforms where the scanner cannot be installed
+
+Some supported PatchMon hosts cannot run compliance scanning at all, because the platform publishes no OpenSCAP package, no SCAP content, or neither. On most of these the install reports the reason in plain terms. The exception is Amazon Linux 2, where the failure surfaces as raw `yum` output:
+
+| Platform | Reason |
+|----------|--------|
+| Debian 11 (bullseye) | OpenSCAP was removed from the archive before bullseye released, so no package provides `oscap` |
+| Amazon Linux 2 | The amzn2 repositories carry neither `openscap-scanner` nor `scap-security-guide` |
+| Alpine Linux | No SCAP datastream is published for Alpine, so a scanner would have nothing to scan against |
+| Arch Linux | OpenSCAP is available only from the AUR, and no datastream is published |
+| FreeBSD | No OpenSCAP port and no datastream |
+| Windows | The agent has no compliance integration on Windows |
+
+Everything else in the supported matrix can install the scanner: Debian 10, 12, 13 and 14, Ubuntu 22.04 and 24.04, the RHEL family (Rocky, AlmaLinux, CentOS Stream, Oracle Linux, Fedora, Amazon Linux 2023), and openSUSE.
+
+On Debian 10 the install succeeds but the results are not useful. PatchMon ships no Debian 10 datastream, so the host falls back to the very old content in buster's own `ssg-debian` package, and every rule comes back as "not applicable" because the content targets an earlier Debian release. Treat compliance scanning on Debian 10 as unavailable in practice.
 
 If the status panel shows **Partial Installation**, some scanners are present and others are not. A common case is a host running Docker, where Docker Bench is ready but OpenSCAP is missing, so scans return Docker Bench results only and the scanner panel reports "No SCAP content found". The same button appears in that state, labelled **Retry install**, and installs whatever is missing.
 

--- a/server-source-code/internal/handler/compliance.go
+++ b/server-source-code/internal/handler/compliance.go
@@ -1129,6 +1129,11 @@ func (h *ComplianceHandler) InstallScanner(w http.ResponseWriter, r *http.Reques
 		Error(w, http.StatusInternalServerError, "Failed to create install task")
 		return
 	}
+	// Drop the previous install's events before the new job exists, so the
+	// first poll cannot read the old run's terminal step as this run's outcome.
+	if h.integrationStatus != nil {
+		_ = h.integrationStatus.ClearInstallEvents(r.Context(), host.ApiID, "compliance")
+	}
 	info, err := h.queueClient.Enqueue(task)
 	if err != nil {
 		Error(w, http.StatusInternalServerError, "Failed to enqueue install")
@@ -1173,6 +1178,68 @@ func (h *ComplianceHandler) CancelInstall(w http.ResponseWriter, r *http.Request
 		"success": true,
 		"message": "Cancel requested",
 	})
+}
+
+// installJobStatusFromEvents derives the install outcome from the agent's
+// install_events, returning the status and the message to report as `error`.
+//
+// The queue state this overrides only describes delivery of the WebSocket
+// command, which reaches a terminal state the moment the agent is told to
+// begin, so it reads "completed" or "unknown" for an install that failed.
+//
+// The outcome deliberately does NOT come from the stored `status` field, even
+// though the install path sets it. That field is shared with the agent's
+// periodic availability report, which writes "error" on any host where OpenSCAP
+// is simply not present yet, from two seconds after agent startup onwards and
+// again on every refresh the compliance tab triggers. Reading it would report
+// every fresh install as already failed before the agent had done anything, and
+// report a re-install on a working host as already complete.
+//
+// install_events are written only by runInstallScanner, and its last step is
+// always `complete`, `done` on success and `failed` on failure. Anything
+// short of that terminal step leaves the queue state alone rather than
+// inventing a verdict: an install that died mid-flight should not read as
+// permanently active.
+// The failure message is taken from the step that actually failed rather than
+// from the terminal step or the stored `message`. The failing step carries the
+// specific reason ("OpenSCAP installation failed: found no installable ...")
+// where `complete` is sometimes just "Installation failed", and unlike
+// `message` it cannot be overwritten by the availability reporter.
+func installJobStatusFromEvents(events []interface{}) (status, message string, ok bool) {
+	terminal := ""
+	terminalMsg := ""
+	failedStepMsg := ""
+
+	for _, raw := range events {
+		e, isMap := raw.(map[string]interface{})
+		if !isMap {
+			continue
+		}
+		step, _ := e["step"].(string)
+		stepStatus, _ := e["status"].(string)
+		msg, _ := e["message"].(string)
+
+		if step == "complete" {
+			switch stepStatus {
+			case "failed":
+				terminal, terminalMsg = "failed", msg
+			case "done":
+				terminal, terminalMsg = "completed", msg
+			}
+			continue
+		}
+		if stepStatus == "failed" && msg != "" && failedStepMsg == "" {
+			failedStepMsg = msg
+		}
+	}
+
+	if terminal == "" {
+		return "", "", false
+	}
+	if terminal == "failed" && failedStepMsg != "" {
+		return terminal, failedStepMsg, true
+	}
+	return terminal, terminalMsg, true
 }
 
 // GetInstallJobStatus handles GET /compliance/install-job/:hostId.
@@ -1230,6 +1297,20 @@ func (h *ComplianceHandler) GetInstallJobStatus(w http.ResponseWriter, r *http.R
 				}
 				if evts, ok := live["install_events"].([]interface{}); ok && len(evts) > 0 {
 					resp["install_events"] = evts
+					if mapped, reason, ok := installJobStatusFromEvents(evts); ok {
+						resp["status"] = mapped
+						if mapped == "failed" {
+							// live["message"] is the last resort only: the
+							// availability reporter writes that field too, so it
+							// may describe the host rather than this install.
+							if reason == "" {
+								reason, _ = live["message"].(string)
+							}
+							if reason != "" {
+								resp["error"] = reason
+							}
+						}
+					}
 				}
 				if prog, ok := live["progress"].(float64); ok {
 					resp["progress"] = prog

--- a/server-source-code/internal/handler/integration_status_events_test.go
+++ b/server-source-code/internal/handler/integration_status_events_test.go
@@ -72,3 +72,98 @@ func TestReportIntegrationStatusShapeOmitsInstallEvents(t *testing.T) {
 		t.Errorf("expected install_events to be omitted, got %s", b)
 	}
 }
+
+// GetInstallJobStatus reports the asynq state of the WebSocket delivery, which
+// completes as soon as the agent is told to start, so a scanner install that
+// failed on the host surfaced as "completed" or "unknown".
+//
+// The outcome is taken from install_events and NOT from the stored `status`
+// field. That field is shared with the agent's periodic availability report,
+// which writes "error" on any host that simply has no scanner yet, from two
+// seconds after agent startup. Deriving from it reported every fresh install as
+// already failed before the agent had done anything.
+func TestInstallJobStatusFromEvents(t *testing.T) {
+	event := func(step, status, message string) interface{} {
+		return map[string]interface{}{"step": step, "status": status, "message": message}
+	}
+
+	tests := []struct {
+		name        string
+		events      []interface{}
+		wantStatus  string
+		wantMessage string
+		wantOK      bool
+	}{
+		{
+			// The specific reason comes from the step that failed, not from the
+			// terminal step's generic label.
+			name:        "failed install prefers the failing step's reason",
+			events:      []interface{}{event("detect_os", "done", ""), event("install_openscap", "failed", "no package"), event("complete", "failed", "Installation failed")},
+			wantStatus:  "failed",
+			wantMessage: "no package",
+			wantOK:      true,
+		},
+		{
+			name:        "failure with only a terminal message",
+			events:      []interface{}{event("detect_os", "done", ""), event("complete", "failed", "timed out after 5 minutes")},
+			wantStatus:  "failed",
+			wantMessage: "timed out after 5 minutes",
+			wantOK:      true,
+		},
+		{
+			// A failed step with no terminal step is not a verdict, so the
+			// earlier-failed-step preference must not leak into an in-flight run.
+			name:   "failed step without a terminal step",
+			events: []interface{}{event("install_openscap", "failed", "no package")},
+			wantOK: false,
+		},
+		{
+			name:        "successful install",
+			events:      []interface{}{event("detect_os", "done", ""), event("complete", "done", "Installation complete - scanner is ready")},
+			wantStatus:  "completed",
+			wantMessage: "Installation complete - scanner is ready",
+			wantOK:      true,
+		},
+		{
+			// No terminal step yet: the queue state must be left alone rather
+			// than reported as permanently active.
+			name:   "in flight",
+			events: []interface{}{event("detect_os", "done", ""), event("install_openscap", "in_progress", "Installing...")},
+			wantOK: false,
+		},
+		{
+			// What InstallScanner leaves behind when it clears the previous
+			// run's events, and what a host that has never installed holds.
+			name:   "no events",
+			events: nil,
+			wantOK: false,
+		},
+		{
+			name:   "malformed entries are skipped",
+			events: []interface{}{"not-a-map", map[string]interface{}{"step": 42}},
+			wantOK: false,
+		},
+		{
+			// A failed step that is not the terminal one is not an outcome:
+			// SSG content can fail while the install still completes.
+			name:   "non-terminal failure is not the verdict",
+			events: []interface{}{event("install_ssg", "failed", "content unavailable")},
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status, message, ok := installJobStatusFromEvents(tt.events)
+			if ok != tt.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if status != tt.wantStatus || message != tt.wantMessage {
+				t.Fatalf("= (%q, %q), want (%q, %q)", status, message, tt.wantStatus, tt.wantMessage)
+			}
+		})
+	}
+}

--- a/server-source-code/internal/store/integration_status.go
+++ b/server-source-code/internal/store/integration_status.go
@@ -77,6 +77,26 @@ func (s *IntegrationStatusStore) SetComplianceInstallJob(ctx context.Context, ho
 	return rdb.Set(ctx, key, jobID, time.Duration(complianceInstallJobTTL)*time.Second).Err()
 }
 
+// ClearInstallEvents drops the stored install_events for a host's integration,
+// leaving the rest of the status blob alone.
+//
+// Called when a new install is queued. Without it the previous install's
+// terminal event survives in Redis, and the first poll of the new job reports
+// that older run's outcome as if it were this one's. The blob is not cleared
+// wholesale because the agent's periodic availability report legitimately owns
+// the other fields.
+func (s *IntegrationStatusStore) ClearInstallEvents(ctx context.Context, apiID, integrationName string) error {
+	current, err := s.Get(ctx, apiID, integrationName)
+	if err != nil || current == nil {
+		return err
+	}
+	if _, ok := current["install_events"]; !ok {
+		return nil
+	}
+	current["install_events"] = []interface{}{}
+	return s.Set(ctx, apiID, integrationName, current)
+}
+
 // GetComplianceInstallJob returns the install job ID for a host.
 func (s *IntegrationStatusStore) GetComplianceInstallJob(ctx context.Context, hostID string) (string, error) {
 	rdb := s.rdb.RDB(ctx)


### PR DESCRIPTION
Fixes #809

## The bug

The agent hard-coded the Debian-family scanner packages as `openscap-scanner` plus `openscap-common`. Those names only exist on Debian 12 and newer and Ubuntu 24.04 and newer. On Ubuntu 22.04 and Debian 10 `apt-get install` exits 100 with "Unable to locate package", and because that error was fatal the install aborted before the step that syncs SCAP content from the PatchMon server. Debian 11 packages no OpenSCAP at all.

This is exactly the failure in #809, whose reporter is on Ubuntu 22.04 despite the issue title.

Verified against every distro's real repository metadata rather than inferred:

| Release | Provides |
|---|---|
| Debian 12, 13, 14, Ubuntu 24.04 | `openscap-scanner` + `openscap-common` |
| Ubuntu 22.04, Debian 10 | `libopenscap8` only (it does ship `/usr/bin/oscap`) |
| Debian 11 | nothing, OpenSCAP was removed before bullseye released |

Ubuntu packages no SSG content at any release, so on Ubuntu the datastream has to come from the server. The server already bundles `ssg-ubuntu2204-ds.xml`; the aborted install just never reached the step that fetches it.

## The fix

- The Debian branch asks `apt-cache policy` which package set the release actually has, falling back to `libopenscap8`. No release table to go stale.
- A failed package transaction is fatal only when no `oscap` binary survives it. A host that ends up with a working scanner and no content now continues to the server content sync instead of aborting.
- Scanner and content are separate transactions on Debian, RHEL and SUSE, because content is recoverable from the server and the scanner is not. This also fixes a latent SUSE bug: zypper exits 102 and 103 to mean "reboot needed" and "restart needed" after a **successful** install, and the old single transaction treated those as failures.
- Platforms with no install path (Debian 11, Amazon Linux 2, Alpine, Arch, FreeBSD) report that instead of a package manager error.
- A scheduled scan that finds no scanner now logs the reason. It previously bailed at debug level, so at the default log level a host with no scanner printed nothing after "Starting scheduled compliance scan" and looked like a hang.

## Install job status

Separately, `GET /compliance/install-job/{hostId}` reported the wrong outcome. Its status came from the queue task, which only delivers the WebSocket command and so reaches a terminal state the moment the agent is told to begin. A failed install surfaced as `completed` or `unknown`, and the compliance panel's `failed` branch was unreachable.

The status now comes from the agent's `install_events`, using the terminal `complete` step, with the reason taken from the step that actually failed rather than the generic terminal label. `InstallScanner` clears the previous run's events when queueing so a re-install cannot report the earlier outcome.

Deliberately not read: the stored `status` field. It is shared with the agent's periodic availability report, which writes `error` on any host that simply has no scanner yet, from two seconds after agent start. Deriving from it would report every fresh install as failed before the agent had done anything.

## Testing

`make check` passes for both modules. New unit tests cover the `apt-cache policy` parse, the package-set selection, and the install-event derivation.

Exercised end to end on a real fleet with a patched agent and server:

| Host | Result |
|---|---|
| Ubuntu 22.04 | was broken, now installs `libopenscap8`, syncs `ssg-ubuntu2204-ds.xml`, and completes a scan |
| Debian 10 | was broken, now installs |
| openSUSE 16, AlmaLinux 10, Rocky 10, Fedora | still work, no regression from the transaction split |
| Debian 11 | fails in one second with an actionable reason instead of five seconds of apt errors |
| Alpine | reports the platform is unsupported rather than an empty OS family |

Install job checks: a fresh install reports `waiting` then `completed` and never a spurious `failed`; a second install does not report the first one's outcome; a failed install surfaces the specific reason.

## Note on Debian 10

The install now succeeds on Debian 10, but scanning there is not useful: no Debian 10 datastream is published, so it falls back to buster's own `ssg-debian` 0.1.39, which carries `ssg-debian8` content, and every rule returns "not applicable". Documented in the admin guide rather than left to be rediscovered.
