### PR TITLE
fix(dashboard): stop counting hosts with no data as up to date

### DIFF
--- a/frontend/src/pages/Hosts.jsx
+++ b/frontend/src/pages/Hosts.jsx
@@ -235,6 +235,10 @@ const Hosts = () => {
 					setShowFilters(true);
 					setStatusFilter("reporting");
 					break;
+				case "awaitingData":
+					setShowFilters(true);
+					setStatusFilter("all");
+					break;
 				default:
 					break;
 			}
@@ -910,7 +914,13 @@ const Hosts = () => {
 					(host.updatesCount && host.updatesCount > 0)) &&
 				(filter !== "inactive" ||
 					(host.effectiveStatus || host.status) === "inactive") &&
-				(filter !== "upToDate" || (!host.isStale && host.updatesCount === 0)) &&
+				// "Up to date" requires package data: a host we have never received
+				// packages from is unknown, not healthy. Mirrors the server predicate.
+				(filter !== "upToDate" ||
+					(!host.isStale &&
+						host.totalPackagesCount > 0 &&
+						host.updatesCount === 0)) &&
+				(filter !== "awaitingData" || !host.totalPackagesCount) &&
 				(filter !== "stale" || host.isStale) &&
 				(filter !== "selected" ||
 					(selectedIds &&

--- a/server-source-code/internal/db/dashboard.sql.go
+++ b/server-source-code/internal/db/dashboard.sql.go
@@ -47,8 +47,13 @@ WHERE (
         SELECT 1 FROM host_packages hp WHERE hp.host_id = filtered_hosts.id AND hp.needs_update
     ))
     OR ($1 = 'inactive' AND effective_status = 'inactive')
-    OR ($1 = 'upToDate' AND is_stale = false AND NOT EXISTS (
+    OR ($1 = 'upToDate' AND is_stale = false AND EXISTS (
+        SELECT 1 FROM host_packages hp WHERE hp.host_id = filtered_hosts.id
+    ) AND NOT EXISTS (
         SELECT 1 FROM host_packages hp WHERE hp.host_id = filtered_hosts.id AND hp.needs_update
+    ))
+    OR ($1 = 'awaitingData' AND NOT EXISTS (
+        SELECT 1 FROM host_packages hp WHERE hp.host_id = filtered_hosts.id
     ))
     OR ($1 = 'stale' AND is_stale = true)
     OR ($1 = 'selected')
@@ -145,7 +150,13 @@ hp_package_counts AS (
                 WHERE hp.needs_update = true AND hp.is_security_update = true
                 GROUP BY hp.package_id
             ) security_packages
-        ), 0)::int AS security_updates
+        ), 0)::int AS security_updates,
+        -- Hosts we have actually received packages from. "Up to date" is
+        -- derived from this, not from total_hosts, so a host we know nothing
+        -- about is never reported as healthy.
+        COALESCE((
+            SELECT COUNT(DISTINCT hp.host_id)::int FROM host_packages hp
+        ), 0)::int AS hosts_with_package_data
 )
 SELECT
     hc.total_hosts,
@@ -157,7 +168,8 @@ SELECT
     hc.hosts_needing_reboot,
     (SELECT COUNT(*)::int FROM host_groups),
     (SELECT COUNT(*)::int FROM users),
