### PR TITLE
fix(agent): honour the compliance mode the server sends on startup sync

### DIFF
--- a/agent-source-code/cmd/patchmon-agent/commands/serve.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/serve.go
@@ -70,6 +70,105 @@ func agentHostKeyCallback() ssh.HostKeyCallback {
 	return ssh.InsecureIgnoreHostKey()
 }
 
+// syncIntegrationStatus reconciles config.yml with the integration state the
+// server reports at startup.
+//
+// Compliance is three-state on the server (disabled / on-demand / enabled) but
+// only two-state in the integrations map, so the boolean alone cannot say
+// whether scans are scheduled. It is synced from compliance_mode, and the
+// boolean is used only for a server too old to send that field.
+func syncIntegrationStatus(integrationResp *models.IntegrationStatusResponse) {
+	configUpdated := false
+	serverComplianceMode, serverSentComplianceMode := config.ParseComplianceMode(integrationResp.ComplianceMode)
+	if integrationResp.ComplianceMode != "" && !serverSentComplianceMode {
+		logger.WithField("compliance_mode", logutil.Sanitize(integrationResp.ComplianceMode)).
+			Warn("Unknown compliance mode from server, keeping local compliance configuration")
+	}
+
+	for integrationName, serverEnabled := range integrationResp.Integrations {
+		// The boolean cannot express on-demand, so compliance is left to the
+		// mode whenever the server sends one. A mode that failed to parse is
+		// skipped here too: falling back to the boolean would write the
+		// scheduled state this whole change exists to stop writing.
+		if integrationName == "compliance" && integrationResp.ComplianceMode != "" {
+			continue
+		}
+		configEnabled := cfgManager.IsIntegrationEnabled(integrationName)
+		if serverEnabled != configEnabled {
+			logger.WithFields(logutil.SanitizeMap(map[string]interface{}{
+				"integration":  integrationName,
+				"config_value": configEnabled,
+				"server_value": serverEnabled,
+			})).Info("Integration status differs, updating config.yml")
+
+			if err := cfgManager.SetIntegrationEnabled(integrationName, serverEnabled); err != nil {
+				logger.WithError(err).Warn("Failed to save integration status to config.yml")
+			} else {
+				configUpdated = true
+				logger.WithFields(logutil.SanitizeMap(map[string]interface{}{
+					"integration": integrationName,
+					"enabled":     serverEnabled,
+				})).Info("Updated integration status in config.yml")
+			}
+		}
+	}
+
+	// Sync the compliance mode from server (when server sends one)
+	if serverSentComplianceMode {
+		configMode := cfgManager.GetComplianceMode()
+		if serverComplianceMode != configMode {
+			logger.WithFields(logutil.SanitizeMap(map[string]interface{}{
+				"config_value": string(configMode),
+				"server_value": string(serverComplianceMode),
+			})).Info("Compliance mode differs, updating config.yml")
+
+			if err := cfgManager.SetComplianceMode(serverComplianceMode); err != nil {
+				logger.WithError(err).Warn("Failed to save compliance mode to config.yml")
+			} else {
+				configUpdated = true
+				logger.WithField("mode", string(serverComplianceMode)).Info("Updated compliance mode in config.yml")
+			}
+		}
+	}
+
+	// Sync compliance scanner toggles from server (when server sends them)
+	if integrationResp.ComplianceOpenscapEnabled != nil || integrationResp.ComplianceDockerBenchEnabled != nil {
+		configOpenscap := cfgManager.GetComplianceOpenscapEnabled()
+		configDockerBench := cfgManager.GetComplianceDockerBenchEnabled()
+		serverOpenscap := configOpenscap
+		serverDockerBench := configDockerBench
+		if integrationResp.ComplianceOpenscapEnabled != nil {
+			serverOpenscap = *integrationResp.ComplianceOpenscapEnabled
+		}
+		if integrationResp.ComplianceDockerBenchEnabled != nil {
+			serverDockerBench = *integrationResp.ComplianceDockerBenchEnabled
+		}
+		if serverOpenscap != configOpenscap || serverDockerBench != configDockerBench {
+			logger.WithFields(logutil.SanitizeMap(map[string]interface{}{
+				"config_openscap": configOpenscap, "server_openscap": serverOpenscap,
+				"config_docker_bench": configDockerBench, "server_docker_bench": serverDockerBench,
+			})).Info("Compliance scanner toggles differ, updating config.yml")
+			if err := cfgManager.SetComplianceScanners(serverOpenscap, serverDockerBench); err != nil {
+				logger.WithError(err).Warn("Failed to save compliance scanner toggles to config.yml")
+			} else {
+				configUpdated = true
+				logger.Info("Updated compliance scanner toggles in config.yml")
+			}
+		}
+	}
+
+	if configUpdated {
+		// Reload config so in-memory state matches the updated file
+		if err := cfgManager.LoadConfig(); err != nil {
+			logger.WithError(err).Warn("Failed to reload config after integration update")
+		} else {
+			logger.Info("Config reloaded, integration settings will be applied")
+		}
+	} else {
+		logger.Debug("Integration status matches config, no update needed")
+	}
+}
+
 // runServiceLoop is the main service loop. stopCh signals shutdown (nil = run forever on Unix)
 func runServiceLoop(stopCh <-chan struct{}) error {
 	// Starting on defaults when the file is present but unparseable means an
@@ -143,64 +242,7 @@ func runServiceLoop(stopCh <-chan struct{}) error {
 	// Fetch integration status from server and sync with config.yml
 	logger.Info("Syncing integration status from server...")
 	if integrationResp, err := httpClient.GetIntegrationStatus(ctx); err == nil && integrationResp.Success {
-		configUpdated := false
-		for integrationName, serverEnabled := range integrationResp.Integrations {
-			configEnabled := cfgManager.IsIntegrationEnabled(integrationName)
-			if serverEnabled != configEnabled {
-				logger.WithFields(logutil.SanitizeMap(map[string]interface{}{
-					"integration":  integrationName,
-					"config_value": configEnabled,
-					"server_value": serverEnabled,
-				})).Info("Integration status differs, updating config.yml")
-
-				if err := cfgManager.SetIntegrationEnabled(integrationName, serverEnabled); err != nil {
-					logger.WithError(err).Warn("Failed to save integration status to config.yml")
-				} else {
-					configUpdated = true
-					logger.WithFields(logutil.SanitizeMap(map[string]interface{}{
-						"integration": integrationName,
-						"enabled":     serverEnabled,
-					})).Info("Updated integration status in config.yml")
-				}
-			}
-		}
-
-		// Sync compliance scanner toggles from server (when server sends them)
-		if integrationResp.ComplianceOpenscapEnabled != nil || integrationResp.ComplianceDockerBenchEnabled != nil {
-			configOpenscap := cfgManager.GetComplianceOpenscapEnabled()
-			configDockerBench := cfgManager.GetComplianceDockerBenchEnabled()
-			serverOpenscap := configOpenscap
-			serverDockerBench := configDockerBench
-			if integrationResp.ComplianceOpenscapEnabled != nil {
-				serverOpenscap = *integrationResp.ComplianceOpenscapEnabled
-			}
-			if integrationResp.ComplianceDockerBenchEnabled != nil {
-				serverDockerBench = *integrationResp.ComplianceDockerBenchEnabled
-			}
-			if serverOpenscap != configOpenscap || serverDockerBench != configDockerBench {
-				logger.WithFields(logutil.SanitizeMap(map[string]interface{}{
-					"config_openscap": configOpenscap, "server_openscap": serverOpenscap,
-					"config_docker_bench": configDockerBench, "server_docker_bench": serverDockerBench,
-				})).Info("Compliance scanner toggles differ, updating config.yml")
-				if err := cfgManager.SetComplianceScanners(serverOpenscap, serverDockerBench); err != nil {
-					logger.WithError(err).Warn("Failed to save compliance scanner toggles to config.yml")
-				} else {
-					configUpdated = true
-					logger.Info("Updated compliance scanner toggles in config.yml")
-				}
-			}
-		}
-
-		if configUpdated {
-			// Reload config so in-memory state matches the updated file
-			if err := cfgManager.LoadConfig(); err != nil {
-				logger.WithError(err).Warn("Failed to reload config after integration update")
-			} else {
-				logger.Info("Config reloaded, integration settings will be applied")
-			}
-		} else {
-			logger.Debug("Integration status matches config, no update needed")
-		}
+		syncIntegrationStatus(integrationResp)
 	} else if err != nil {
 		logger.WithError(err).Warn("Failed to fetch integration status from server, using config values")
 	}

--- a/agent-source-code/cmd/patchmon-agent/commands/serve_integration_sync_test.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/serve_integration_sync_test.go
@@ -1,0 +1,190 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"patchmon-agent/internal/config"
+	"patchmon-agent/pkg/models"
+)
+
+// withTestConfig points the package-level cfgManager at a throwaway config.yml
+// holding the given compliance value, and restores the previous manager.
+func withTestConfig(t *testing.T, complianceYAML string) *config.Manager {
+	t.Helper()
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yml")
+	contents := `patchmon_server: https://patchmon.example.com
+api_version: v1
+log_level: info
+update_interval: 60
+integrations:
+  compliance:
+    enabled: ` + complianceYAML + `
+    openscap_enabled: true
+    docker_bench_enabled: false
+  docker: false
+`
+	if err := os.WriteFile(cfgPath, []byte(contents), 0o600); err != nil {
+		t.Fatalf("writing test config: %v", err)
+	}
+
+	m := config.New()
+	m.SetConfigFile(cfgPath)
+	// Keep the derived paths inside the temp dir so saving does not try to
+	// create /etc/patchmon.
+	cfg := m.GetConfig()
+	cfg.CredentialsFile = filepath.Join(dir, "credentials.yml")
+	cfg.LogFile = filepath.Join(dir, "agent.log")
+	if err := m.LoadConfig(); err != nil {
+		t.Fatalf("initial LoadConfig: %v", err)
+	}
+
+	previous := cfgManager
+	cfgManager = m
+	t.Cleanup(func() { cfgManager = previous })
+	return m
+}
+
+func TestSyncIntegrationStatusCompliance(t *testing.T) {
+	tests := []struct {
+		name       string
+		startMode  string
+		response   *models.IntegrationStatusResponse
+		wantMode   config.ComplianceMode
+		wantDocker bool
+	}{
+		{
+			// The reported bug: the host is on-demand server-side, so the
+			// integrations boolean is true. Writing that boolean starts the
+			// compliance scheduler and runs full OpenSCAP scans nobody asked
+			// for. The mode is what must land in config.yml.
+			name:      "enabling an on-demand host does not schedule scans",
+			startMode: "false",
+			response: &models.IntegrationStatusResponse{
+				Success:        true,
+				Integrations:   map[string]bool{"compliance": true, "docker": false},
+				ComplianceMode: "on-demand",
+			},
+			wantMode: config.ComplianceOnDemand,
+		},
+		{
+			// The boolean is identical either side of this transition, so it
+			// used to be invisible to the sync and the agent stayed on-demand
+			// after the operator asked for scheduled scans.
+			name:      "on-demand to scheduled propagates",
+			startMode: "on-demand",
+			response: &models.IntegrationStatusResponse{
+				Success:        true,
+				Integrations:   map[string]bool{"compliance": true},
+				ComplianceMode: "enabled",
+			},
+			wantMode: config.ComplianceEnabled,
+		},
+		{
+			name:      "scheduled to on-demand propagates",
+			startMode: "true",
+			response: &models.IntegrationStatusResponse{
+				Success:        true,
+				Integrations:   map[string]bool{"compliance": true},
+				ComplianceMode: "on-demand",
+			},
+			wantMode: config.ComplianceOnDemand,
+		},
+		{
+			name:      "disabled server-side disables the agent",
+			startMode: "on-demand",
+			response: &models.IntegrationStatusResponse{
+				Success:        true,
+				Integrations:   map[string]bool{"compliance": false},
+				ComplianceMode: "disabled",
+			},
+			wantMode: config.ComplianceDisabled,
+		},
+		{
+			// A server predating compliance_mode. The boolean path has to keep
+			// working exactly as it did, or upgrading the agent alone breaks
+			// compliance for every host.
+			name:      "server without compliance_mode falls back to the boolean",
+			startMode: "false",
+			response: &models.IntegrationStatusResponse{
+				Success:      true,
+				Integrations: map[string]bool{"compliance": true},
+			},
+			wantMode: config.ComplianceEnabled,
+		},
+		{
+			// A mode the agent does not understand is not a licence to fall
+			// back on the boolean: that fallback writes the scheduled state
+			// this whole change exists to stop writing.
+			//
+			// The fixture has to make the boolean and the local mode disagree
+			// to prove it. Starting from on-demand would not: the boolean
+			// reads back as true on both sides, so the fallback would write
+			// nothing and the assertion would hold for the wrong reason.
+			name:      "unknown mode leaves the local configuration alone",
+			startMode: "false",
+			response: &models.IntegrationStatusResponse{
+				Success:        true,
+				Integrations:   map[string]bool{"compliance": true},
+				ComplianceMode: "sometimes",
+			},
+			wantMode: config.ComplianceDisabled,
+		},
+		{
+			// The compliance special case must not swallow the other
+			// integrations sharing the loop.
+			name:      "docker still syncs alongside compliance",
+			startMode: "on-demand",
+			response: &models.IntegrationStatusResponse{
+				Success:        true,
+				Integrations:   map[string]bool{"compliance": true, "docker": true},
+				ComplianceMode: "on-demand",
+			},
+			wantMode:   config.ComplianceOnDemand,
+			wantDocker: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := withTestConfig(t, tt.startMode)
+
+			syncIntegrationStatus(tt.response)
+
+			if got := m.GetComplianceMode(); got != tt.wantMode {
+				t.Fatalf("compliance mode = %q, want %q", got, tt.wantMode)
+			}
+			if got := m.IsIntegrationEnabled("docker"); got != tt.wantDocker {
+				t.Fatalf("docker enabled = %v, want %v", got, tt.wantDocker)
+			}
+		})
+	}
+}
+
+// TestSyncIntegrationStatusKeepsScannerToggles guards the block that follows
+// the compliance mode: the scanner toggles are sent independently and must
+// still be applied when the mode itself does not move.
+func TestSyncIntegrationStatusKeepsScannerToggles(t *testing.T) {
+	m := withTestConfig(t, "on-demand")
+
+	syncIntegrationStatus(&models.IntegrationStatusResponse{
+		Success:                      true,
+		Integrations:                 map[string]bool{"compliance": true},
+		ComplianceMode:               "on-demand",
+		ComplianceOpenscapEnabled:    boolPtr(false),
+		ComplianceDockerBenchEnabled: boolPtr(true),
+	})
+
+	if m.GetComplianceOpenscapEnabled() {
+		t.Fatal("OpenSCAP toggle was not applied")
+	}
+	if !m.GetComplianceDockerBenchEnabled() {
+		t.Fatal("docker-bench toggle was not applied")
+	}
+	if got := m.GetComplianceMode(); got != config.ComplianceOnDemand {
+		t.Fatalf("compliance mode = %q, want %q", got, config.ComplianceOnDemand)
+	}
+}

