### PR TITLE
perf(gethomepage): compute distinct counts by GROUP BY, not COUNT(DISTINCT)

### DIFF
--- a/server-source-code/internal/db/dashboard.sql.go
+++ b/server-source-code/internal/db/dashboard.sql.go
@@ -203,21 +203,41 @@ WITH host_counts AS (
     SELECT COUNT(*)::int AS total_hosts FROM hosts
 ),
 hosts_needing_updates AS (
-    SELECT COUNT(DISTINCT hp.host_id)::int AS cnt
-    FROM host_packages hp
-    WHERE hp.needs_update = true
+    SELECT COUNT(*)::int AS cnt FROM (
+        SELECT hp.host_id
+        FROM host_packages hp
+        WHERE hp.needs_update = true
+        GROUP BY hp.host_id
+    ) t
 ),
 hosts_with_security AS (
-    SELECT COUNT(DISTINCT hp.host_id)::int AS cnt
-    FROM host_packages hp
-    WHERE hp.needs_update = true AND hp.is_security_update = true
+    SELECT COUNT(*)::int AS cnt FROM (
+        SELECT hp.host_id
+        FROM host_packages hp
+        WHERE hp.needs_update = true AND hp.is_security_update = true
+        GROUP BY hp.host_id
+    ) t
 ),
 package_counts AS (
+    -- Split rather than one pass with FILTER: two passes each driven by their
+    -- own covering index beat one pass that can only use the wider of them.
     SELECT
-        COUNT(DISTINCT package_id)::int AS total_outdated,
-        COUNT(DISTINCT package_id) FILTER (WHERE is_security_update)::int AS security_updates
-    FROM host_packages
-    WHERE needs_update = true
+        COALESCE((
+            SELECT COUNT(*)::int FROM (
+                SELECT hp.package_id
+                FROM host_packages hp
+                WHERE hp.needs_update = true
+                GROUP BY hp.package_id
+            ) t
+        ), 0)::int AS total_outdated,
+        COALESCE((
+            SELECT COUNT(*)::int FROM (
+                SELECT hp.package_id
+                FROM host_packages hp
+                WHERE hp.needs_update = true AND hp.is_security_update = true
+                GROUP BY hp.package_id
+            ) t
+        ), 0)::int AS security_updates
 )
 SELECT
     hc.total_hosts,
