### PR TITLE
fix: correct WS/WSS reporting and two other agent presence registry bugs

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -58,6 +58,10 @@ services:
       target: development
       tags: [patchmon-server:dev]
     restart: unless-stopped
+    # See the note in docker-compose.yml: a stable hostname keeps the agent
+    # presence registry able to recognise its own records across a rebuild,
+    # which recreates the container far more often here than in production.
+    hostname: patchmon-server-dev
     environment:
       APP_ENV: development
       LOG_LEVEL: info

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,6 +22,11 @@ services:
   server:
     image: ghcr.io/patchmon/patchmon-server:latest
     restart: unless-stopped
+    # Stable identity for the agent presence registry. Without this the server
+    # identifies itself by the container hostname, which Docker derives from the
+    # container ID, so upgrading with `up -d` recreates the container and the
+    # new process cannot recognise the presence records the old one left behind.
+    hostname: patchmon-server
     env_file: .env
     ports:
       - "${PORT:-3000}:${PORT:-3000}"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,6 +26,9 @@ services:
     # identifies itself by the container hostname, which Docker derives from the
     # container ID, so upgrading with `up -d` recreates the container and the
     # new process cannot recognise the presence records the old one left behind.
+    # This name must also be unique per server process. The stack below ships
+    # its own Redis, so separate installs cannot collide; if you instead point
+    # several servers at one shared Redis, give each a distinct POD_ID.
     hostname: patchmon-server
     env_file: .env
     ports:

