### PR TITLE
fix(api): return effective_status so the API agrees with the UI

### DIFF
--- a/docs/patchmon-api-integrations-guide.md
+++ b/docs/patchmon-api-integrations-guide.md
@@ -3987,6 +3987,9 @@ GET /api/v1/api/hosts?hostgroup=Production&include=stats
       "os_version": "24.04 LTS",
       "last_update": "2026-02-12T10:30:00.000Z",
       "status": "active",
+      "effective_status": "active",
+      "reporting_state": "reporting",
+      "update_state": "security_required",
       "needs_reboot": false,
       "updates_count": 15,
       "security_updates_count": 3,
@@ -4013,13 +4016,53 @@ GET /api/v1/api/hosts?hostgroup=Production&include=stats
 | `hosts[].os_type` | string | Operating system type (only with `include=stats`) |
 | `hosts[].os_version` | string | Operating system version (only with `include=stats`) |
 | `hosts[].last_update` | string (ISO 8601) | Timestamp of last agent update (only with `include=stats`) |
-| `hosts[].status` | string | Host status, e.g. `active`, `pending` (only with `include=stats`) |
+| `hosts[].status` | string | Enrolment lifecycle state, `pending` or `active` (only with `include=stats`). See "Which status field should I use?" below |
+| `hosts[].effective_status` | string | The status the web interface displays: `pending`, `active` or `inactive` (only with `include=stats`) |
+| `hosts[].reporting_state` | string | Report freshness: `reporting`, `overdue` or `stale` (only with `include=stats`) |
+| `hosts[].update_state` | string | Patch position: `up_to_date`, `updates_pending` or `security_required` (only with `include=stats`) |
 | `hosts[].needs_reboot` | boolean | Whether a reboot is pending (only with `include=stats`) |
 | `hosts[].updates_count` | integer | Number of packages needing updates (only with `include=stats`) |
 | `hosts[].security_updates_count` | integer | Number of security updates available (only with `include=stats`) |
 | `hosts[].total_packages` | integer | Total installed packages (only with `include=stats`) |
 | `total` | integer | Total number of hosts returned |
 | `filtered_by_groups` | array | Groups used for filtering (only present when filtering) |
+
+##### Which status field should I use?
+
+The response carries four status-like fields because they answer four different
+questions. Picking the wrong one is the most common source of confusion when an
+integration disagrees with what the web interface shows.
+
+| Field | Question it answers | Values |
+|-------|--------------------|--------|
+| `status` | Has this host finished enrolling? | `pending` until the first check-in, then `active` for ever |
+| `effective_status` | What does the web interface show for this host? | `pending`, `active`, `inactive` |
+| `reporting_state` | How fresh is this host's data? | `reporting`, `overdue`, `stale` |
+| `update_state` | Does this host need patching? | `up_to_date`, `updates_pending`, `security_required` |
+
+Two points worth knowing:
+
+- **`status` never becomes `inactive`.** It records how far a host got through
+  enrolment, not whether it is alive. Once a host has checked in once, it stays
+  `active` until you delete it, even if it never reports again. If you are
+  looking for "is this host still talking to PatchMon", use `effective_status`
+  or `reporting_state`.
+- **`effective_status` is calculated when you make the request**, from
+  `last_update` and the Update Interval configured in Settings. A host reads as
+  `inactive` once it has been silent for more than twice that interval, which is
+  exactly the rule the web interface applies. `reporting_state` uses the same
+  clock but splits the middle out: `overdue` covers one to two intervals of
+  silence, and `stale` is past two.
+
+The `pending` case is the one place the two disagree on purpose. A host that was
+created but never checked in stays `pending` in `effective_status`, because
+"never finished enrolling" is more useful than "went quiet", whilst
+`reporting_state` reports it as `stale`.
+
+> `effective_status` was added in PatchMon 2.0.3. On earlier versions the
+> endpoint returns only `status`, and you can reproduce the web interface value
+> yourself by comparing `last_update` against twice your configured Update
+> Interval.
 
 ---
 