-    (SELECT COUNT(*)::int FROM repositories)
+    (SELECT COUNT(*)::int FROM repositories),
+    hpc.hosts_with_package_data
 FROM host_counts hc
 CROSS JOIN hp_package_counts hpc
 `
@@ -178,6 +190,7 @@ type GetDashboardStatsRow struct {
 	Column8               int32 `json:"column_8"`
 	Column9               int32 `json:"column_9"`
 	Column10              int32 `json:"column_10"`
+	HostsWithPackageData  int32 `json:"hosts_with_package_data"`
 }
 
 func (q *Queries) GetDashboardStats(ctx context.Context, arg GetDashboardStatsParams) (GetDashboardStatsRow, error) {
@@ -194,6 +207,7 @@ func (q *Queries) GetDashboardStats(ctx context.Context, arg GetDashboardStatsPa
 		&i.Column8,
 		&i.Column9,
 		&i.Column10,
+		&i.HostsWithPackageData,
 	)
 	return i, err
 }
@@ -218,6 +232,9 @@ package_counts AS (
         COUNT(DISTINCT package_id) FILTER (WHERE is_security_update)::int AS security_updates
     FROM host_packages
     WHERE needs_update = true
+),
+hosts_with_data AS (
+    SELECT COUNT(DISTINCT host_id)::int AS cnt FROM host_packages
 )
 SELECT
     hc.total_hosts,
@@ -226,11 +243,13 @@ SELECT
     pc.security_updates AS security_updates,
     hws.cnt AS hosts_with_security_updates,
     (SELECT COUNT(*)::int FROM repositories WHERE is_active = true) AS total_repos,
-    (SELECT COUNT(*)::int FROM update_history WHERE timestamp >= $1 AND status = 'success' AND report_type IN ('full', 'partial')) AS recent_updates_24h
+    (SELECT COUNT(*)::int FROM update_history WHERE timestamp >= $1 AND status = 'success' AND report_type IN ('full', 'partial')) AS recent_updates_24h,
+    hwd.cnt AS hosts_with_package_data
 FROM host_counts hc
 CROSS JOIN hosts_needing_updates hnu
 CROSS JOIN hosts_with_security hws
 CROSS JOIN package_counts pc
+CROSS JOIN hosts_with_data hwd
 `
 
 type GetHomepageStatsRow struct {
@@ -241,6 +260,7 @@ type GetHomepageStatsRow struct {
 	HostsWithSecurityUpdates int32 `json:"hosts_with_security_updates"`
 	TotalRepos               int32 `json:"total_repos"`
 	RecentUpdates24h         int32 `json:"recent_updates_24h"`
+	HostsWithPackageData     int32 `json:"hosts_with_package_data"`
 }
 
 // The host counters here must match GetDashboardStats, otherwise a widget and
@@ -260,6 +280,7 @@ func (q *Queries) GetHomepageStats(ctx context.Context, since pgtype.Timestamp) 
 		&i.HostsWithSecurityUpdates,
 		&i.TotalRepos,
 		&i.RecentUpdates24h,
+		&i.HostsWithPackageData,
 	)
 	return i, err
 }
@@ -538,7 +559,10 @@ filtered_hosts AS (
         $10::text IS NULL
         OR ($10 = 'needsUpdates' AND updates_count > 0)
         OR ($10 = 'inactive' AND effective_status = 'inactive')
-        OR ($10 = 'upToDate' AND is_stale = false AND updates_count = 0)
+        -- "Up to date" requires package data. A host we have never received
+        -- packages from is not healthy, it is unknown: see filter 'awaitingData'.
+        OR ($10 = 'upToDate' AND is_stale = false AND total_packages_count > 0 AND updates_count = 0)
+        OR ($10 = 'awaitingData' AND total_packages_count = 0)
         OR ($10 = 'stale' AND is_stale = true)
         OR ($10 = 'selected')
     )
@@ -758,8 +782,13 @@ filtered_hosts AS (
             SELECT 1 FROM host_packages hp WHERE hp.host_id = bh.id AND hp.needs_update
         ))
         OR ($10 = 'inactive' AND bh.effective_status = 'inactive')
-        OR ($10 = 'upToDate' AND bh.is_stale = false AND NOT EXISTS (
+        OR ($10 = 'upToDate' AND bh.is_stale = false AND EXISTS (
+            SELECT 1 FROM host_packages hp WHERE hp.host_id = bh.id
+        ) AND NOT EXISTS (
             SELECT 1 FROM host_packages hp WHERE hp.host_id = bh.id AND hp.needs_update
+        ))
+        OR ($10 = 'awaitingData' AND NOT EXISTS (
+            SELECT 1 FROM host_packages hp WHERE hp.host_id = bh.id
         ))
         OR ($10 = 'stale' AND bh.is_stale = true)
         OR ($10 = 'selected')

--- a/server-source-code/internal/db/dashboard.sql.go
+++ b/server-source-code/internal/db/dashboard.sql.go
@@ -119,7 +119,19 @@ WITH host_counts AS (
         -- links to disagree.
         COUNT(*) FILTER (WHERE (status = 'active' AND last_update < $1) OR status = 'inactive')::int AS errored_hosts,
         COUNT(*) FILTER (WHERE status = 'active' AND last_update < $2)::int AS offline_hosts,
-        COUNT(*) FILTER (WHERE needs_reboot = true)::int AS hosts_needing_reboot
+        COUNT(*) FILTER (WHERE needs_reboot = true)::int AS hosts_needing_reboot,
+        -- Hosts we have actually received packages from. "Up to date" is
+        -- derived from this, not from total_hosts, so a host we know nothing
+        -- about is never reported as healthy.
+        --
+        -- An EXISTS semi-join, not COUNT(DISTINCT host_id) over host_packages:
+        -- the latter reads every row in the table (1.25M at 1k hosts, 55 ms)
+        -- to rediscover something 1000 index probes answer in 2 ms, and it
+        -- scales with package rows rather than host count. It also rides the
+        -- scan of hosts this CTE is already doing.
+        COUNT(*) FILTER (WHERE EXISTS (
+            SELECT 1 FROM host_packages hp WHERE hp.host_id = hosts.id
+        ))::int AS hosts_with_package_data
     FROM hosts
 ),
 hp_package_counts AS (
@@ -150,13 +162,7 @@ hp_package_counts AS (
                 WHERE hp.needs_update = true AND hp.is_security_update = true
                 GROUP BY hp.package_id
             ) security_packages
-        ), 0)::int AS security_updates,
-        -- Hosts we have actually received packages from. "Up to date" is
-        -- derived from this, not from total_hosts, so a host we know nothing
-        -- about is never reported as healthy.
-        COALESCE((
-            SELECT COUNT(DISTINCT hp.host_id)::int FROM host_packages hp
-        ), 0)::int AS hosts_with_package_data
+        ), 0)::int AS security_updates
 )
 SELECT
     hc.total_hosts,