--- a/agent-source-code/internal/config/compliance_mode_test.go
+++ b/agent-source-code/internal/config/compliance_mode_test.go
@@ -1,0 +1,70 @@
+package config
+
+import "testing"
+
+func TestParseComplianceMode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		wantMode ComplianceMode
+		wantOK   bool
+	}{
+		// The three values the server's compliance_mode field can carry.
+		{name: "server on-demand", input: "on-demand", wantMode: ComplianceOnDemand, wantOK: true},
+		{name: "server enabled", input: "enabled", wantMode: ComplianceEnabled, wantOK: true},
+		{name: "server disabled", input: "disabled", wantMode: ComplianceDisabled, wantOK: true},
+
+		// Spellings config.yml itself is allowed to hold, so a value read back
+		// out of the file parses the same way it went in.
+		{name: "underscore spelling", input: "on_demand", wantMode: ComplianceOnDemand, wantOK: true},
+		{name: "stringified true", input: "true", wantMode: ComplianceEnabled, wantOK: true},
+		{name: "stringified false", input: "false", wantMode: ComplianceDisabled, wantOK: true},
+
+		// Anything else must be reported as unrecognised rather than guessed
+		// at, so the caller can decide what to do with a value neither side
+		// agrees on.
+		{name: "empty means the server did not send the field", input: "", wantOK: false},
+		{name: "unknown mode", input: "ondemand", wantOK: false},
+		{name: "wrong case", input: "On-Demand", wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotMode, gotOK := ParseComplianceMode(tt.input)
+			if gotOK != tt.wantOK {
+				t.Fatalf("ParseComplianceMode(%q) ok = %v, want %v", tt.input, gotOK, tt.wantOK)
+			}
+			if gotMode != tt.wantMode {
+				t.Fatalf("ParseComplianceMode(%q) = %q, want %q", tt.input, gotMode, tt.wantMode)
+			}
+		})
+	}
+}
+
+// TestSetIntegrationEnabledCannotExpressOnDemand pins the reason the startup
+// sync cannot go through the boolean setter. Both on-demand and scheduled read
+// back as "enabled" through IsIntegrationEnabled, so a caller holding only the
+// boolean has no way to tell them apart, and writing it back collapses
+// on-demand into scheduled scans.
+func TestSetIntegrationEnabledCannotExpressOnDemand(t *testing.T) {
+	t.Parallel()
+
+	m := newTestManager(t)
+
+	if err := m.SetComplianceMode(ComplianceOnDemand); err != nil {
+		t.Fatalf("SetComplianceMode(on-demand): %v", err)
+	}
+	if !m.IsIntegrationEnabled("compliance") {
+		t.Fatal("on-demand compliance reads as disabled through IsIntegrationEnabled")
+	}
+
+	if err := m.SetIntegrationEnabled("compliance", true); err != nil {
+		t.Fatalf("SetIntegrationEnabled(compliance, true): %v", err)
+	}
+	if got := m.GetComplianceMode(); got != ComplianceEnabled {
+		t.Fatalf("compliance mode = %q, want %q", got, ComplianceEnabled)
+	}
+}