--- a/server-source-code/internal/handler/api_hosts.go
+++ b/server-source-code/internal/handler/api_hosts.go
@@ -138,11 +138,11 @@ func (h *ApiHostsHandler) ListHosts(w http.ResponseWriter, r *http.Request) {
 	// can show "reporting / overdue / stale" without parsing timestamps.
 	updateIntervalMinutes := h.dashboard.UpdateIntervalMinutesOrDefault(ctx)
 	if updateIntervalMinutes <= 0 {
-		updateIntervalMinutes = 60
+		updateIntervalMinutes = store.DefaultUpdateIntervalMinutes
 	}
 	now := time.Now()
 	overdueCutoff := now.Add(-time.Duration(updateIntervalMinutes) * time.Minute)
-	staleCutoff := now.Add(-time.Duration(updateIntervalMinutes*2) * time.Minute)
+	staleCutoff := store.StaleCutoff(now, updateIntervalMinutes)
 
 	out := make([]map[string]interface{}, len(hosts))
 	for i, host := range hosts {
@@ -174,6 +174,10 @@ func (h *ApiHostsHandler) ListHosts(w http.ResponseWriter, r *http.Request) {
 			item["os_version"] = host.OSVersion
 			item["last_update"] = host.LastUpdate.Format(time.RFC3339)
 			item["status"] = host.Status
+			// `status` is the stored provisioning lifecycle value and never
+			// becomes "inactive"; `effective_status` is what the UI renders.
+			// Both are returned so existing consumers keep the old field.
+			item["effective_status"] = store.EffectiveStatus(host.Status, host.LastUpdate, staleCutoff)
 			item["needs_reboot"] = host.NeedsReboot != nil && *host.NeedsReboot
 			st := statsMap[host.ID]
 			item["updates_count"] = st.Outdated

--- a/server-source-code/internal/handler/host_groups.go
+++ b/server-source-code/internal/handler/host_groups.go
@@ -163,13 +163,14 @@ func (h *HostGroupsHandler) GetHosts(w http.ResponseWriter, r *http.Request) {
 	}
 	hostsList, _ := h.hosts.GetByIDs(r.Context(), hostIDs)
 	groupsByHost, _ := h.hosts.GetHostGroupsForHosts(r.Context(), hostIDs)
+	staleCutoff := h.hosts.StaleCutoff(r.Context())
 	hosts := make([]map[string]interface{}, 0, len(hostsList))
 	for _, host := range hostsList {
 		groups := groupsByHost[host.ID]
 		if groups == nil {
 			groups = []models.HostGroup{}
 		}
-		hosts = append(hosts, hostToResponse(&host, groups))
+		hosts = append(hosts, hostToResponse(&host, groups, staleCutoff))
 	}
 	JSON(w, http.StatusOK, hosts)
 }

--- a/server-source-code/internal/handler/hosts.go
+++ b/server-source-code/internal/handler/hosts.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"time"
 
 	"github.com/PatchMon/PatchMon/server-source-code/internal/agentregistry"
 	hostctx "github.com/PatchMon/PatchMon/server-source-code/internal/context"
@@ -106,13 +107,14 @@ func (h *HostsHandler) AdminList(w http.ResponseWriter, r *http.Request) {
 	groupsByHost, _ := h.hosts.GetHostGroupsForHosts(r.Context(), hostIDs)
 
 	// Enrich with host groups
+	staleCutoff := h.hosts.StaleCutoff(r.Context())
 	data := make([]map[string]interface{}, len(hosts))
 	for i, host := range hosts {
 		groups := groupsByHost[host.ID]
 		if groups == nil {
 			groups = []models.HostGroup{}
 		}
-		data[i] = hostToResponse(&host, groups)
+		data[i] = hostToResponse(&host, groups, staleCutoff)
 	}
 
 	totalPages := 1
@@ -143,7 +145,7 @@ func (h *HostsHandler) GetByID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	groups, _ := h.hosts.GetHostGroups(r.Context(), host.ID)
-	JSON(w, http.StatusOK, hostToResponse(host, groups))
+	JSON(w, http.StatusOK, hostToResponse(host, groups, h.hosts.StaleCutoff(r.Context())))
 }
 
 // Create handles POST /hosts/create.
@@ -286,7 +288,7 @@ func (h *HostsHandler) UpdateGroups(w http.ResponseWriter, r *http.Request) {
 	groups, _ := h.hosts.GetHostGroups(r.Context(), hostID)
 	JSON(w, http.StatusOK, map[string]interface{}{
 		"message": "Host groups updated successfully",
-		"host":    hostToResponse(host, groups),
+		"host":    hostToResponse(host, groups, h.hosts.StaleCutoff(r.Context())),
 	})
 }
 
@@ -337,7 +339,7 @@ func (h *HostsHandler) UpdateFriendlyName(w http.ResponseWriter, r *http.Request
 	groups, _ := h.hosts.GetHostGroups(r.Context(), hostID)
 	JSON(w, http.StatusOK, map[string]interface{}{
 		"message": "Friendly name updated successfully",
-		"host":    hostToResponse(host, groups),
+		"host":    hostToResponse(host, groups, h.hosts.StaleCutoff(r.Context())),
 	})
 }
 
@@ -365,7 +367,7 @@ func (h *HostsHandler) UpdateNotes(w http.ResponseWriter, r *http.Request) {
 	groups, _ := h.hosts.GetHostGroups(r.Context(), hostID)
 	JSON(w, http.StatusOK, map[string]interface{}{
 		"message": "Notes updated successfully",
-		"host":    hostToResponse(host, groups),
+		"host":    hostToResponse(host, groups, h.hosts.StaleCutoff(r.Context())),
 	})
 }
 
@@ -394,7 +396,7 @@ func (h *HostsHandler) UpdateConnection(w http.ResponseWriter, r *http.Request) 
 	groups, _ := h.hosts.GetHostGroups(r.Context(), hostID)
 	JSON(w, http.StatusOK, map[string]interface{}{
 		"message": "Host connection information updated successfully",
-		"host":    hostToResponse(host, groups),
+		"host":    hostToResponse(host, groups, h.hosts.StaleCutoff(r.Context())),
 	})
 }
 
@@ -432,7 +434,7 @@ func (h *HostsHandler) SetPrimaryInterface(w http.ResponseWriter, r *http.Reques
 	groups, _ := h.hosts.GetHostGroups(r.Context(), hostID)
 	JSON(w, http.StatusOK, map[string]interface{}{
 		"message": "Primary interface updated successfully",
-		"host":    hostToResponse(host, groups),
+		"host":    hostToResponse(host, groups, h.hosts.StaleCutoff(r.Context())),
 	})
 }
 
@@ -823,13 +825,14 @@ func (h *HostsHandler) BulkUpdateGroups(w http.ResponseWriter, r *http.Request) 
 	for i := range hostsList {
 		hostByID[hostsList[i].ID] = &hostsList[i]
 	}
+	staleCutoff := h.hosts.StaleCutoff(r.Context())
 	for i, hid := range req.HostIds {
 		if host := hostByID[hid]; host != nil {
 			groups := groupsByHost[hid]
 			if groups == nil {
 				groups = []models.HostGroup{}
 			}
-			hosts[i] = hostToResponse(host, groups)
+			hosts[i] = hostToResponse(host, groups, staleCutoff)
 		}
 	}
 
@@ -1292,11 +1295,13 @@ func (h *HostsHandler) ApplyPendingConfig(w http.ResponseWriter, r *http.Request
 	})
 }
 
