### PR TITLE
fix(gethomepage): count hosts the same way the dashboard does

### DIFF
--- a/docs/patchmon-api-integrations-guide.md
+++ b/docs/patchmon-api-integrations-guide.md
@@ -474,7 +474,7 @@ Each `mappings` entry has two parts:
 
 | Field | Type | Description | Included by default |
 |-------|------|-------------|---------------------|
-| `total_hosts` | Number | Total active hosts in PatchMon | Yes |
+| `total_hosts` | Number | Total hosts in PatchMon, matching the Total Hosts card on the dashboard | Yes |
 | `hosts_needing_updates` | Number | Hosts with at least one outdated package | Yes |
 | `security_updates` | Number | Total security updates available across all hosts | Yes |
 | `up_to_date_hosts` | Number | Hosts with zero outdated packages | No |

--- a/server-source-code/internal/db/dashboard.sql.go
+++ b/server-source-code/internal/db/dashboard.sql.go
@@ -199,22 +199,17 @@ func (q *Queries) GetDashboardStats(ctx context.Context, arg GetDashboardStatsPa
 }
 
 const getHomepageStats = `-- name: GetHomepageStats :one
-WITH active_hosts AS (
-    SELECT id FROM hosts WHERE status = 'active'
-),
-host_counts AS (
-    SELECT COUNT(*)::int AS total_hosts FROM active_hosts
+WITH host_counts AS (
+    SELECT COUNT(*)::int AS total_hosts FROM hosts
 ),
 hosts_needing_updates AS (
     SELECT COUNT(DISTINCT hp.host_id)::int AS cnt
     FROM host_packages hp
-    JOIN active_hosts ah ON ah.id = hp.host_id
     WHERE hp.needs_update = true
 ),
 hosts_with_security AS (
     SELECT COUNT(DISTINCT hp.host_id)::int AS cnt
     FROM host_packages hp
-    JOIN active_hosts ah ON ah.id = hp.host_id
     WHERE hp.needs_update = true AND hp.is_security_update = true
 ),
 package_counts AS (
@@ -248,6 +243,12 @@ type GetHomepageStatsRow struct {
 	RecentUpdates24h         int32 `json:"recent_updates_24h"`
 }
 
+// The host counters here must match GetDashboardStats, otherwise a widget and
+// the dashboard card it mirrors report different numbers for the same fleet.
+// They previously filtered on status = 'active', which silently dropped hosts
+// that had been created but not yet enrolled. That filter also did not mean
+// what it appeared to: hosts.status is an enrolment lifecycle column and never
+// becomes 'inactive', so a host that stopped reporting was counted regardless.
 func (q *Queries) GetHomepageStats(ctx context.Context, since pgtype.Timestamp) (GetHomepageStatsRow, error) {
 	row := q.db.QueryRow(ctx, getHomepageStats, since)
 	var i GetHomepageStatsRow

--- a/server-source-code/internal/db/querier.go
+++ b/server-source-code/internal/db/querier.go
@@ -273,6 +273,12 @@ type Querier interface {
 	GetDockerHostsMinimalByIDs(ctx context.Context, dollar_1 []string) ([]GetDockerHostsMinimalByIDsRow, error)
 	GetFirstComplianceProfileByType(ctx context.Context, type_ string) (ComplianceProfile, error)
 	GetFirstSettings(ctx context.Context) (Setting, error)
+	// The host counters here must match GetDashboardStats, otherwise a widget and
+	// the dashboard card it mirrors report different numbers for the same fleet.
+	// They previously filtered on status = 'active', which silently dropped hosts
+	// that had been created but not yet enrolled. That filter also did not mean
+	// what it appeared to: hosts.status is an enrolment lifecycle column and never
+	// becomes 'inactive', so a host that stopped reporting was counted regardless.
 	GetHomepageStats(ctx context.Context, since pgtype.Timestamp) (GetHomepageStatsRow, error)
 	GetHostByApiID(ctx context.Context, apiID string) (Host, error)
 	GetHostByID(ctx context.Context, id string) (Host, error)

--- a/server-source-code/internal/sqlc/queries/dashboard.sql
+++ b/server-source-code/internal/sqlc/queries/dashboard.sql
@@ -512,22 +512,23 @@ FROM hosts
 ORDER BY friendly_name ASC;
 
 -- name: GetHomepageStats :one
-WITH active_hosts AS (
-    SELECT id FROM hosts WHERE status = 'active'
-),
-host_counts AS (
-    SELECT COUNT(*)::int AS total_hosts FROM active_hosts
+-- The host counters here must match GetDashboardStats, otherwise a widget and
+-- the dashboard card it mirrors report different numbers for the same fleet.
+-- They previously filtered on status = 'active', which silently dropped hosts
+-- that had been created but not yet enrolled. That filter also did not mean
+-- what it appeared to: hosts.status is an enrolment lifecycle column and never
+-- becomes 'inactive', so a host that stopped reporting was counted regardless.
+WITH host_counts AS (
+    SELECT COUNT(*)::int AS total_hosts FROM hosts
 ),
 hosts_needing_updates AS (
     SELECT COUNT(DISTINCT hp.host_id)::int AS cnt
     FROM host_packages hp
-    JOIN active_hosts ah ON ah.id = hp.host_id
     WHERE hp.needs_update = true
 ),
 hosts_with_security AS (
     SELECT COUNT(DISTINCT hp.host_id)::int AS cnt
     FROM host_packages hp
-    JOIN active_hosts ah ON ah.id = hp.host_id
     WHERE hp.needs_update = true AND hp.is_security_update = true
 ),
 package_counts AS (

--- a/server-source-code/internal/swagger/openapi.json
+++ b/server-source-code/internal/swagger/openapi.json
@@ -820,7 +820,7 @@
 			"get": {
 				"tags": ["GetHomepage"],
 				"summary": "Get homepage widget statistics",
-				"description": "Returns widget statistics for GetHomepage dashboard (total hosts, outdated packages, security updates, OS distribution, etc.). Requires Basic Auth with GetHomepage credentials.",
+				"description": "Returns widget statistics for GetHomepage dashboard (total hosts, outdated packages, security updates, OS distribution, etc.). The host counters match the equivalent cards on the PatchMon dashboard: total_hosts counts every host, including ones created but not yet enrolled. Requires Basic Auth with GetHomepage credentials.",
 				"security": [{ "basicAuth": [] }],
 				"responses": {
 					"200": {


### PR DESCRIPTION
Fixes #1026

## The problem

`total_hosts` reported to a gethomepage widget could disagree with the **Total Hosts** card on the dashboard, for the same instance at the same moment.

`GetHomepageStats` routed three counters through an `active_hosts` CTE filtering on `status = 'active'`, while `GetDashboardStats` counts every row. Any host created in the UI but not yet enrolled was counted by the dashboard and excluded from the widget.

The filter also did not mean what it appeared to. `hosts.status` is an enrolment lifecycle column that never becomes `inactive` (see #874), so it only ever excluded never-enrolled hosts. Hosts that enrolled and then went silent for months were counted as active by both queries regardless.

## The change

The `active_hosts` CTE is gone. `total_hosts`, `hosts_needing_updates` and `hosts_with_security_updates` now count every host, matching `GetDashboardStats`. All three move together so `up_to_date_hosts`, derived as `total_hosts - hosts_needing_updates`, stays arithmetically consistent.

## Verification

Local stack, fleet of two hosts: one enrolled with a pending security update, one created but never enrolled.

Query level, before and after:

```
OLD (status='active' filter, ships in 2.0.2):   total_hosts=1  needing_updates=1
NEW (this PR):                                  total_hosts=2  needing_updates=1
dashboard card (unchanged reference):           total_hosts=2  needing_updates=1
```

Endpoint level, after the change:

```
dashboard   : totalHosts=2  hostsNeedingUpdates=1  upToDateHosts=1  securityUpdates=1
gethomepage : total_hosts=2 hosts_needing_updates=1 up_to_date_hosts=1 security_updates=1
```

`make check` clean, including sqlc regeneration.

## Behaviour change to flag in the release notes

**Widget totals will go up on any instance that has hosts sitting at `pending`.** Nothing is double counted; those hosts were previously missing. Users watching the number will see it move, so this wants a release-note line rather than a silent fix.

## Observed but not changed

`total_repos` also differs between the two: the widget counts `repositories WHERE is_active = true`, the dashboard counts all repositories. That is arguably deliberate for a widget, it is not what this issue reported, and changing it moves another visible number, so I have left it alone. Happy to fold it in if you would rather they matched.