@@ -169,7 +175,7 @@ SELECT
     (SELECT COUNT(*)::int FROM host_groups),
     (SELECT COUNT(*)::int FROM users),
     (SELECT COUNT(*)::int FROM repositories),
-    hpc.hosts_with_package_data
+    hc.hosts_with_package_data
 FROM host_counts hc
 CROSS JOIN hp_package_counts hpc
 `
@@ -214,7 +220,13 @@ func (q *Queries) GetDashboardStats(ctx context.Context, arg GetDashboardStatsPa
 
 const getHomepageStats = `-- name: GetHomepageStats :one
 WITH host_counts AS (
-    SELECT COUNT(*)::int AS total_hosts FROM hosts
+    SELECT COUNT(*)::int AS total_hosts,
+           -- See GetDashboardStats: semi-join, not COUNT(DISTINCT), and it
+           -- rides the scan of ` + "`" + `hosts` + "`" + ` already happening here.
+           COUNT(*) FILTER (WHERE EXISTS (
+               SELECT 1 FROM host_packages hp WHERE hp.host_id = hosts.id
+           ))::int AS hosts_with_package_data
+    FROM hosts
 ),
 hosts_needing_updates AS (
     SELECT COUNT(DISTINCT hp.host_id)::int AS cnt
@@ -232,9 +244,6 @@ package_counts AS (
         COUNT(DISTINCT package_id) FILTER (WHERE is_security_update)::int AS security_updates
     FROM host_packages
     WHERE needs_update = true
-),
-hosts_with_data AS (
-    SELECT COUNT(DISTINCT host_id)::int AS cnt FROM host_packages
 )
 SELECT
     hc.total_hosts,
@@ -244,12 +253,11 @@ SELECT
     hws.cnt AS hosts_with_security_updates,
     (SELECT COUNT(*)::int FROM repositories WHERE is_active = true) AS total_repos,
     (SELECT COUNT(*)::int FROM update_history WHERE timestamp >= $1 AND status = 'success' AND report_type IN ('full', 'partial')) AS recent_updates_24h,
-    hwd.cnt AS hosts_with_package_data
+    hc.hosts_with_package_data
 FROM host_counts hc
 CROSS JOIN hosts_needing_updates hnu
 CROSS JOIN hosts_with_security hws
 CROSS JOIN package_counts pc
-CROSS JOIN hosts_with_data hwd
 `
 
 type GetHomepageStatsRow struct {

--- a/server-source-code/internal/handler/dashboard.go
+++ b/server-source-code/internal/handler/dashboard.go
@@ -95,7 +95,7 @@ func parseCSVQuery(value string, maxItems int) ([]string, bool) {
 
 func validHostsListFilter(filter string) bool {
 	switch filter {
-	case "", "needsUpdates", "inactive", "upToDate", "stale", "selected", "offline":
+	case "", "needsUpdates", "inactive", "upToDate", "awaitingData", "stale", "selected", "offline":
 		return true
 	default:
 		return false

--- a/server-source-code/internal/sqlc/queries/dashboard.sql
+++ b/server-source-code/internal/sqlc/queries/dashboard.sql
@@ -7,7 +7,19 @@ WITH host_counts AS (
         -- links to disagree.
         COUNT(*) FILTER (WHERE (status = 'active' AND last_update < $1) OR status = 'inactive')::int AS errored_hosts,
         COUNT(*) FILTER (WHERE status = 'active' AND last_update < $2)::int AS offline_hosts,
-        COUNT(*) FILTER (WHERE needs_reboot = true)::int AS hosts_needing_reboot
+        COUNT(*) FILTER (WHERE needs_reboot = true)::int AS hosts_needing_reboot,
+        -- Hosts we have actually received packages from. "Up to date" is
+        -- derived from this, not from total_hosts, so a host we know nothing
+        -- about is never reported as healthy.
+        --
+        -- An EXISTS semi-join, not COUNT(DISTINCT host_id) over host_packages:
+        -- the latter reads every row in the table (1.25M at 1k hosts, 55 ms)
+        -- to rediscover something 1000 index probes answer in 2 ms, and it
+        -- scales with package rows rather than host count. It also rides the
+        -- scan of hosts this CTE is already doing.
+        COUNT(*) FILTER (WHERE EXISTS (
+            SELECT 1 FROM host_packages hp WHERE hp.host_id = hosts.id
+        ))::int AS hosts_with_package_data
     FROM hosts
 ),
 hp_package_counts AS (
@@ -38,13 +50,7 @@ hp_package_counts AS (
                 WHERE hp.needs_update = true AND hp.is_security_update = true
                 GROUP BY hp.package_id
             ) security_packages
-        ), 0)::int AS security_updates,
-        -- Hosts we have actually received packages from. "Up to date" is
-        -- derived from this, not from total_hosts, so a host we know nothing
-        -- about is never reported as healthy.
-        COALESCE((
-            SELECT COUNT(DISTINCT hp.host_id)::int FROM host_packages hp
-        ), 0)::int AS hosts_with_package_data
+        ), 0)::int AS security_updates
 )
 SELECT
     hc.total_hosts,
@@ -57,7 +63,7 @@ SELECT
     (SELECT COUNT(*)::int FROM host_groups),
     (SELECT COUNT(*)::int FROM users),
     (SELECT COUNT(*)::int FROM repositories),
-    hpc.hosts_with_package_data
+    hc.hosts_with_package_data
 FROM host_counts hc
 CROSS JOIN hp_package_counts hpc;
 
@@ -539,7 +545,13 @@ ORDER BY friendly_name ASC;
 -- what it appeared to: hosts.status is an enrolment lifecycle column and never
 -- becomes 'inactive', so a host that stopped reporting was counted regardless.
 WITH host_counts AS (
-    SELECT COUNT(*)::int AS total_hosts FROM hosts
+    SELECT COUNT(*)::int AS total_hosts,
+           -- See GetDashboardStats: semi-join, not COUNT(DISTINCT), and it
+           -- rides the scan of `hosts` already happening here.
+           COUNT(*) FILTER (WHERE EXISTS (
+               SELECT 1 FROM host_packages hp WHERE hp.host_id = hosts.id
+           ))::int AS hosts_with_package_data
+    FROM hosts
 ),
 hosts_needing_updates AS (
     SELECT COUNT(DISTINCT hp.host_id)::int AS cnt
@@ -557,9 +569,6 @@ package_counts AS (
         COUNT(DISTINCT package_id) FILTER (WHERE is_security_update)::int AS security_updates
     FROM host_packages
     WHERE needs_update = true
-),
-hosts_with_data AS (
-    SELECT COUNT(DISTINCT host_id)::int AS cnt FROM host_packages
 )
 SELECT
     hc.total_hosts,
@@ -569,10 +578,9 @@ SELECT
     hws.cnt AS hosts_with_security_updates,
     (SELECT COUNT(*)::int FROM repositories WHERE is_active = true) AS total_repos,
     (SELECT COUNT(*)::int FROM update_history WHERE timestamp >= sqlc.arg('since') AND status = 'success' AND report_type IN ('full', 'partial')) AS recent_updates_24h,
-    hwd.cnt AS hosts_with_package_data
+    hc.hosts_with_package_data
 FROM host_counts hc
 CROSS JOIN hosts_needing_updates hnu
 CROSS JOIN hosts_with_security hws
-CROSS JOIN package_counts pc
-CROSS JOIN hosts_with_data hwd;
+CROSS JOIN package_counts pc;
 

--- a/server-source-code/internal/sqlc/queries/dashboard.sql
+++ b/server-source-code/internal/sqlc/queries/dashboard.sql
@@ -38,7 +38,13 @@ hp_package_counts AS (
                 WHERE hp.needs_update = true AND hp.is_security_update = true
                 GROUP BY hp.package_id
             ) security_packages
-        ), 0)::int AS security_updates
+        ), 0)::int AS security_updates,
+        -- Hosts we have actually received packages from. "Up to date" is
+        -- derived from this, not from total_hosts, so a host we know nothing
+        -- about is never reported as healthy.
+        COALESCE((
+            SELECT COUNT(DISTINCT hp.host_id)::int FROM host_packages hp
+        ), 0)::int AS hosts_with_package_data
 )
 SELECT
     hc.total_hosts,
@@ -50,7 +56,8 @@ SELECT
     hc.hosts_needing_reboot,
     (SELECT COUNT(*)::int FROM host_groups),
     (SELECT COUNT(*)::int FROM users),
-    (SELECT COUNT(*)::int FROM repositories)
+    (SELECT COUNT(*)::int FROM repositories),
+    hpc.hosts_with_package_data
 FROM host_counts hc
 CROSS JOIN hp_package_counts hpc;
 
@@ -139,7 +146,10 @@ filtered_hosts AS (
         sqlc.narg('filter')::text IS NULL
         OR (sqlc.narg('filter') = 'needsUpdates' AND updates_count > 0)
         OR (sqlc.narg('filter') = 'inactive' AND effective_status = 'inactive')
-        OR (sqlc.narg('filter') = 'upToDate' AND is_stale = false AND updates_count = 0)
+        -- "Up to date" requires package data. A host we have never received
+        -- packages from is not healthy, it is unknown: see filter 'awaitingData'.
+        OR (sqlc.narg('filter') = 'upToDate' AND is_stale = false AND total_packages_count > 0 AND updates_count = 0)
+        OR (sqlc.narg('filter') = 'awaitingData' AND total_packages_count = 0)
         OR (sqlc.narg('filter') = 'stale' AND is_stale = true)
         OR (sqlc.narg('filter') = 'selected')
     )
@@ -247,8 +257,13 @@ filtered_hosts AS (
             SELECT 1 FROM host_packages hp WHERE hp.host_id = bh.id AND hp.needs_update
         ))
         OR (sqlc.narg('filter') = 'inactive' AND bh.effective_status = 'inactive')
-        OR (sqlc.narg('filter') = 'upToDate' AND bh.is_stale = false AND NOT EXISTS (
+        OR (sqlc.narg('filter') = 'upToDate' AND bh.is_stale = false AND EXISTS (
+            SELECT 1 FROM host_packages hp WHERE hp.host_id = bh.id
+        ) AND NOT EXISTS (
             SELECT 1 FROM host_packages hp WHERE hp.host_id = bh.id AND hp.needs_update
+        ))
+        OR (sqlc.narg('filter') = 'awaitingData' AND NOT EXISTS (
+            SELECT 1 FROM host_packages hp WHERE hp.host_id = bh.id
         ))
         OR (sqlc.narg('filter') = 'stale' AND bh.is_stale = true)
         OR (sqlc.narg('filter') = 'selected')
@@ -391,8 +406,13 @@ WHERE (
         SELECT 1 FROM host_packages hp WHERE hp.host_id = filtered_hosts.id AND hp.needs_update
     ))
     OR (sqlc.narg('filter') = 'inactive' AND effective_status = 'inactive')
-    OR (sqlc.narg('filter') = 'upToDate' AND is_stale = false AND NOT EXISTS (
+    OR (sqlc.narg('filter') = 'upToDate' AND is_stale = false AND EXISTS (
+        SELECT 1 FROM host_packages hp WHERE hp.host_id = filtered_hosts.id
+    ) AND NOT EXISTS (
         SELECT 1 FROM host_packages hp WHERE hp.host_id = filtered_hosts.id AND hp.needs_update
+    ))
+    OR (sqlc.narg('filter') = 'awaitingData' AND NOT EXISTS (
+        SELECT 1 FROM host_packages hp WHERE hp.host_id = filtered_hosts.id
     ))
     OR (sqlc.narg('filter') = 'stale' AND is_stale = true)
     OR (sqlc.narg('filter') = 'selected')
@@ -537,6 +557,9 @@ package_counts AS (
         COUNT(DISTINCT package_id) FILTER (WHERE is_security_update)::int AS security_updates
     FROM host_packages
     WHERE needs_update = true
+),
+hosts_with_data AS (
+    SELECT COUNT(DISTINCT host_id)::int AS cnt FROM host_packages
 )
 SELECT
     hc.total_hosts,
@@ -545,9 +568,11 @@ SELECT
     pc.security_updates AS security_updates,
     hws.cnt AS hosts_with_security_updates,
     (SELECT COUNT(*)::int FROM repositories WHERE is_active = true) AS total_repos,
-    (SELECT COUNT(*)::int FROM update_history WHERE timestamp >= sqlc.arg('since') AND status = 'success' AND report_type IN ('full', 'partial')) AS recent_updates_24h
+    (SELECT COUNT(*)::int FROM update_history WHERE timestamp >= sqlc.arg('since') AND status = 'success' AND report_type IN ('full', 'partial')) AS recent_updates_24h,
+    hwd.cnt AS hosts_with_package_data
 FROM host_counts hc
 CROSS JOIN hosts_needing_updates hnu
 CROSS JOIN hosts_with_security hws
-CROSS JOIN package_counts pc;
+CROSS JOIN package_counts pc
+CROSS JOIN hosts_with_data hwd;
 

--- a/server-source-code/internal/store/dashboard.go
+++ b/server-source-code/internal/store/dashboard.go
@@ -46,12 +46,18 @@ func (s *DashboardStore) withWorkMem(ctx context.Context, fn func(q *db.Queries)
 // Whether the last job succeeded does not enter into it, so a host that patched
 // cleanly and then stopped checking in belongs here, while one whose run failed
 // but is still reporting does not.
-func updateStatusSegments(upToDate, needsUpdates, notReporting int) []map[string]interface{} {
-	return []map[string]interface{}{
+func updateStatusSegments(upToDate, needsUpdates, notReporting, awaitingData int) []map[string]interface{} {
+	segments := []map[string]interface{}{
 		{"name": "Up to date", "filter": "upToDate", "count": upToDate},
 		{"name": "Needs updates", "filter": "needsUpdates", "count": needsUpdates},
 		{"name": "Not reporting", "filter": "inactive", "count": notReporting},
 	}
+	// Only surfaced when it applies. A fleet where every host has reported
+	// should not carry a permanent empty segment.
+	if awaitingData > 0 {
+		segments = append(segments, map[string]interface{}{"name": "Awaiting data", "filter": "awaitingData", "count": awaitingData})
+	}
+	return segments
 }
 
 // GetStats returns dashboard statistics matching Node backend structure for frontend compatibility.
@@ -120,9 +126,16 @@ func (s *DashboardStore) GetStats(ctx context.Context) (map[string]interface{}, 
 	totalUsers := int(stats.Column9)
 	totalRepos := int(stats.Column10)
 
-	upToDateHosts := totalHosts - hostsNeedingUpdates
+	// Derived from hosts we hold package data for, not from every host. A host
+	// that has never reported packages is unknown, not healthy, and folding it
+	// into "up to date" reports silence as good news.
+	upToDateHosts := int(stats.HostsWithPackageData) - hostsNeedingUpdates
 	if upToDateHosts < 0 {
 		upToDateHosts = 0
+	}
+	awaitingDataHosts := totalHosts - int(stats.HostsWithPackageData)
+	if awaitingDataHosts < 0 {
+		awaitingDataHosts = 0
 	}
 
 	osDistribution := make([]map[string]interface{}, len(osRows))
@@ -133,7 +146,7 @@ func (s *DashboardStore) GetStats(ctx context.Context) (map[string]interface{}, 
 		}
 	}
 
-	updateStatusDistribution := updateStatusSegments(upToDateHosts, hostsNeedingUpdates, erroredHosts)
+	updateStatusDistribution := updateStatusSegments(upToDateHosts, hostsNeedingUpdates, erroredHosts, awaitingDataHosts)
 
 	regularUpdates := totalOutdatedPackages - securityUpdates
 	if regularUpdates < 0 {
@@ -181,9 +194,15 @@ func (s *DashboardStore) GetHomepageStats(ctx context.Context) (map[string]inter
 
 	totalHosts := int(stats.TotalHosts)
 	hostsNeedingUpdates := int(stats.HostsNeedingUpdates)
-	upToDateHosts := totalHosts - hostsNeedingUpdates
+	// Same rule as the dashboard card: only hosts we hold package data for can
+	// be called up to date.
+	upToDateHosts := int(stats.HostsWithPackageData) - hostsNeedingUpdates
 	if upToDateHosts < 0 {
 		upToDateHosts = 0
+	}
+	awaitingDataHosts := totalHosts - int(stats.HostsWithPackageData)
+	if awaitingDataHosts < 0 {
+		awaitingDataHosts = 0
 	}
 
 	osRows, _ := d.Queries.GetOSDistributionByTypeAndVersion(ctx)
@@ -221,6 +240,7 @@ func (s *DashboardStore) GetHomepageStats(ctx context.Context) (map[string]inter
 		"total_repos":                 int(stats.TotalRepos),
 		"hosts_needing_updates":       hostsNeedingUpdates,
 		"up_to_date_hosts":            upToDateHosts,
+		"awaiting_data_hosts":         awaitingDataHosts,
 		"security_updates":            int(stats.SecurityUpdates),
 		"hosts_with_security_updates": int(stats.HostsWithSecurityUpdates),
 		"recent_updates_24h":          int(stats.RecentUpdates24h),

--- a/server-source-code/internal/store/dashboard_segments_test.go
+++ b/server-source-code/internal/store/dashboard_segments_test.go
@@ -5,12 +5,12 @@ import "testing"
 // The update-status chart navigates by the filter its segment carries. A
 // segment without one is not a cosmetic problem: the click falls through and
 // lands on an unfiltered host list, which reads as having worked. These tests
-// pin that contract so a fourth segment cannot be added without a filter, and
-// so the three filters stay the ones the Hosts page actually understands.
+// pin that contract so a further segment cannot be added without a filter, and
+// so the filters stay the ones the Hosts page actually understands.
 func TestUpdateStatusSegments_EverySegmentCarriesAFilter(t *testing.T) {
 	t.Parallel()
 
-	for _, seg := range updateStatusSegments(1, 2, 3) {
+	for _, seg := range updateStatusSegments(1, 2, 3, 4) {
 		name, ok := seg["name"].(string)
 		if !ok || name == "" {
 			t.Fatalf("segment %v has no display name", seg)
@@ -29,13 +29,17 @@ func TestUpdateStatusSegments_FiltersMatchTheHostsPage(t *testing.T) {
 	// one whose server-side effective_status predicate the chart's own count is
 	// computed from. The two must stay in step or the count and the list it
 	// links to disagree.
+	//
+	// "awaitingData" is the same contract for hosts we hold no package data
+	// for. It must remain in validHostsListFilter or the click 400s.
 	want := []struct{ name, filter string }{
 		{"Up to date", "upToDate"},
 		{"Needs updates", "needsUpdates"},
 		{"Not reporting", "inactive"},
+		{"Awaiting data", "awaitingData"},
 	}
 
-	got := updateStatusSegments(0, 0, 0)
+	got := updateStatusSegments(0, 0, 0, 1)
 	if len(got) != len(want) {
 		t.Fatalf("expected %d segments, got %d", len(want), len(got))
 	}
@@ -52,10 +56,27 @@ func TestUpdateStatusSegments_FiltersMatchTheHostsPage(t *testing.T) {
 func TestUpdateStatusSegments_CountsLandOnTheRightSegment(t *testing.T) {
 	t.Parallel()
 
-	got := updateStatusSegments(7, 11, 13)
-	for i, want := range []int{7, 11, 13} {
+	got := updateStatusSegments(7, 11, 13, 17)
+	for i, want := range []int{7, 11, 13, 17} {
 		if got[i]["count"] != want {
 			t.Errorf("segment %d (%v): expected count %d, got %v", i, got[i]["name"], want, got[i]["count"])
+		}
+	}
+}
+
+// A fleet where every host has reported should not carry a permanently empty
+// fourth segment, which would render as a dead slice and a click leading to an
+// empty list.
+func TestUpdateStatusSegments_AwaitingDataHiddenWhenZero(t *testing.T) {
+	t.Parallel()
+
+	got := updateStatusSegments(5, 3, 1, 0)
+	if len(got) != 3 {
+		t.Fatalf("expected the awaiting-data segment to be omitted at zero, got %d segments", len(got))
+	}
+	for _, seg := range got {
+		if seg["filter"] == "awaitingData" {
+			t.Errorf("awaiting-data segment present despite a zero count: %v", seg)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #1032

## The problem

`up_to_date_hosts` was derived by subtraction:

```go
upToDateHosts := totalHosts - hostsNeedingUpdates
```

A host with no rows in `host_packages` is not in `hostsNeedingUpdates`, so the subtraction dropped it straight into "up to date". A host we have **never received any package data from** was being reported as healthy and fully patched.

That is the worst direction to be wrong in. On a dashboard whose job is to surface what needs attention, silence was being reported as good news.

## The change

"Up to date" now means *we hold package data for this host and none of it needs updating*. The remainder gets its own **Awaiting data** bucket instead of vanishing from every segment.

All six definitions move together, because the card, the chart segment and the list they link to disagreeing is exactly the failure mode here:

| # | Location | Change |
|---|---|---|
| 1 | `GetHostsWithCounts` | adds `total_packages_count > 0` |
| 2 | `GetHostsWithPageCounts` | adds an `EXISTS(host_packages)` guard |
| 3 | `CountHostsForList` | same |
| 4 | `GetDashboardStats` consumer | derives from new `hosts_with_package_data` |
| 5 | `GetHomepageStats` consumer | same, plus `awaiting_data_hosts` |
| 6 | `Hosts.jsx` client predicate | adds `host.totalPackagesCount > 0` |

Plus an `awaitingData` filter in all three list predicates, and in `validHostsListFilter`, **without which the new segment's click would 400**.

The chart segment is emitted only when the count is non-zero, so a fully-reported fleet does not carry a permanently empty slice leading to an empty list.

## Why "has package data" rather than `status = 'pending'`

`hosts.status` is the enrolment lifecycle column behind #874. It cannot distinguish an enrolled host whose package collection returned nothing from one reporting normally, and after this session's work it is the last column that should be trusted for anything but enrolment. Whether package data exists is the honest test and covers both cases.

Verified below that it does catch both.

## Verification

Local stack, three hosts: one reporting and clean, one reporting and needing an update, one never enrolled.

```
cards : totalHosts=3  upToDateHosts=1  hostsNeedingUpdates=1
chart : Up to date    count=1  filter=upToDate
        Needs updates count=1  filter=needsUpdates
        Not reporting count=0  filter=inactive
        Awaiting data count=1  filter=awaitingData
```

Before this change `upToDateHosts` was `3 - 1 = 2`, wrongly including the never-enrolled host.

Card and list agree, which is the property that matters:

```
filter=upToDate     -> total=1  ['reported-clean']
filter=awaitingData -> total=1  ['never-enrolled']
filter=needsUpdates -> total=1  ['reported-needs']
```

Widget matches the dashboard:

```
total_hosts=3 up_to_date_hosts=1 hosts_needing_updates=1 awaiting_data_hosts=1
```

Then the case a `status = 'pending'` definition would have missed. Flipping the third host to `active` with a fresh `last_update` but still zero packages, simulating a failed collector:

```
upToDateHosts=1   (stays 1, does not become 2)
awaitingData=1    list: ['never-enrolled']
```

`make check` clean, `npx biome check src/` clean, 189 frontend tests pass. The existing `dashboard_segments_test.go` explicitly pinned "a fourth segment cannot be added without a filter"; the new segment honours that contract and the tests are extended to cover it, including that it is hidden at zero.

## Numbers that move

**"Up to date" will drop on any instance with hosts that have never reported**, and those hosts reappear under "Awaiting data". Nothing is lost, it is recategorised, but users watching the figure will see it change, so it wants a release-note line rather than a silent fix.

---

## SQL performance

Measured, not assumed. Seeded fleet of **1000 hosts / 1.25M `host_packages` rows / 155k needing updates**. Timings are `EXPLAIN (ANALYZE)` at the `work_mem = 32MB` the dashboard actually runs with, alternating runs to cancel cache effects.

### The counter, two ways

The first cut asked for `COUNT(DISTINCT host_id)` over `host_packages`. That was a genuine regression:

| Form | Time | Plan |
|---|---|---|
| `COUNT(DISTINCT hp.host_id)` | **55.3 ms** | Index Only Scan, all 1,248,000 rows, 1313 disk reads |
| `EXISTS` semi-join | **2.5 ms** | Nested Loop Semi Join, 1000 probes, stops at first match |

The distinct-count scales with **package rows**; the semi-join scales with **host count**. Package rows grow roughly 1300x faster, so the wrong one gets worse fastest.

It is now folded into the `host_counts` CTE rather than added as a fourth scalar subquery, so it rides the scan of `hosts` already happening there (2.9 ms in that position, versus 2.5 ms standalone plus a second scan).

### End to end, against main

| Query | main | this branch | delta |
|---|---|---|---|
| `GetDashboardStats` | 11.7 – 13.5 ms | 13.8 – 14.4 ms | **+2.3 ms** |
| `GetHomepageStats` | 54.6 – 59.3 ms | 58.3 – 60.2 ms | within noise |

With the first formulation `GetDashboardStats` was 48 – 55 ms, so the rewrite removed about 94% of the cost this change added.

### The list predicates are not a cost

The extra `EXISTS` guard on the `upToDate` filter turned out **faster**, because the cheap semi-join prunes hosts before the anti-join runs:

```
old (no data guard):  8.5 ms
new (with guard):     5.3 ms
```

`GetHostsWithCounts` needed no subquery at all: `total_packages_count` was already computed in `enriched_hosts`, so the guard is a comparison on an existing column.

### Pre-existing, not changed here

`GetHomepageStats` is ~4x slower than `GetDashboardStats` for largely overlapping work, and it spills: `Sort Method: external sort  Disk: 3072kB`. It is the one stats query **not** wrapped in `withWorkMem`. Re-running it at 32MB removes the spill but only recovers ~7% at this size, since the 155k-row scan dominates rather than the sort. It would matter more on larger fleets. Left alone as out of scope; happy to raise it separately.