-func hostToResponse(h *models.Host, groups []models.HostGroup) map[string]interface{} {
+func hostToResponse(h *models.Host, groups []models.HostGroup, staleCutoff time.Time) map[string]interface{} {
 	res := map[string]interface{}{
 		"id": h.ID, "friendly_name": h.FriendlyName, "hostname": h.Hostname, "ip": h.IP,
 		"os_type": h.OSType, "os_version": h.OSVersion, "architecture": h.Architecture,
-		"last_update": h.LastUpdate, "status": h.Status, "api_id": h.ApiID, "agent_version": h.AgentVersion,
+		"last_update": h.LastUpdate, "status": h.Status,
+		"effective_status": store.EffectiveStatus(h.Status, h.LastUpdate, staleCutoff),
+		"api_id":           h.ApiID, "agent_version": h.AgentVersion,
 		"auto_update": h.AutoUpdate, "created_at": h.CreatedAt, "notes": h.Notes,
 		"system_uptime": h.SystemUptime, "boot_time": h.BootTime, "needs_reboot": h.NeedsReboot,
 		"docker_enabled": h.DockerEnabled, "compliance_enabled": h.ComplianceEnabled,

--- a/server-source-code/internal/store/dashboard.go
+++ b/server-source-code/internal/store/dashboard.go
@@ -692,12 +692,7 @@ func (s *DashboardStore) UpdateIntervalMinutesOrDefault(ctx context.Context) int
 // conservative fallback. It is a helper so the list and count endpoints use
 // exactly the same stale/down thresholds.
 func UpdateIntervalMinutes(ctx context.Context, s *DashboardStore) int {
-	if settings, _ := s.getSettings(ctx); settings != nil {
-		if settings.UpdateInterval > 0 {
-			return settings.UpdateInterval
-		}
-	}
-	return 60
+	return UpdateIntervalMinutesFromDB(ctx, s.db)
 }
 
 // GetHostDetail returns host detail with packages and history for dashboard (matches Node structure).
@@ -738,7 +733,10 @@ func (s *DashboardStore) GetHostDetail(ctx context.Context, hostID string, histo
 		"id": host.ID, "machine_id": host.MachineID, "friendly_name": host.FriendlyName,
 		"hostname": host.Hostname, "ip": host.IP, "gateway_ip": host.GatewayIP,
 		"os_type": host.OSType, "os_version": host.OSVersion, "architecture": host.Architecture,
-		"last_update": host.LastUpdate, "status": host.Status, "api_id": host.ApiID,
+		"last_update": host.LastUpdate, "status": host.Status,
+		"effective_status": EffectiveStatus(host.Status, host.LastUpdate,
+			StaleCutoff(time.Now(), UpdateIntervalMinutes(ctx, s))),
+		"api_id":        host.ApiID,
 		"agent_version": host.AgentVersion, "auto_update": host.AutoUpdate, "notes": host.Notes,
 		"system_uptime": host.SystemUptime, "boot_time": host.BootTime, "needs_reboot": host.NeedsReboot,
 		"reboot_reason":  host.RebootReason,

--- a/server-source-code/internal/store/host_status.go
+++ b/server-source-code/internal/store/host_status.go
@@ -1,0 +1,63 @@
+package store
+
+import (
+	"context"
+	"time"
+
+	"github.com/PatchMon/PatchMon/server-source-code/internal/database"
+)
+
+// DefaultUpdateIntervalMinutes is the fallback agent update interval used when
+// settings are unreadable or unset.
+const DefaultUpdateIntervalMinutes = 60
+
+// StatusActive is the stored provisioning status of a host that has checked in
+// at least once. It is a lifecycle value: nothing ever writes "inactive" to the
+// hosts.status column, which is why staleness has to be derived at read time.
+const StatusActive = "active"
+
+// StatusInactive is the derived status of an active host that has stopped
+// reporting. It exists only in API responses, never in the database.
+const StatusInactive = "inactive"
+
+// UpdateIntervalMinutesFromDB reads the configured agent update interval for the
+// calling context, falling back to DefaultUpdateIntervalMinutes. Callers that
+// already hold a DashboardStore should use UpdateIntervalMinutes instead.
+func UpdateIntervalMinutesFromDB(ctx context.Context, dbp database.DBProvider) int {
+	setting, err := dbp.DB(ctx).Queries.GetFirstSettings(ctx)
+	if err != nil {
+		return DefaultUpdateIntervalMinutes
+	}
+	if s := dbSettingToModel(setting); s.UpdateInterval > 0 {
+		return s.UpdateInterval
+	}
+	return DefaultUpdateIntervalMinutes
+}
+
+// StaleCutoff returns the instant before which a host counts as stale: two
+// agent update intervals back from now. Kept in one place so every surface that
+// reports host status uses the same boundary as the GetHostsWithCounts SQL.
+func StaleCutoff(now time.Time, updateIntervalMinutes int) time.Time {
+	if updateIntervalMinutes <= 0 {
+		updateIntervalMinutes = DefaultUpdateIntervalMinutes
+	}
+	return now.Add(-time.Duration(updateIntervalMinutes*2) * time.Minute)
+}
+
+// EffectiveStatus derives the status the UI renders from the stored
+// provisioning status and the agent's last check-in.
+//
+// Mirrors the effective_status CASE in GetHostsWithCounts exactly, including
+// the deliberate asymmetry that only an "active" host degrades: a host that
+// enrolled but never reported stays "pending" rather than becoming "inactive".
+func EffectiveStatus(status string, lastUpdate, staleCutoff time.Time) string {
+	if status == StatusActive && lastUpdate.Before(staleCutoff) {
+		return StatusInactive
+	}
+	return status
+}
+
+// StaleCutoff resolves the stale boundary for the calling context.
+func (s *HostsStore) StaleCutoff(ctx context.Context) time.Time {
+	return StaleCutoff(time.Now(), UpdateIntervalMinutesFromDB(ctx, s.db))
+}

--- a/server-source-code/internal/store/host_status_test.go
+++ b/server-source-code/internal/store/host_status_test.go
@@ -1,0 +1,58 @@
+package store
+
+import (
+	"testing"
+	"time"
+)
+
+func TestStaleCutoff(t *testing.T) {
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name     string
+		interval int
+		want     time.Time
+	}{
+		{"default interval", 60, now.Add(-120 * time.Minute)},
+		{"short interval", 5, now.Add(-10 * time.Minute)},
+		{"zero falls back to default", 0, now.Add(-120 * time.Minute)},
+		{"negative falls back to default", -30, now.Add(-120 * time.Minute)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := StaleCutoff(now, tt.interval); !got.Equal(tt.want) {
+				t.Errorf("StaleCutoff(%d) = %v, want %v", tt.interval, got, tt.want)
+			}
+		})
+	}
+}
+
+// The boundaries here must stay identical to the effective_status CASE in
+// GetHostsWithCounts, otherwise the scoped API and the UI disagree again.
+func TestEffectiveStatus(t *testing.T) {
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	staleCutoff := StaleCutoff(now, 60)
+
+	tests := []struct {
+		name       string
+		status     string
+		lastUpdate time.Time
+		want       string
+	}{
+		{"active and reporting", "active", now.Add(-5 * time.Minute), "active"},
+		{"active and overdue but not stale", "active", now.Add(-90 * time.Minute), "active"},
+		{"active exactly on the cutoff", "active", staleCutoff, "active"},
+		{"active past the cutoff", "active", now.Add(-3 * time.Hour), "inactive"},
+		{"pending never degrades", "pending", now.Add(-30 * time.Hour), "pending"},
+		{"unknown status passes through", "error", now.Add(-30 * time.Hour), "error"},
+		{"zero last update on an active host", "active", time.Time{}, "inactive"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := EffectiveStatus(tt.status, tt.lastUpdate, staleCutoff)
+			if got != tt.want {
+				t.Errorf("EffectiveStatus(%q, %v) = %q, want %q", tt.status, tt.lastUpdate, got, tt.want)
+			}
+		})
+	}
+}

--- a/server-source-code/internal/swagger/openapi.json
+++ b/server-source-code/internal/swagger/openapi.json
@@ -83,7 +83,7 @@
 					{
 						"name": "include",
 						"in": "query",
-						"description": "Comma-separated. Supported: stats (adds updates_count, security_updates_count, total_packages, needs_reboot, os_type, os_version, last_update, status, reporting_state, update_state). reporting_state is one of 'reporting' | 'overdue' | 'stale'. update_state is one of 'up_to_date' | 'updates_pending' | 'security_required'.",
+						"description": "Comma-separated. Supported: stats (adds updates_count, security_updates_count, total_packages, needs_reboot, os_type, os_version, last_update, status, effective_status, reporting_state, update_state). status is the stored provisioning lifecycle value, 'pending' before the first check-in and 'active' after it; it never becomes 'inactive'. effective_status is the value the web UI displays and is one of 'pending' | 'active' | 'inactive', where 'inactive' means an active host has not reported for more than twice the configured update interval. reporting_state is one of 'reporting' | 'overdue' | 'stale'. update_state is one of 'up_to_date' | 'updates_pending' | 'security_required'.",
 						"schema": { "type": "string" }
 					}
 				],