--- a/agent-source-code/internal/config/config.go
+++ b/agent-source-code/internal/config/config.go
@@ -683,6 +683,21 @@ const (
 	ComplianceEnabled ComplianceMode = "enabled" // true - enabled with automatic scheduled scans
 )
 
+// ParseComplianceMode maps a mode string to a ComplianceMode. The second
+// return value is false for anything unrecognised, so callers decide whether
+// to fall back or to keep the local configuration.
+func ParseComplianceMode(s string) (ComplianceMode, bool) {
+	switch s {
+	case "on-demand", "on_demand":
+		return ComplianceOnDemand, true
+	case "enabled", "true":
+		return ComplianceEnabled, true
+	case "disabled", "false":
+		return ComplianceDisabled, true
+	}
+	return "", false
+}
+
 // GetComplianceMode returns the current compliance mode
 // Returns: "disabled" (false), "on-demand" ("on-demand"), or "enabled" (true)
 func (m *Manager) GetComplianceMode() ComplianceMode {

--- a/agent-source-code/pkg/models/models.go
+++ b/agent-source-code/pkg/models/models.go
@@ -269,10 +269,14 @@ type HostSettingsResponse struct {
 
 // IntegrationStatusResponse represents integration status response from server
 type IntegrationStatusResponse struct {
-	Success                      bool            `json:"success"`
-	Integrations                 map[string]bool `json:"integrations"`
-	ComplianceOpenscapEnabled    *bool           `json:"compliance_openscap_enabled,omitempty"`
-	ComplianceDockerBenchEnabled *bool           `json:"compliance_docker_bench_enabled,omitempty"`
+	Success      bool            `json:"success"`
+	Integrations map[string]bool `json:"integrations"`
+	// ComplianceMode carries the three-state mode ("disabled", "on-demand",
+	// "enabled") that the boolean in Integrations cannot express. Empty when
+	// the server predates the field.
+	ComplianceMode               string `json:"compliance_mode,omitempty"`
+	ComplianceOpenscapEnabled    *bool  `json:"compliance_openscap_enabled,omitempty"`
+	ComplianceDockerBenchEnabled *bool  `json:"compliance_docker_bench_enabled,omitempty"`
 }
 
 // InstallEvent represents a single notable event during scanner installation


### PR DESCRIPTION
## What does this PR do?

Fixes #841

The agent's startup integration sync read only the boolean in `integrations`,
which cannot express on-demand. `AgentGetIntegrationStatus` reports a
compliance-enabled host as `true` whether scans are scheduled or on-demand
(`server-source-code/internal/handler/integrations.go:551-566`), and the
`compliance_mode` field it sends alongside was dropped at decode time —
`IntegrationStatusResponse` had no field for it.

So enabling compliance on an on-demand host wrote `enabled: true` into
config.yml, which the agent reads as **scheduled**. The compliance scheduler
started and ran full OpenSCAP scans on hosts the operator had set to on-demand.

While fixing that I found a second half the issue does not mention: **moving
between the two modes was invisible to the sync entirely.** The boolean is
`true` on both sides of an on-demand ↔ scheduled transition, so the
`serverEnabled != configEnabled` comparison never fired and the mode change
never reached the agent, in either direction.

## Type of change

- [x] 🐛 Bug fix — references an open issue with `Fixes #N`
- [ ] 💡 Feature — has an **Accepted** request on [feedback.patchmon.net](https://feedback.patchmon.net) (link it below)
- [ ] 📚 Documentation
- [ ] 🔧 Refactor / chore / CI

## Changes

- `pkg/models/models.go` — `IntegrationStatusResponse` gains `ComplianceMode`.
- `internal/config/config.go` — `ParseComplianceMode()` maps a mode string onto
  the existing three-state `ComplianceMode`, reporting unrecognised values
  rather than guessing at them.
- `cmd/patchmon-agent/commands/serve.go` — the compliance branch of the sync is
  driven by the mode; the boolean is used only when the server sends no mode.

### Backward compatibility

An agent on this code talking to a server that predates `compliance_mode` takes
the old boolean path unchanged — same comparison, same setter, same result.
That case is pinned by `server without compliance_mode falls back to the
boolean`, because upgrading the agent alone must not disturb compliance on an
existing fleet.

An unrecognised mode is logged and **leaves the local configuration alone**. It
is deliberately not treated as a reason to fall back on the boolean: that
fallback is what writes the scheduled state this change exists to stop writing.

### One structural change worth flagging

Most of the diff on `serve.go` is a move, not an edit: the sync block is lifted
verbatim out of `runServiceLoop` into `syncIntegrationStatus()` so it can be
tested. `git diff -w` still shows it as a rewrite because the block changed
position in the file; comparing the extracted body against the original shows
the only differences are the additions described above. Happy to fold it back
inline if you would rather keep the function count down, but the tests below
are not writable without it.

`applyConfig()` — the WebSocket runtime path — already handled the three states
correctly and is untouched. Two notes on it for a possible follow-up, not done
here to keep this PR to the reported bug:

- its inline switch now duplicates the vocabulary `ParseComplianceMode` holds,
  and could be de-duplicated onto it;
- its `default` coerces an unrecognised mode to `on-demand` rather than
  skipping the write, which is the same class of bug as this one, in the
  gentler direction. Say the word and I will open it.

## Checklist

- [x] I have signed the Contributor Licence Agreement (the bot will prompt you on your first PR)
- [x] I have disclosed any AI assistance, as required by [AI-DECLARATION.md](../AI-DECLARATION.md)
- [x] Tests and linters pass locally
- [x] I have tested this against a real PatchMon install

## Testing performed

Tested against a live install (server 2.0.2, agent 2.0.2, Debian 13 host) — and
it turned out that host was already sitting in the bug. The server reports it
as on-demand:

```console
$ curl -sH "X-API-ID: …" -H "X-API-KEY: …" https://patchmon.example/api/v1/hosts/integrations
{"compliance_mode":"on-demand","integrations":{"compliance":true,"docker":true}, …}
```

while its config.yml has held `enabled: true` — scheduled — and the agent had
been scanning daily off the back of it for as long as the log goes back:

```
time="2026-08-09T00:28:54" level=info msg="Starting scheduled compliance scan"
time="2026-08-10T00:28:54" level=info msg="Starting scheduled compliance scan"
time="2026-08-11T00:28:54" level=info msg="Starting scheduled compliance scan"
time="2026-08-12T00:28:54" level=info msg="Starting scheduled compliance scan"
```

Both agents were then run against that same real server, from an identical
copy of that config, isolated via `--config` so the running service was not
touched.

Shipped 2.0.2 binary:

```
msg="Syncing integration status from server..."
msg="Compliance scheduler started" compliance_scan_interval_minutes=1440
-> compliance.enabled = true
```

This branch:

```
msg="Syncing integration status from server..."
msg="Compliance mode differs, updating config.yml" config_value=enabled server_value=on-demand
msg="Updated compliance mode in config.yml" mode=on-demand
-> compliance.enabled = on-demand
```

No `Compliance scheduler started` line on the second run: the mode reaches
config.yml and the scheduler correctly stays down.

`make check` in `agent-source-code/` (fmt-check, vet, golangci-lint, full
suite) exits 0, and `GOOS=windows golangci-lint run` reports 0 issues.

New tests, in `serve_integration_sync_test.go` and `compliance_mode_test.go`:

| Case | Asserts |
| --- | --- |
| enabling an on-demand host does not schedule scans | the reported bug |
| on-demand → scheduled propagates | the transition the boolean hid |
| scheduled → on-demand propagates | the same, other direction |
| disabled server-side disables the agent | no regression on the off path |
| server without `compliance_mode` falls back to the boolean | old server, unchanged |
| unknown mode leaves the local configuration alone | no guessing |
| docker still syncs alongside compliance | the special case does not swallow the loop |

I checked the tests fail against the pre-fix behaviour rather than assuming
they do: with the mode branch disabled, three of them fail with
`compliance mode = "enabled", want "on-demand"` — the symptom from the issue.

The `unknown mode` case is worth a word. Its first version started from
on-demand, and it passed against the broken code: `IsIntegrationEnabled`
returns true for on-demand, so the boolean matched the server's and the faulty
path wrote nothing. The fixture now starts from `disabled` so the two genuinely
disagree, which is what makes the assertion mean something.

## AI Disclosure

- **Used AI:** yes
- **Model(s):** Claude Opus 5 (1M context)
- **Harness / tool:** Claude Code CLI
- **Scope:** code, tests, commit message and this PR description
- **Human review completed:** yes — reviewed line by line before opening. The
  root cause was re-derived against the current `main` rather than taken from
  the issue, which is how the second half (mode transitions being invisible)
  turned up. An independent review round caught a real defect in the first
  draft: the skip condition keyed on the mode having *parsed*, so an
  unparseable mode fell through to the boolean and re-introduced the flatten,
  while the log line above it claimed the local config was being kept. That is
  fixed, and the test that should have caught it was passing for the wrong
  reason, which is fixed too.


