### PR TITLE
fix(store): strip NUL from docker and compliance ingest too

### DIFF
--- a/server-source-code/internal/store/compliance.go
+++ b/server-source-code/internal/store/compliance.go
@@ -162,6 +162,11 @@ type ProcessedScan struct {
 // SubmitScan processes and stores scan results from an agent.
 // All DB writes are wrapped in a transaction to prevent partial/orphaned data.
 func (s *ComplianceStore) SubmitScan(ctx context.Context, hostID string, openscapEnabled, dockerBenchEnabled bool, scans []SubmittedScan) ([]ProcessedScan, error) {
+	// Strip NUL before anything touches a query parameter. The handler has
+	// already run the canonical compliance-hash check by this point, so
+	// cleaning here cannot cause a hash mismatch.
+	sanitizeComplianceScans(scans)
+
 	d := s.db.DB(ctx)
 
 	tx, err := d.BeginLong(ctx)

--- a/server-source-code/internal/store/docker_integration.go
+++ b/server-source-code/internal/store/docker_integration.go
@@ -122,6 +122,11 @@ func mapToJSON(m interface{}) []byte {
 
 // ReceiveDockerData processes and stores Docker data from an agent.
 func (s *DockerStore) ReceiveDockerData(ctx context.Context, hostID string, payload *DockerReceivePayload) (*DockerReceiveResult, error) {
+	// Strip NUL before anything touches a query parameter. The handler has
+	// already run the canonical docker-hash check by this point, so cleaning
+	// here cannot cause a hash mismatch.
+	sanitizeDockerPayload(payload)
+
 	d := s.db.DB(ctx)
 	now := time.Now().UTC()
 	nowPg := pgtime.From(now)

--- a/server-source-code/internal/store/report_sanitize.go
+++ b/server-source-code/internal/store/report_sanitize.go
@@ -48,6 +48,21 @@ func sanitizeTextSlice(ss []string) {
 	}
 }
 
+// sanitizeTextMap cleans both keys and values of an agent-supplied map.
+// Docker labels and port maps are arbitrary strings set by whoever built the
+// image, so neither side can be assumed clean. Rebuilt rather than mutated in
+// place because sanitising a key changes its identity.
+func sanitizeTextMap(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return m
+	}
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[sanitizeText(k)] = sanitizeText(v)
+	}
+	return out
+}
+
 // sanitizeRawJSON cleans a pre-encoded JSON blob that is bound straight to a
 // jsonb parameter. A raw 0x00 byte would already have failed json.Valid, so
 // the only reachable form is the \u0000 escape. Re-encoding is confined to
@@ -142,4 +157,105 @@ func sanitizeReportPayload(p *ReportPayload) {
 
 	p.DiskDetails = sanitizeRawJSON(p.DiskDetails)
 	p.NetworkInterfaces = sanitizeRawJSON(p.NetworkInterfaces)
+}
+
+// sanitizeDockerPayload cleans every agent-supplied string in a Docker
+// payload, in place.
+//
+// Same reasoning as sanitizeReportPayload: container, image, volume and
+// network fields land in `text` columns and the label / port / option maps are
+// marshalled into `jsonb`, so a single NUL anywhere aborts the whole payload
+// for that host rather than dropping one field.
+//
+// Must run AFTER the handler's canonical docker-hash check, for the same
+// reason the report path does: the agent hashes the bytes it collected, so
+// stripping first would fail every affected host on hash mismatch instead of
+// storing its data.
+func sanitizeDockerPayload(p *DockerReceivePayload) {
+	for i := range p.Containers {
+		c := &p.Containers[i]
+		c.ContainerID = sanitizeText(c.ContainerID)
+		c.Name = sanitizeText(c.Name)
+		c.ImageName = sanitizeText(c.ImageName)
+		c.ImageTag = sanitizeText(c.ImageTag)
+		c.ImageRepository = sanitizeText(c.ImageRepository)
+		c.ImageSource = sanitizeText(c.ImageSource)
+		c.ImageID = sanitizeText(c.ImageID)
+		c.Status = sanitizeText(c.Status)
+		c.State = sanitizeText(c.State)
+		c.Ports = sanitizeTextMap(c.Ports)
+		c.Labels = sanitizeTextMap(c.Labels)
+	}
+
+	for i := range p.Images {
+		img := &p.Images[i]
+		img.Repository = sanitizeText(img.Repository)
+		img.Tag = sanitizeText(img.Tag)
+		img.ImageID = sanitizeText(img.ImageID)
+		img.Source = sanitizeText(img.Source)
+		img.Digest = sanitizeText(img.Digest)
+	}
+
+	for i := range p.Volumes {
+		v := &p.Volumes[i]
+		v.VolumeID = sanitizeText(v.VolumeID)
+		v.Name = sanitizeText(v.Name)
+		v.Driver = sanitizeText(v.Driver)
+		v.Mountpoint = sanitizeText(v.Mountpoint)
+		v.Renderer = sanitizeText(v.Renderer)
+		v.Scope = sanitizeText(v.Scope)
+		v.Labels = sanitizeTextMap(v.Labels)
+		v.Options = sanitizeTextMap(v.Options)
+	}
+
+	for i := range p.Networks {
+		n := &p.Networks[i]
+		n.NetworkID = sanitizeText(n.NetworkID)
+		n.Name = sanitizeText(n.Name)
+		n.Driver = sanitizeText(n.Driver)
+		n.Scope = sanitizeText(n.Scope)
+		n.Labels = sanitizeTextMap(n.Labels)
+	}
+
+	for i := range p.Updates {
+		u := &p.Updates[i]
+		u.Repository = sanitizeText(u.Repository)
+		u.CurrentTag = sanitizeText(u.CurrentTag)
+		u.AvailableTag = sanitizeText(u.AvailableTag)
+		u.CurrentDigest = sanitizeText(u.CurrentDigest)
+		u.AvailableDigest = sanitizeText(u.AvailableDigest)
+		u.ImageID = sanitizeText(u.ImageID)
+	}
+}
+
+// sanitizeComplianceScans cleans every agent-supplied string in a compliance
+// submission, in place.
+//
+// Rule titles, descriptions and findings come from scanner output (OpenSCAP
+// content or Docker Bench), which is third-party text this codebase does not
+// control, and they land in `text` columns.
+//
+// Must run AFTER the handler's canonical compliance-hash check, for the same
+// reason the report and docker paths do.
+func sanitizeComplianceScans(scans []SubmittedScan) {
+	for i := range scans {
+		s := &scans[i]
+		s.ProfileName = sanitizeText(s.ProfileName)
+		s.ProfileType = sanitizeText(s.ProfileType)
+		s.Status = sanitizeText(s.Status)
+		s.Error = sanitizeText(s.Error)
+		for j := range s.Results {
+			r := &s.Results[j]
+			r.RuleRef = sanitizeText(r.RuleRef)
+			r.Title = sanitizeText(r.Title)
+			r.Description = sanitizeText(r.Description)
+			r.Severity = sanitizeText(r.Severity)
+			r.Section = sanitizeText(r.Section)
+			r.Remediation = sanitizeText(r.Remediation)
+			r.Status = sanitizeText(r.Status)
+			r.Finding = sanitizeText(r.Finding)
+			r.Actual = sanitizeText(r.Actual)
+			r.Expected = sanitizeText(r.Expected)
+		}
+	}
 }

--- a/server-source-code/internal/store/report_sanitize.go
+++ b/server-source-code/internal/store/report_sanitize.go
@@ -52,6 +52,13 @@ func sanitizeTextSlice(ss []string) {
 // Docker labels and port maps are arbitrary strings set by whoever built the
 // image, so neither side can be assumed clean. Rebuilt rather than mutated in
 // place because sanitising a key changes its identity.
+//
+// Two keys differing only by a NUL collapse into one, and the survivor is
+// whichever the map range happens to reach last. That is deliberate: the
+// alternative is failing the write, which is the exact outage this is here to
+// prevent. Losing one absurd duplicate label beats rejecting the host's whole
+// payload. The report path has the same hazard on package names and resolves
+// it the same way, by deduplicating rather than erroring.
 func sanitizeTextMap(m map[string]string) map[string]string {
 	if len(m) == 0 {
 		return m

--- a/server-source-code/internal/store/report_sanitize_test.go
+++ b/server-source-code/internal/store/report_sanitize_test.go
@@ -173,3 +173,92 @@ func TestSanitizeRawJSON(t *testing.T) {
 		}
 	})
 }
+
+func TestSanitizeDockerPayload_StripsNulsEverywhere(t *testing.T) {
+	nul := "\x00"
+	p := &DockerReceivePayload{
+		Containers: []DockerReceiveContainer{{
+			ContainerID: "abc" + nul,
+			Name:        "web" + nul,
+			ImageName:   "nginx" + nul,
+			ImageTag:    "1.27" + nul,
+			Status:      "Up 3 hours" + nul,
+			State:       "running" + nul,
+			Ports:       map[string]string{"80/tcp" + nul: "8080" + nul},
+			Labels:      map[string]string{"com.example" + nul: "value" + nul},
+		}},
+		Images:   []DockerReceiveImage{{Repository: "nginx" + nul, Tag: "latest" + nul, Digest: "sha256:x" + nul}},
+		Volumes:  []DockerReceiveVolume{{Name: "data" + nul, Mountpoint: "/var/lib/x" + nul, Options: map[string]string{"o" + nul: "bind" + nul}}},
+		Networks: []DockerReceiveNetwork{{Name: "bridge" + nul, Driver: "bridge" + nul, Labels: map[string]string{"k" + nul: "v" + nul}}},
+		Updates:  []DockerReceiveImageUpdate{{Repository: "nginx" + nul, AvailableTag: "1.28" + nul}},
+	}
+
+	sanitizeDockerPayload(p)
+
+	c := p.Containers[0]
+	for name, got := range map[string]string{
+		"ContainerID": c.ContainerID, "Name": c.Name, "ImageName": c.ImageName,
+		"ImageTag": c.ImageTag, "Status": c.Status, "State": c.State,
+		"image.Repository": p.Images[0].Repository, "image.Tag": p.Images[0].Tag,
+		"image.Digest": p.Images[0].Digest, "volume.Name": p.Volumes[0].Name,
+		"volume.Mountpoint": p.Volumes[0].Mountpoint, "network.Name": p.Networks[0].Name,
+		"network.Driver": p.Networks[0].Driver, "update.Repository": p.Updates[0].Repository,
+		"update.AvailableTag": p.Updates[0].AvailableTag,
+	} {
+		if strings.ContainsRune(got, 0) {
+			t.Errorf("%s still contains NUL: %q", name, got)
+		}
+	}
+
+	// Maps must be cleaned on both sides. A NUL in a key survives
+	// json.Marshal as an escape sequence and aborts the jsonb write.
+	for label, m := range map[string]map[string]string{
+		"container.Ports": c.Ports, "container.Labels": c.Labels,
+		"volume.Options": p.Volumes[0].Options, "network.Labels": p.Networks[0].Labels,
+	} {
+		for k, v := range m {
+			if strings.ContainsRune(k, 0) {
+				t.Errorf("%s key still contains NUL: %q", label, k)
+			}
+			if strings.ContainsRune(v, 0) {
+				t.Errorf("%s value still contains NUL: %q", label, v)
+			}
+		}
+	}
+	if got := c.Labels["com.example"]; got != "value" {
+		t.Errorf("label not reachable under its cleaned key, got %q", got)
+	}
+}
+
+func TestSanitizeComplianceScans_StripsNulsEverywhere(t *testing.T) {
+	nul := "\x00"
+	scans := []SubmittedScan{{
+		ProfileName: "CIS" + nul,
+		ProfileType: "openscap" + nul,
+		Status:      "completed" + nul,
+		Error:       "none" + nul,
+		Results: []SubmittedScanResult{{
+			RuleRef: "r1" + nul, Title: "Ensure X" + nul, Description: "desc" + nul,
+			Severity: "high" + nul, Section: "1.1" + nul, Remediation: "do y" + nul,
+			Status: "fail" + nul, Finding: "f" + nul, Actual: "a" + nul, Expected: "e" + nul,
+		}},
+	}}
+
+	sanitizeComplianceScans(scans)
+
+	s := scans[0]
+	r := s.Results[0]
+	for name, got := range map[string]string{
+		"ProfileName": s.ProfileName, "ProfileType": s.ProfileType, "Status": s.Status,
+		"Error": s.Error, "RuleRef": r.RuleRef, "Title": r.Title, "Description": r.Description,
+		"Severity": r.Severity, "Section": r.Section, "Remediation": r.Remediation,
+		"result.Status": r.Status, "Finding": r.Finding, "Actual": r.Actual, "Expected": r.Expected,
+	} {
+		if strings.ContainsRune(got, 0) {
+			t.Errorf("%s still contains NUL: %q", name, got)
+		}
+	}
+	if s.ProfileName != "CIS" || r.Title != "Ensure X" {
+		t.Errorf("content altered beyond NUL removal: %q / %q", s.ProfileName, r.Title)
+	}
+}


### PR DESCRIPTION
Fixes #1029

## The problem

#979 hardened agent input against NUL bytes, fixing #824 and #1021. It covered the `/hosts/update` report path only. Two other agent endpoints still wrote agent-supplied strings straight to Postgres:

| Path | Unsanitised input | Destination |
|---|---|---|
| `DockerStore.ReceiveDockerData` | container `name`, `image_name`, `image_tag`, `status`, `state`, image `digest`, volume `mountpoint`, `driver`, `scope`, network fields | `TEXT` |
| same | `labels`, `ports`, `options` maps via `mapToJSON` | `JSONB` |
| `ComplianceStore.SubmitScan` | rule `Title`, `Description`, `Finding`, `Remediation` and the rest, from scanner output | `TEXT` |

One NUL anywhere in those aborts that host's entire Docker or compliance payload, the same failure #1021 described for package reports. Postgres rejects NUL in `text` with 22021 and the escaped form in `jsonb` with 22P05.

## The change

`sanitizeDockerPayload` and `sanitizeComplianceScans` reuse the existing `sanitizeText` helper, so there is no new sanitisation logic and no new exported API.

Both run at the top of their store entry point, which is **after** the handlers' canonical hash checks (`canonicalDockerHashFromReq`, `canonicalComplianceHashFromPayload`). That ordering is load-bearing and matches `sanitizeReportPayload`: the agent hashes the bytes it collected, so stripping before the comparison would turn every affected host into a permanent hash mismatch instead of storing its data.

Map **keys** are sanitised as well as values. A NUL in a Docker label key breaks the `jsonb` write just as readily as one in the value, and since cleaning a key changes its identity the map is rebuilt rather than mutated.

## Scope, stated honestly

This is defence in depth, not a reported outage. Worth being precise about reachability so it is not over-rated:

- **Invalid UTF-8 is not reachable on these paths.** `json.Unmarshal` already coerces malformed bytes to U+FFFD, so it cannot survive decoding into a Go string.
- **NUL is reachable**, because the escaped form is legal JSON that decodes to a real NUL byte, and `json.Marshal` re-emits it into the JSONB payload.

Docker's own naming rules keep container names clean, so the realistic carriers are arbitrary `labels` values set by an image author and scanner-produced compliance text. Lower probability than the Windows registry case in #1021, identical blast radius when it happens.

## Verification

`make check` clean.

Two new table tests cover every sanitised field on both payloads, including map keys and values, and assert that content is not altered beyond NUL removal.

Mutation-checked rather than assumed: with both sanitisers stubbed to return immediately, **37 assertions fail**; restored, they pass. The tests are not vacuous.