@@ -109,6 +109,7 @@
 											"os_version": "22.04",
 											"last_update": "2025-03-01T12:00:00Z",
 											"status": "active",
+											"effective_status": "active",
 											"reporting_state": "reporting",
 											"update_state": "security_required"
 										}


### PR DESCRIPTION
Fixes #874

## The problem

`GET /api/v1/api/hosts?include=stats` returned `hosts[].status` straight from the `hosts.status` column. That column tracks enrolment only: it is `pending` on insert, promoted to `active` by the first check-in, and **nothing in the codebase ever writes `inactive` to it**. No worker demotes a silent host.

The web interface shows something else entirely: a value derived on every request, where an `active` host that has not reported for more than 2x the configured update interval reads as `inactive`. That result is never written back.

So a host that stopped reporting showed as **Inactive** in the UI and **`active`** over the API at the same instant, with no field on the response that could reconcile the two. Confirmed not to be OS-specific.

## The change

Adds `effective_status` alongside the existing fields on every host read path:

| Path | Field added |
|------|-------------|
| `GET /api/v1/api/hosts?include=stats` | `effective_status` |
| `GET /api/v1/hosts/admin/list` | `effective_status` |
| `GET /api/v1/host-groups/{id}/hosts` | `effective_status` |
| `GET /api/v1/dashboard/hosts/{id}` | `effective_status` |