@@ -249,6 +269,16 @@ type GetHomepageStatsRow struct {
 // that had been created but not yet enrolled. That filter also did not mean
 // what it appeared to: hosts.status is an enrolment lifecycle column and never
 // becomes 'inactive', so a host that stopped reporting was counted regardless.
+// Distinct counts are expressed as GROUP BY subqueries, not COUNT(DISTINCT),
+// and must stay that way. COUNT(DISTINCT) cannot stream: it sorts the whole
+// matching set, which at 3.7M host_packages rows spills multiple megabytes to
+// disk and costs ~3x what the identical aggregates cost in GetDashboardStats,
+// which already uses this shape. GROUP BY reads straight off the partial
+// covering indexes (idx_host_packages_needs_update_host_cover and the
+// _package / _security_package pair) and sorts nothing worth spilling.
+//
+// Exact, not approximate: the two forms differ only on NULL handling, and
+// host_id and package_id are both NOT NULL.
 func (q *Queries) GetHomepageStats(ctx context.Context, since pgtype.Timestamp) (GetHomepageStatsRow, error) {
 	row := q.db.QueryRow(ctx, getHomepageStats, since)
 	var i GetHomepageStatsRow

--- a/server-source-code/internal/db/querier.go
+++ b/server-source-code/internal/db/querier.go
@@ -279,6 +279,16 @@ type Querier interface {
 	// that had been created but not yet enrolled. That filter also did not mean
 	// what it appeared to: hosts.status is an enrolment lifecycle column and never
 	// becomes 'inactive', so a host that stopped reporting was counted regardless.
+	// Distinct counts are expressed as GROUP BY subqueries, not COUNT(DISTINCT),
+	// and must stay that way. COUNT(DISTINCT) cannot stream: it sorts the whole
+	// matching set, which at 3.7M host_packages rows spills multiple megabytes to
+	// disk and costs ~3x what the identical aggregates cost in GetDashboardStats,
+	// which already uses this shape. GROUP BY reads straight off the partial
+	// covering indexes (idx_host_packages_needs_update_host_cover and the
+	// _package / _security_package pair) and sorts nothing worth spilling.
+	//
+	// Exact, not approximate: the two forms differ only on NULL handling, and
+	// host_id and package_id are both NOT NULL.
 	GetHomepageStats(ctx context.Context, since pgtype.Timestamp) (GetHomepageStatsRow, error)
 	GetHostByApiID(ctx context.Context, apiID string) (Host, error)
 	GetHostByID(ctx context.Context, id string) (Host, error)

--- a/server-source-code/internal/sqlc/queries/dashboard.sql
+++ b/server-source-code/internal/sqlc/queries/dashboard.sql
@@ -521,22 +521,52 @@ ORDER BY friendly_name ASC;
 WITH host_counts AS (
     SELECT COUNT(*)::int AS total_hosts FROM hosts
 ),
+-- Distinct counts are expressed as GROUP BY subqueries, not COUNT(DISTINCT),
+-- and must stay that way. COUNT(DISTINCT) cannot stream: it sorts the whole
+-- matching set, which at 3.7M host_packages rows spills multiple megabytes to
+-- disk and costs ~3x what the identical aggregates cost in GetDashboardStats,
+-- which already uses this shape. GROUP BY reads straight off the partial
+-- covering indexes (idx_host_packages_needs_update_host_cover and the
+-- _package / _security_package pair) and sorts nothing worth spilling.
+--
+-- Exact, not approximate: the two forms differ only on NULL handling, and
+-- host_id and package_id are both NOT NULL.
 hosts_needing_updates AS (
-    SELECT COUNT(DISTINCT hp.host_id)::int AS cnt
-    FROM host_packages hp
-    WHERE hp.needs_update = true
+    SELECT COUNT(*)::int AS cnt FROM (
+        SELECT hp.host_id
+        FROM host_packages hp
+        WHERE hp.needs_update = true
+        GROUP BY hp.host_id
+    ) t
 ),
 hosts_with_security AS (
-    SELECT COUNT(DISTINCT hp.host_id)::int AS cnt
-    FROM host_packages hp
-    WHERE hp.needs_update = true AND hp.is_security_update = true
+    SELECT COUNT(*)::int AS cnt FROM (
+        SELECT hp.host_id
+        FROM host_packages hp
+        WHERE hp.needs_update = true AND hp.is_security_update = true
+        GROUP BY hp.host_id
+    ) t
 ),
 package_counts AS (
+    -- Split rather than one pass with FILTER: two passes each driven by their
+    -- own covering index beat one pass that can only use the wider of them.
     SELECT
-        COUNT(DISTINCT package_id)::int AS total_outdated,
-        COUNT(DISTINCT package_id) FILTER (WHERE is_security_update)::int AS security_updates
-    FROM host_packages
-    WHERE needs_update = true
+        COALESCE((
+            SELECT COUNT(*)::int FROM (
+                SELECT hp.package_id
+                FROM host_packages hp
+                WHERE hp.needs_update = true
+                GROUP BY hp.package_id
+            ) t
+        ), 0)::int AS total_outdated,
+        COALESCE((
+            SELECT COUNT(*)::int FROM (
+                SELECT hp.package_id
+                FROM host_packages hp
+                WHERE hp.needs_update = true AND hp.is_security_update = true
+                GROUP BY hp.package_id
+            ) t
+        ), 0)::int AS security_updates
 )
 SELECT
     hc.total_hosts,


### PR DESCRIPTION
Fixes #1034

## The problem

`GetHomepageStats` computed four distinct counts with `COUNT(DISTINCT ...)`. That cannot stream: Postgres sorts the whole matching set. `GetDashboardStats` was moved to `GROUP BY` subqueries at some point, which read straight off the partial covering indexes, but the widget query never got the same treatment. Two queries, nearly the same aggregates over the same table, very different cost.

Measured on a seeded fleet of **3000 hosts / 3.74M `host_packages` rows / 467k needing updates**:

| | Time | Sorts |
|---|---|---|
| `GetHomepageStats` before | **~277 ms** | two external sorts, spilling 6.2 MB and 9.2 MB |
| `GetHomepageStats` after | **~30 ms** | none |
| `GetDashboardStats` for reference | ~83 ms | in-memory, 97 kB |

**About 9x faster**, and the widget is no longer the most expensive stats query in the app.

## Why not just raise work_mem

That was my first instinct, since this is the one stats query not wrapped in `withWorkMem`. It is the wrong fix on two counts:

- It only recovers the spill, leaving roughly 237 ms on the table. The sort was a symptom.
- It adds a `BEGIN` / `SET LOCAL` / `COMMIT` round trip to a frequently polled endpoint, which is a genuine cost when the database sits behind a proxy rather than a local socket.

Fixing the plan shape removes the spill as a side effect, so no bump is needed at all.

The spill was also worsening faster than the fleet grows, which is what made this worth doing now rather than later:

| Fleet | Default `work_mem` | With 32 MB | Spill cost |
|---|---|---|---|
| 1000 hosts / 1.25M rows | 57 ms | 54 ms | 4 ms |
| 3000 hosts / 3.74M rows | 277 ms | 237 ms | 40 ms |

## Correctness

This is a plan change, not a semantics change, and the two queries must keep agreeing: making them disagree was #1026, fixed recently.

Verified against main on identical data:

```
OLD (main):    3000|2880|162|40|2880|0|0
NEW (rewrite): 3000|2880|162|40|2880|0|0
```

And on an empty database, where aggregate rewrites most often diverge:

```
OLD on empty db: 0|0|0|0|0|0|0
NEW on empty db: 0|0|0|0|0|0|0
```

`COUNT(DISTINCT x)` and `COUNT(*) FROM (SELECT x ... GROUP BY x)` differ only on NULL handling. `host_id` and `package_id` are both `NOT NULL`, so the rewrite is exact rather than approximate.

`make check` clean.

## Note on the split in package_counts

The two package aggregates were one pass using `FILTER`; they are now two subqueries. That looks like more work and is less, because each can then be driven by its own covering index (`idx_host_packages_needs_update_package` and `idx_host_packages_needs_update_security_package`) instead of one pass constrained to the wider of the two. This mirrors what `GetDashboardStats` already does.

## Relationship to #1033

Independent. Both touch `GetHomepageStats` but in different CTEs, and they merge cleanly in either order (verified with `git merge-tree`: zero conflicts).