--- a/server-source-code/internal/agentregistry/presence_secure_test.go
+++ b/server-source-code/internal/agentregistry/presence_secure_test.go
@@ -1,0 +1,132 @@
+package agentregistry
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	redisclient "github.com/redis/go-redis/v9"
+)
+
+// newPresenceRedis returns a registry wired to a real in-memory Redis, with
+// distributed presence active but no pubsub consumer running, so tests can
+// assert on the presence hash without racing the subscriber.
+func newPresenceRedis(t *testing.T, podID string) (*Registry, *redisclient.Client) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := redisclient.NewClient(&redisclient.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	r := New()
+	r.distCtx = context.Background()
+	r.rdb = client
+	r.podID = podID
+	return r, client
+}
+
+// awaitPresenceField polls the presence hash until the field appears, so the
+// async setPresence goroutine has a bounded window to land.
+func awaitPresenceField(t *testing.T, client *redisclient.Client, apiID, field string) string {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	var last string
+	for time.Now().Before(deadline) {
+		v, err := client.HGet(context.Background(), "agent:meta:"+apiID, field).Result()
+		if err == nil {
+			last = v
+			return last
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("presence field %q for %s never appeared", field, apiID)
+	return ""
+}
+
+// TestSetConnection_PublishesRealSecureFlag is the direct regression guard for
+// the WS/WSS mislabel. SetConnection republishes presence to carry the context
+// label forward, and used to hardcode secure=true while doing so. That value
+// raced Register's correct one through the agent:events channel, so roughly
+// half of a plain-HTTP fleet ended up labelled WSS in the UI.
+//
+// The published flag must mirror whatever Register already stored, never a
+// constant.
+func TestSetConnection_PublishesRealSecureFlag(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		secure bool
+		want   string
+	}{
+		{"plain ws stays insecure", false, "0"},
+		{"wss stays secure", true, "1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			r, client := newPresenceRedis(t, "pod-a")
+
+			// Seed exactly what Register leaves behind on the upgrade path,
+			// without letting its own async publish race this assertion.
+			r.mu.Lock()
+			r.meta["api-1"] = ConnectionInfo{Connected: true, Secure: tc.secure}
+			r.mu.Unlock()
+
+			r.SetConnection("api-1", newFakeConn())
+
+			if got := awaitPresenceField(t, client, "api-1", "secure"); got != tc.want {
+				t.Fatalf("presence secure=%q, want %q: SetConnection must publish the "+
+					"connection's real TLS state, not a constant", got, tc.want)
+			}
+			if info := r.Get("api-1"); info.Secure != tc.secure {
+				t.Fatalf("local meta Secure=%v, want %v", info.Secure, tc.secure)
+			}
+		})
+	}
+}
+
+// TestUpgradePath_PlainHTTPFleetNeverReportsSecure exercises the real upgrade
+// sequence from handler.AgentWSHandler.ServeWS (Register then SetConnection)
+// with the pubsub consumer live, which is where the race actually bit: the pod
+// receives its own connect events and handlePubSubMessage overwrites local meta
+// from them. Every agent here connected over plain HTTP, so not one may end up
+// reported as secure.
+func TestUpgradePath_PlainHTTPFleetNeverReportsSecure(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redisclient.NewClient(&redisclient.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	r := New()
+	if err := r.EnableDistributed(context.Background(), client, "pod-a"); err != nil {
+		t.Fatalf("EnableDistributed: %v", err)
+	}
+	// Let the subscription register before anything publishes.
+	time.Sleep(200 * time.Millisecond)
+
+	// A fleet rather than a single agent: the losing side of the race was
+	// per-agent and roughly a coin flip, so one agent would pass by luck half
+	// the time.
+	const fleet = 40
+	for i := range fleet {
+		apiID := fmt.Sprintf("api-%02d", i)
+		r.Register(apiID, false /* plain HTTP, no X-Forwarded-Proto: https */, "")
+		r.SetConnection(apiID, newFakeConn())
+	}
+
+	// Give every async publish and its pubsub round trip room to land.
+	time.Sleep(time.Second)
+
+	var mislabelled []string
+	for i := range fleet {
+		apiID := fmt.Sprintf("api-%02d", i)
+		if r.Get(apiID).Secure {
+			mislabelled = append(mislabelled, apiID)
+		}
+	}
+	if len(mislabelled) > 0 {
+		t.Fatalf("%d/%d plain-HTTP agents reported Secure=true (UI renders a WSS pill): %v",
+			len(mislabelled), fleet, mislabelled)
+	}
+}

--- a/server-source-code/internal/agentregistry/presence_secure_test.go
+++ b/server-source-code/internal/agentregistry/presence_secure_test.go
@@ -118,12 +118,25 @@ func TestUpgradePath_PlainHTTPFleetNeverReportsSecure(t *testing.T) {
 	// Give every async publish and its pubsub round trip room to land.
 	time.Sleep(time.Second)
 
-	var mislabelled []string
+	// Assert on the durable presence record as well as local meta. Local meta
+	// alone would pass vacuously on a runner slow enough that no event is
+	// consumed within the settle window, since Register's own correct value
+	// would simply still be sitting there — the guard would silently disarm
+	// rather than fail. The hash is also what a peer's snapshotPresence reads
+	// back, so a wrong value there mislabels the pill on another pod too.
+	var mislabelled, badRecord []string
 	for i := range fleet {
 		apiID := fmt.Sprintf("api-%02d", i)
 		if r.Get(apiID).Secure {
 			mislabelled = append(mislabelled, apiID)
 		}
+		if got := awaitPresenceField(t, client, apiID, "secure"); got != "0" {
+			badRecord = append(badRecord, fmt.Sprintf("%s=%s", apiID, got))
+		}
+	}
+	if len(badRecord) > 0 {
+		t.Errorf("%d/%d plain-HTTP agents have a secure presence record: %v",
+			len(badRecord), fleet, badRecord)
 	}
 	if len(mislabelled) > 0 {
 		t.Fatalf("%d/%d plain-HTTP agents reported Secure=true (UI renders a WSS pill): %v",

--- a/server-source-code/internal/agentregistry/registry.go
+++ b/server-source-code/internal/agentregistry/registry.go
@@ -373,12 +373,30 @@ func (r *Registry) EnableDistributed(ctx context.Context, rdb *redisclient.Clien
 }
 
 // snapshotPresence reads existing agent:meta:* keys and populates local maps.
+//
+// It runs once from EnableDistributed, at startup, when this process owns no
+// agent connections at all. A record naming another pod is therefore a claim
+// about a connection someone else holds, and is imported as connected. A
+// record naming US is a leftover from the process we just replaced: its socket
+// died with the old process, so importing it as connected would have the
+// registry assert a connection nothing in this process can write to. That lie
+// reaches operators directly — the WS pill shows connected, the sidebar count
+// is inflated, and host_down alerting is suppressed — for as long as the key
+// survives its 5 minute TTL, or until the agent reconnects and Register
+// overwrites the entry honestly.
+//
+// Own records are imported disconnected instead, stamped from now: the real
+// drop time is unknowable here, and "since this server started" is the honest
+// floor. Residual case not covered: a restart that changes the pod identity
+// (POD_ID unset and the container recreated, so os.Hostname differs) makes our
+// own leftovers indistinguishable from a peer's, and they import as connected
+// until the TTL expires.
 func (r *Registry) snapshotPresence() error {
 	if r.rdb == nil {
 		return fmt.Errorf("redis not configured")
 	}
 	var cursor uint64
-	var total int
+	var total, stale int
 	for {
 		keys, cur, err := r.rdb.Scan(r.distCtx, cursor, "agent:meta:*", 100).Result()
 		if err != nil {
@@ -404,14 +422,25 @@ func (r *Registry) snapshotPresence() error {
 					lastConnected = &t
 				}
 			}
-			r.mu.Lock()
-			r.meta[apiID] = ConnectionInfo{
-				Connected:       true,
+			// An empty pod is treated as ours: it cannot be routed to, so
+			// claiming it is connected is the same unbackable assertion.
+			ours := pod == "" || pod == r.podID
+			info := ConnectionInfo{
+				Connected:       !ours,
 				Secure:          secure,
 				Scope:           vals["scope"],
 				LastConnectedAt: lastConnected,
 			}
-			if pod != "" {
+			if ours {
+				now := time.Now().UTC()
+				info.DisconnectedAt = &now
+				stale++
+			}
+			r.mu.Lock()
+			r.meta[apiID] = info
+			// Only record a route we could actually publish to; publishForward
+			// rejects our own pod anyway.
+			if !ours {
 				r.podMap[apiID] = pod
 			}
 			r.mu.Unlock()
@@ -421,7 +450,7 @@ func (r *Registry) snapshotPresence() error {
 			break
 		}
 	}
-	slog.Info("agentregistry: snapshotPresence loaded", "keys", total)
+	slog.Info("agentregistry: snapshotPresence loaded", "keys", total, "stale_own_pod", stale)
 	return nil
 }
 

--- a/server-source-code/internal/agentregistry/registry.go
+++ b/server-source-code/internal/agentregistry/registry.go
@@ -468,6 +468,22 @@ func (r *Registry) handlePubSubMessage(channel string, payload []byte) {
 			slog.Error("agentregistry: invalid event payload", "error", err)
 			return
 		}
+		// Our own events carry nothing we do not already hold: Register,
+		// SetConnection and markDisconnectedLocked all write meta and podMap
+		// under the lock before the publish leaves the process. Applying them
+		// back is not merely redundant, it reorders. setPresence publishes from
+		// a goroutine while removePresence publishes inline, so a socket that
+		// dies inside that scheduling window delivers connect AFTER disconnect
+		// and the connect branch below rebuilds the entry as connected. Nothing
+		// then clears it — meta has no TTL — so the agent is a ghost for the
+		// life of the process: host_down suppressed, sidebar count inflated,
+		// every send failing with ErrNotConnected.
+		r.mu.RLock()
+		self := r.podID
+		r.mu.RUnlock()
+		if ev.Pod == self {
+			return
+		}
 		r.mu.Lock()
 		switch ev.Type {
 		case "connect":

--- a/server-source-code/internal/agentregistry/registry.go
+++ b/server-source-code/internal/agentregistry/registry.go
@@ -119,12 +119,16 @@ func (r *Registry) SetConnection(apiID string, conn *websocket.Conn) {
 	prev.LastConnectedAt = &now
 	prev.DisconnectedAt = nil
 	r.meta[apiID] = prev
-	// Carried from the Register call that precedes this on the upgrade path, so
-	// the presence record republished below keeps the agent's context label.
+	// Both carried from the Register call that precedes this on the upgrade
+	// path, so the presence record republished below keeps the agent's context
+	// label and its real TLS state. Secure must never be a constant here: the
+	// two publishes race through agent:events, and the pod consumes its own
+	// events, so a hardcoded value wins for roughly half the fleet.
 	scope := prev.Scope
+	secure := prev.Secure
 	r.mu.Unlock()
 	if r.rdb != nil {
-		go func() { _ = r.setPresence(apiID, true, scope) }()
+		go func() { _ = r.setPresence(apiID, secure, scope) }()
 	}
 }
 

--- a/server-source-code/internal/agentregistry/self_events_test.go
+++ b/server-source-code/internal/agentregistry/self_events_test.go
@@ -1,0 +1,130 @@
+package agentregistry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	redisclient "github.com/redis/go-redis/v9"
+)
+
+// TestUpgradeThenImmediateDrop_DoesNotGhost is the regression guard for an
+// agent left permanently marked connected despite having no socket.
+//
+// Register and SetConnection publish their connect event from a goroutine,
+// while UnregisterConn publishes its disconnect inline. A socket that dies
+// inside that scheduling window therefore delivers connect AFTER disconnect,
+// and the pod consumes its own events. The connect case rebuilt the entry
+// wholesale, so the agent came back as connected.
+//
+// The consequence outlives the two bugs this package already guards against:
+// in-memory meta has no TTL, so nothing ever flips the ghost back. host_down
+// alerting is suppressed for the life of the process, the sidebar count is
+// inflated, and every send to the agent fails with ErrNotConnected.
+func TestUpgradeThenImmediateDrop_DoesNotGhost(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := redisclient.NewClient(&redisclient.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	r := New()
+	if err := r.EnableDistributed(context.Background(), client, "pod-a"); err != nil {
+		t.Fatalf("EnableDistributed: %v", err)
+	}
+	time.Sleep(200 * time.Millisecond) // let the subscription register
+
+	// A fleet, because the window is a goroutine scheduling race: one agent
+	// could win it by luck.
+	const fleet = 20
+	for i := range fleet {
+		apiID := fmt.Sprintf("api-%02d", i)
+		conn := newFakeConn()
+		r.Register(apiID, false, "")
+		r.SetConnection(apiID, conn)
+		// The socket dies before the publish goroutines have been scheduled.
+		r.UnregisterConn(apiID, conn)
+	}
+
+	time.Sleep(time.Second) // let every publish and round trip land
+
+	var ghosts []string
+	for i := range fleet {
+		apiID := fmt.Sprintf("api-%02d", i)
+		if r.Get(apiID).Connected {
+			ghosts = append(ghosts, apiID)
+		}
+	}
+	if len(ghosts) > 0 {
+		t.Fatalf("%d/%d agents with no socket are still reported connected: %v. "+
+			"Nothing clears this: meta has no TTL, so host_down stays suppressed "+
+			"for the life of the process", len(ghosts), fleet, ghosts)
+	}
+}
+
+// TestHandlePubSubMessage_IgnoresOwnPodEvents pins the mechanism directly: an
+// event we published ourselves must not be applied, because local state was
+// already written synchronously under the lock before the publish went out.
+func TestHandlePubSubMessage_IgnoresOwnPodEvents(t *testing.T) {
+	t.Parallel()
+	r := New()
+	r.podID = "pod-a"
+
+	// Local truth: the agent dropped.
+	r.Register("api-1", false, "")
+	r.Unregister("api-1")
+
+	ev, err := json.Marshal(map[string]any{
+		"api_id": "api-1",
+		"type":   "connect",
+		"pod":    "pod-a", // ours
+		"secure": true,
+		"scope":  "",
+		"ts":     time.Now().UTC().Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	r.handlePubSubMessage("agent:events", ev)
+
+	if info := r.Get("api-1"); info.Connected {
+		t.Errorf("our own connect event must not resurrect an agent we know is gone")
+	}
+}
+
+// TestHandlePubSubMessage_AppliesPeerPodEvents is the other half: filtering our
+// own events must not deafen us to a peer's, which is the entire purpose of
+// distributed presence.
+func TestHandlePubSubMessage_AppliesPeerPodEvents(t *testing.T) {
+	t.Parallel()
+	r := New()
+	r.podID = "pod-a"
+
+	ev, err := json.Marshal(map[string]any{
+		"api_id": "api-1",
+		"type":   "connect",
+		"pod":    "pod-b", // a peer
+		"secure": true,
+		"scope":  "",
+		"ts":     time.Now().UTC().Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	r.handlePubSubMessage("agent:events", ev)
+
+	info := r.Get("api-1")
+	if !info.Connected {
+		t.Fatalf("a peer pod's connect event must still be applied")
+	}
+	if !info.Secure {
+		t.Errorf("expected the peer event's Secure flag to be applied")
+	}
+	r.mu.RLock()
+	pod := r.podMap["api-1"]
+	r.mu.RUnlock()
+	if pod != "pod-b" {
+		t.Errorf("podMap = %q, want pod-b so sends can be routed to the owner", pod)
+	}
+}

--- a/server-source-code/internal/agentregistry/snapshot_presence_test.go
+++ b/server-source-code/internal/agentregistry/snapshot_presence_test.go
@@ -1,0 +1,162 @@
+package agentregistry
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	redisclient "github.com/redis/go-redis/v9"
+)
+
+// seedPresence writes a presence record the way setPresence would.
+func seedPresence(t *testing.T, client *redisclient.Client, apiID, pod string, secure bool) {
+	t.Helper()
+	secureVal := "0"
+	if secure {
+		secureVal = "1"
+	}
+	vals := map[string]interface{}{
+		"pod":       pod,
+		"secure":    secureVal,
+		"scope":     "",
+		"last_seen": time.Now().UTC().Format(time.RFC3339),
+	}
+	if err := client.HSet(context.Background(), "agent:meta:"+apiID, vals).Err(); err != nil {
+		t.Fatalf("seed %s: %v", apiID, err)
+	}
+}
+
+// TestSnapshotPresence_OwnPodRecordsAreNotResurrected is the regression guard
+// for a restarted server claiming agents are connected when they are not.
+//
+// snapshotPresence runs at startup, before this process holds any socket. It
+// used to import every surviving presence record as Connected=true, including
+// the ones the previous process left behind for its own pod. Those sockets
+// died with that process, so the registry asserted connections nothing could
+// write to: a connected WS pill, an inflated sidebar count, and suppressed
+// host_down alerting for the remainder of the key's 5 minute TTL.
+func TestSnapshotPresence_OwnPodRecordsAreNotResurrected(t *testing.T) {
+	t.Parallel()
+	mr := miniredis.RunT(t)
+	client := redisclient.NewClient(&redisclient.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	// Left behind by the process we are replacing.
+	seedPresence(t, client, "api-ours", "pod-a", false)
+	// Held by a peer that is still running.
+	seedPresence(t, client, "api-theirs", "pod-b", true)
+	// Written before pod labelling, or by a pod that could not name itself.
+	seedPresence(t, client, "api-nopod", "", false)
+
+	r := New()
+	r.distCtx = context.Background()
+	r.rdb = client
+	r.podID = "pod-a"
+
+	if err := r.snapshotPresence(); err != nil {
+		t.Fatalf("snapshotPresence: %v", err)
+	}
+
+	ours := r.Get("api-ours")
+	if ours.Connected {
+		t.Errorf("our own leftover record must not be imported as connected: " +
+			"this process holds no sockets at startup")
+	}
+	if ours.DisconnectedAt == nil {
+		t.Errorf("expected DisconnectedAt to be stamped so the pill can show a duration")
+	}
+	if r.IsConnected("api-ours") {
+		t.Errorf("IsConnected must be false for our own leftover record")
+	}
+
+	if nopod := r.Get("api-nopod"); nopod.Connected {
+		t.Errorf("an unroutable record (no pod) must not be imported as connected")
+	}
+
+	theirs := r.Get("api-theirs")
+	if !theirs.Connected {
+		t.Errorf("a peer pod's record must still be imported as connected: " +
+			"that is the whole point of distributed presence")
+	}
+	if !theirs.Secure {
+		t.Errorf("expected the peer record's Secure flag to survive the snapshot")
+	}
+
+	if n := r.CountConnected(""); n != 1 {
+		t.Errorf("CountConnected = %d, want 1 (only the peer pod's agent)", n)
+	}
+}
+
+// TestSnapshotPresence_OwnPodRecordsAreNotRouted checks the routing half: a
+// leftover of ours must not leave a podMap entry pointing at a pod with no
+// socket behind it.
+func TestSnapshotPresence_OwnPodRecordsAreNotRouted(t *testing.T) {
+	t.Parallel()
+	mr := miniredis.RunT(t)
+	client := redisclient.NewClient(&redisclient.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	seedPresence(t, client, "api-ours", "pod-a", false)
+	seedPresence(t, client, "api-theirs", "pod-b", false)
+
+	r := New()
+	r.distCtx = context.Background()
+	r.rdb = client
+	r.podID = "pod-a"
+
+	if err := r.snapshotPresence(); err != nil {
+		t.Fatalf("snapshotPresence: %v", err)
+	}
+
+	r.mu.RLock()
+	oursPod, oursOK := r.podMap["api-ours"]
+	theirsPod := r.podMap["api-theirs"]
+	r.mu.RUnlock()
+
+	if oursOK {
+		t.Errorf("podMap[api-ours] = %q, want no entry", oursPod)
+	}
+	if theirsPod != "pod-b" {
+		t.Errorf("podMap[api-theirs] = %q, want pod-b", theirsPod)
+	}
+}
+
+// TestSnapshotPresence_ReconnectOverwritesStaleEntry confirms the honest
+// disconnected entry is not sticky: the agent reconnecting to this process
+// puts it back to connected with the real TLS state.
+func TestSnapshotPresence_ReconnectOverwritesStaleEntry(t *testing.T) {
+	t.Parallel()
+	mr := miniredis.RunT(t)
+	client := redisclient.NewClient(&redisclient.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	seedPresence(t, client, "api-1", "pod-a", true)
+
+	r := New()
+	r.distCtx = context.Background()
+	r.rdb = client
+	r.podID = "pod-a"
+
+	if err := r.snapshotPresence(); err != nil {
+		t.Fatalf("snapshotPresence: %v", err)
+	}
+	if r.Get("api-1").Connected {
+		t.Fatalf("precondition: stale entry should be disconnected")
+	}
+
+	r.Register("api-1", false, "")
+	r.SetConnection("api-1", newFakeConn())
+
+	info := r.Get("api-1")
+	if !info.Connected {
+		t.Errorf("expected the reconnect to mark the agent connected")
+	}
+	if info.Secure {
+		t.Errorf("expected Secure=false from the new plain-HTTP connection, " +
+			"not the stale record's true")
+	}
+	if info.DisconnectedAt != nil {
+		t.Errorf("expected DisconnectedAt cleared on reconnect, got %v", info.DisconnectedAt)
+	}
+}


### PR DESCRIPTION
Fixes three bugs in the agent presence registry. All three were introduced together in #722, which added the Redis-backed distributed registry. None of them has ever been in a published release: v2.0.2 predates that PR by a day, and no tag contains it.

## 1. Agents on a plain HTTP server were reported as WSS

The reported symptom: a server with no TLS certificate at all showed a secure WSS pill for roughly half its fleet and a plain WS pill for the rest, with no pattern to which was which.

`ServeWS` detects the protocol correctly. The value is then mirrored into a Redis presence record and published as a connect event, and the process is subscribed to that channel itself, so the published value is read back and applied to local state. `SetConnection` republishes presence to carry the context label forward, and passed a hardcoded `true` in the `secure` parameter. That raced the correct value published moments earlier by `Register`, and whichever landed last won. The outcome was per-agent, hence the coin-flip split, and the flag is written once at connect and never refreshed, so each host kept its wrong label until it reconnected.

Fixed by carrying the stored value forward, the same way `scope` already was.

## 2. A restarted server resurrected its own agents as connected

`snapshotPresence` runs once at startup, when the process owns no sockets at all, and imported every surviving presence record as connected. The records left behind by the process being replaced belong to that dead process, and its connections died with it, so the registry asserted connections nothing could write to.

That was operator-visible: a connected pill, an inflated sidebar count, and suppressed `host_down` alerting. Not for the record's 5 minute TTL either, because the resurrected entry lives in memory where nothing expires it, so a genuinely dead host was never alerted on for the life of the process.

Records naming a peer are still imported as connected. Records naming this process, or naming no process and therefore unroutable, are imported disconnected. `publishForward` already guarded the send path against exactly this state; nothing guarded the status path.

## 3. An instant disconnect left a permanent ghost

The disconnect branch of the event handler guarded against clobbering a live local connection. The connect branch had no equivalent guard and rebuilt the entry wholesale.

Presence is published from a goroutine on connect but inline on disconnect, so a socket that dies inside that scheduling window delivers connect after disconnect, and the agent comes back marked connected with nothing behind it. Nothing clears it, so `host_down` stays suppressed for the life of the process and every send to that agent fails. A fleet driven through connect-then-immediate-drop ghosted 20 out of 20.

Events published by this process are now ignored. They carry nothing that is not already held, since local state is written under the lock before the publish goes out. Peer events are still applied.

## Stable hostname in the compose files

The startup protection in (2) depends on the server recognising its own identity across a restart. It falls back to the hostname, which Docker derives from the container ID: stable across `docker compose restart`, but not across `up -d` after an image change, which recreates the container. That is the main upgrade path, so it was the one missing the protection. Both compose files now pin `hostname:` explicitly.

This trades an unstable but unique identity for a stable one that is not guaranteed unique. The stock stack ships its own Redis and cannot collide. If several servers are pointed at one shared Redis, set a distinct `POD_ID` per container, which is read before the hostname fallback. Noted in the compose comment.

## Testing

Nine new tests. Each was confirmed to fail against pre-fix code before being kept, so none of them passes vacuously:

- The presence assertions are deterministic and assert on the durable record, not just in-memory state, which is also what another process reads back.
- The two race-driven regressions are exercised over a fleet rather than a single agent, because the losing side was a per-agent coin flip and one agent would pass by luck.

`make check` passes: formatting, `go vet`, golangci-lint with 0 issues, and the full test suite. `go test -race` on the package is clean over repeated runs.

No API shape change, no schema change, no new environment variable, and no change to how the protocol is detected.