`status` is left byte-identical on every path, so nothing currently reading it changes behaviour.

The derivation moves into one place, `store.EffectiveStatus` / `store.StaleCutoff` in the new `internal/store/host_status.go`, mirroring the `effective_status` CASE in `GetHostsWithCounts`. That includes the deliberate asymmetry both sides share: only an `active` host degrades, so a host that enrolled and never checked in stays `pending` rather than becoming `inactive`. `UpdateIntervalMinutes` now delegates to the same helper instead of carrying its own copy of the fallback.

## Verification

`make check` clean. New table tests pin both boundaries, the `pending` asymmetry, the exactly-on-the-cutoff case and the zero-time case.

Ran against a live server, comparing the SQL-derived UI value with the new Go-derived API value on the same host at the same instant:

```
silent 5 min    db.status=active   UI=active    effective_status=active    reporting_state=reporting  MATCH
silent 90 min   db.status=active   UI=active    effective_status=active    reporting_state=overdue    MATCH
silent 121 min  db.status=active   UI=inactive  effective_status=inactive  reporting_state=stale      MATCH
silent 3 h      db.status=pending  UI=pending   effective_status=pending   reporting_state=stale      MATCH
```

With `update_interval` changed from 60 to 5, the boundary moved with it (4 min active, 8 min active, 11 min inactive, UI and API matching at each point), confirming the derivation reads the setting rather than assuming 60.

Field gating is unchanged: without `include=stats` the scoped API still returns only `id`, `friendly_name`, `hostname`, `ip`, `host_groups`.

## Docs

- `docs/patchmon-api-integrations-guide.md` gains a "Which status field should I use?" section: a table mapping each of the four status fields to the question it answers, an explicit note that `status` never becomes `inactive`, the `pending` asymmetry explained, and the workaround for older versions. `reporting_state` and `update_state` are now documented in the response table for the first time.
- `internal/swagger/openapi.json` defines `status` against `effective_status` on the `include` parameter and adds the field to the example. This is the spec the docs site API reference renders, so it flows through on the next sync.

## Not included

Two adjacent inconsistencies found while investigating, both deliberately left out of scope:

- `frontend/src/pages/Compliance.jsx` tests `host.status === "online"`, a value that endpoint never returns, so a health dot there is permanently red.
- `GetHomepageStats` counts `status = 'active'` for `total_hosts`, which excludes `pending` hosts while the dashboard card counts every row.
