### PR TITLE
fix(dashboard): correct and speed up the host stats queries

### DIFF
--- a/frontend/src/pages/Hosts.jsx
+++ b/frontend/src/pages/Hosts.jsx
@@ -235,6 +235,10 @@ const Hosts = () => {
 					setShowFilters(true);
 					setStatusFilter("reporting");
 					break;
+				case "awaitingData":
+					setShowFilters(true);
+					setStatusFilter("all");
+					break;
 				default:
 					break;
 			}
@@ -910,7 +914,13 @@ const Hosts = () => {
 					(host.updatesCount && host.updatesCount > 0)) &&
 				(filter !== "inactive" ||
 					(host.effectiveStatus || host.status) === "inactive") &&
-				(filter !== "upToDate" || (!host.isStale && host.updatesCount === 0)) &&
+				// "Up to date" requires package data: a host we have never received
+				// packages from is unknown, not healthy. Mirrors the server predicate.
+				(filter !== "upToDate" ||
+					(!host.isStale &&
+						host.totalPackagesCount > 0 &&
+						host.updatesCount === 0)) &&
+				(filter !== "awaitingData" || !host.totalPackagesCount) &&
 				(filter !== "stale" || host.isStale) &&
 				(filter !== "selected" ||
 					(selectedIds &&

--- a/server-source-code/internal/db/dashboard.sql.go
+++ b/server-source-code/internal/db/dashboard.sql.go
@@ -229,21 +229,41 @@ WITH host_counts AS (
     FROM hosts
 ),
 hosts_needing_updates AS (
-    SELECT COUNT(DISTINCT hp.host_id)::int AS cnt
-    FROM host_packages hp
-    WHERE hp.needs_update = true
+    SELECT COUNT(*)::int AS cnt FROM (
+        SELECT hp.host_id
+        FROM host_packages hp
+        WHERE hp.needs_update = true
+        GROUP BY hp.host_id
+    ) t
 ),
 hosts_with_security AS (
-    SELECT COUNT(DISTINCT hp.host_id)::int AS cnt
-    FROM host_packages hp
-    WHERE hp.needs_update = true AND hp.is_security_update = true
+    SELECT COUNT(*)::int AS cnt FROM (
+        SELECT hp.host_id
+        FROM host_packages hp
+        WHERE hp.needs_update = true AND hp.is_security_update = true
+        GROUP BY hp.host_id
+    ) t
 ),
 package_counts AS (
+    -- Split rather than one pass with FILTER: two passes each driven by their
+    -- own covering index beat one pass that can only use the wider of them.
     SELECT
-        COUNT(DISTINCT package_id)::int AS total_outdated,
-        COUNT(DISTINCT package_id) FILTER (WHERE is_security_update)::int AS security_updates
-    FROM host_packages
-    WHERE needs_update = true
+        COALESCE((
+            SELECT COUNT(*)::int FROM (
+                SELECT hp.package_id
+                FROM host_packages hp
+                WHERE hp.needs_update = true
+                GROUP BY hp.package_id
+            ) t
+        ), 0)::int AS total_outdated,
+        COALESCE((
+            SELECT COUNT(*)::int FROM (
+                SELECT hp.package_id
+                FROM host_packages hp
+                WHERE hp.needs_update = true AND hp.is_security_update = true
+                GROUP BY hp.package_id
+            ) t
+        ), 0)::int AS security_updates
 )
 SELECT
     hc.total_hosts,
@@ -277,6 +297,16 @@ type GetHomepageStatsRow struct {
 // that had been created but not yet enrolled. That filter also did not mean
 // what it appeared to: hosts.status is an enrolment lifecycle column and never
 // becomes 'inactive', so a host that stopped reporting was counted regardless.
+// Distinct counts are expressed as GROUP BY subqueries, not COUNT(DISTINCT),
+// and must stay that way. COUNT(DISTINCT) cannot stream: it sorts the whole
+// matching set, which at 3.7M host_packages rows spills multiple megabytes to
+// disk and costs ~3x what the identical aggregates cost in GetDashboardStats,
+// which already uses this shape. GROUP BY reads straight off the partial
+// covering indexes (idx_host_packages_needs_update_host_cover and the
+// _package / _security_package pair) and sorts nothing worth spilling.
+//
+// Exact, not approximate: the two forms differ only on NULL handling, and
+// host_id and package_id are both NOT NULL.
 func (q *Queries) GetHomepageStats(ctx context.Context, since pgtype.Timestamp) (GetHomepageStatsRow, error) {
 	row := q.db.QueryRow(ctx, getHomepageStats, since)
 	var i GetHomepageStatsRow

--- a/server-source-code/internal/db/dashboard.sql.go
+++ b/server-source-code/internal/db/dashboard.sql.go
@@ -47,8 +47,13 @@ WHERE (
         SELECT 1 FROM host_packages hp WHERE hp.host_id = filtered_hosts.id AND hp.needs_update
     ))
     OR ($1 = 'inactive' AND effective_status = 'inactive')
-    OR ($1 = 'upToDate' AND is_stale = false AND NOT EXISTS (
+    OR ($1 = 'upToDate' AND is_stale = false AND EXISTS (
+        SELECT 1 FROM host_packages hp WHERE hp.host_id = filtered_hosts.id
+    ) AND NOT EXISTS (
         SELECT 1 FROM host_packages hp WHERE hp.host_id = filtered_hosts.id AND hp.needs_update
+    ))
+    OR ($1 = 'awaitingData' AND NOT EXISTS (
+        SELECT 1 FROM host_packages hp WHERE hp.host_id = filtered_hosts.id
     ))
     OR ($1 = 'stale' AND is_stale = true)
     OR ($1 = 'selected')
@@ -145,7 +150,13 @@ hp_package_counts AS (
                 WHERE hp.needs_update = true AND hp.is_security_update = true
                 GROUP BY hp.package_id
             ) security_packages
-        ), 0)::int AS security_updates
+        ), 0)::int AS security_updates,
+        -- Hosts we have actually received packages from. "Up to date" is
+        -- derived from this, not from total_hosts, so a host we know nothing
+        -- about is never reported as healthy.
+        COALESCE((
+            SELECT COUNT(DISTINCT hp.host_id)::int FROM host_packages hp
+        ), 0)::int AS hosts_with_package_data
 )
 SELECT
     hc.total_hosts,
@@ -157,7 +168,8 @@ SELECT
     hc.hosts_needing_reboot,
     (SELECT COUNT(*)::int FROM host_groups),
     (SELECT COUNT(*)::int FROM users),
-    (SELECT COUNT(*)::int FROM repositories)
+    (SELECT COUNT(*)::int FROM repositories),
+    hpc.hosts_with_package_data
 FROM host_counts hc
 CROSS JOIN hp_package_counts hpc
 `
@@ -178,6 +190,7 @@ type GetDashboardStatsRow struct {
 	Column8               int32 `json:"column_8"`
 	Column9               int32 `json:"column_9"`
 	Column10              int32 `json:"column_10"`
+	HostsWithPackageData  int32 `json:"hosts_with_package_data"`
 }
 
 func (q *Queries) GetDashboardStats(ctx context.Context, arg GetDashboardStatsParams) (GetDashboardStatsRow, error) {
@@ -194,6 +207,7 @@ func (q *Queries) GetDashboardStats(ctx context.Context, arg GetDashboardStatsPa
 		&i.Column8,
 		&i.Column9,
 		&i.Column10,
+		&i.HostsWithPackageData,
 	)
 	return i, err
 }
@@ -218,6 +232,9 @@ package_counts AS (
         COUNT(DISTINCT package_id) FILTER (WHERE is_security_update)::int AS security_updates
     FROM host_packages
     WHERE needs_update = true
+),
+hosts_with_data AS (
+    SELECT COUNT(DISTINCT host_id)::int AS cnt FROM host_packages
 )
 SELECT
     hc.total_hosts,
@@ -226,11 +243,13 @@ SELECT
     pc.security_updates AS security_updates,
     hws.cnt AS hosts_with_security_updates,
     (SELECT COUNT(*)::int FROM repositories WHERE is_active = true) AS total_repos,
-    (SELECT COUNT(*)::int FROM update_history WHERE timestamp >= $1 AND status = 'success' AND report_type IN ('full', 'partial')) AS recent_updates_24h
+    (SELECT COUNT(*)::int FROM update_history WHERE timestamp >= $1 AND status = 'success' AND report_type IN ('full', 'partial')) AS recent_updates_24h,
+    hwd.cnt AS hosts_with_package_data
 FROM host_counts hc
 CROSS JOIN hosts_needing_updates hnu
 CROSS JOIN hosts_with_security hws
 CROSS JOIN package_counts pc
+CROSS JOIN hosts_with_data hwd
 `
 
 type GetHomepageStatsRow struct {
@@ -241,6 +260,7 @@ type GetHomepageStatsRow struct {
 	HostsWithSecurityUpdates int32 `json:"hosts_with_security_updates"`
 	TotalRepos               int32 `json:"total_repos"`
 	RecentUpdates24h         int32 `json:"recent_updates_24h"`
+	HostsWithPackageData     int32 `json:"hosts_with_package_data"`
 }
 
 // The host counters here must match GetDashboardStats, otherwise a widget and
@@ -260,6 +280,7 @@ func (q *Queries) GetHomepageStats(ctx context.Context, since pgtype.Timestamp) 
 		&i.HostsWithSecurityUpdates,
 		&i.TotalRepos,
 		&i.RecentUpdates24h,
+		&i.HostsWithPackageData,
 	)
 	return i, err
 }
@@ -538,7 +559,10 @@ filtered_hosts AS (
         $10::text IS NULL
         OR ($10 = 'needsUpdates' AND updates_count > 0)
         OR ($10 = 'inactive' AND effective_status = 'inactive')
-        OR ($10 = 'upToDate' AND is_stale = false AND updates_count = 0)
+        -- "Up to date" requires package data. A host we have never received
+        -- packages from is not healthy, it is unknown: see filter 'awaitingData'.
+        OR ($10 = 'upToDate' AND is_stale = false AND total_packages_count > 0 AND updates_count = 0)
+        OR ($10 = 'awaitingData' AND total_packages_count = 0)
         OR ($10 = 'stale' AND is_stale = true)
         OR ($10 = 'selected')
     )
@@ -758,8 +782,13 @@ filtered_hosts AS (
             SELECT 1 FROM host_packages hp WHERE hp.host_id = bh.id AND hp.needs_update
         ))
         OR ($10 = 'inactive' AND bh.effective_status = 'inactive')
-        OR ($10 = 'upToDate' AND bh.is_stale = false AND NOT EXISTS (
+        OR ($10 = 'upToDate' AND bh.is_stale = false AND EXISTS (
+            SELECT 1 FROM host_packages hp WHERE hp.host_id = bh.id
+        ) AND NOT EXISTS (
             SELECT 1 FROM host_packages hp WHERE hp.host_id = bh.id AND hp.needs_update
+        ))
+        OR ($10 = 'awaitingData' AND NOT EXISTS (
+            SELECT 1 FROM host_packages hp WHERE hp.host_id = bh.id
         ))
         OR ($10 = 'stale' AND bh.is_stale = true)
         OR ($10 = 'selected')

--- a/server-source-code/internal/db/dashboard.sql.go
+++ b/server-source-code/internal/db/dashboard.sql.go
@@ -119,7 +119,19 @@ WITH host_counts AS (
         -- links to disagree.
         COUNT(*) FILTER (WHERE (status = 'active' AND last_update < $1) OR status = 'inactive')::int AS errored_hosts,
         COUNT(*) FILTER (WHERE status = 'active' AND last_update < $2)::int AS offline_hosts,
-        COUNT(*) FILTER (WHERE needs_reboot = true)::int AS hosts_needing_reboot
+        COUNT(*) FILTER (WHERE needs_reboot = true)::int AS hosts_needing_reboot,
+        -- Hosts we have actually received packages from. "Up to date" is
+        -- derived from this, not from total_hosts, so a host we know nothing
+        -- about is never reported as healthy.
+        --
+        -- An EXISTS semi-join, not COUNT(DISTINCT host_id) over host_packages:
+        -- the latter reads every row in the table (1.25M at 1k hosts, 55 ms)
+        -- to rediscover something 1000 index probes answer in 2 ms, and it
+        -- scales with package rows rather than host count. It also rides the
+        -- scan of hosts this CTE is already doing.
+        COUNT(*) FILTER (WHERE EXISTS (
+            SELECT 1 FROM host_packages hp WHERE hp.host_id = hosts.id
+        ))::int AS hosts_with_package_data
     FROM hosts
 ),
 hp_package_counts AS (
@@ -150,13 +162,7 @@ hp_package_counts AS (
                 WHERE hp.needs_update = true AND hp.is_security_update = true
                 GROUP BY hp.package_id
             ) security_packages
-        ), 0)::int AS security_updates,
-        -- Hosts we have actually received packages from. "Up to date" is
-        -- derived from this, not from total_hosts, so a host we know nothing
-        -- about is never reported as healthy.
-        COALESCE((
-            SELECT COUNT(DISTINCT hp.host_id)::int FROM host_packages hp
-        ), 0)::int AS hosts_with_package_data
+        ), 0)::int AS security_updates
 )
 SELECT
     hc.total_hosts,
@@ -169,7 +175,7 @@ SELECT
     (SELECT COUNT(*)::int FROM host_groups),
     (SELECT COUNT(*)::int FROM users),
     (SELECT COUNT(*)::int FROM repositories),
-    hpc.hosts_with_package_data
+    hc.hosts_with_package_data
 FROM host_counts hc
 CROSS JOIN hp_package_counts hpc
 `
@@ -214,7 +220,13 @@ func (q *Queries) GetDashboardStats(ctx context.Context, arg GetDashboardStatsPa
 
 const getHomepageStats = `-- name: GetHomepageStats :one
 WITH host_counts AS (
-    SELECT COUNT(*)::int AS total_hosts FROM hosts
+    SELECT COUNT(*)::int AS total_hosts,
+           -- See GetDashboardStats: semi-join, not COUNT(DISTINCT), and it
+           -- rides the scan of ` + "`" + `hosts` + "`" + ` already happening here.
+           COUNT(*) FILTER (WHERE EXISTS (
+               SELECT 1 FROM host_packages hp WHERE hp.host_id = hosts.id
+           ))::int AS hosts_with_package_data
+    FROM hosts
 ),
 hosts_needing_updates AS (
     SELECT COUNT(DISTINCT hp.host_id)::int AS cnt
@@ -232,9 +244,6 @@ package_counts AS (
         COUNT(DISTINCT package_id) FILTER (WHERE is_security_update)::int AS security_updates
     FROM host_packages
     WHERE needs_update = true
-),
-hosts_with_data AS (
-    SELECT COUNT(DISTINCT host_id)::int AS cnt FROM host_packages
 )
 SELECT
     hc.total_hosts,
@@ -244,12 +253,11 @@ SELECT
     hws.cnt AS hosts_with_security_updates,
     (SELECT COUNT(*)::int FROM repositories WHERE is_active = true) AS total_repos,
     (SELECT COUNT(*)::int FROM update_history WHERE timestamp >= $1 AND status = 'success' AND report_type IN ('full', 'partial')) AS recent_updates_24h,
-    hwd.cnt AS hosts_with_package_data
+    hc.hosts_with_package_data
 FROM host_counts hc
 CROSS JOIN hosts_needing_updates hnu
 CROSS JOIN hosts_with_security hws
 CROSS JOIN package_counts pc
-CROSS JOIN hosts_with_data hwd
 `
 
 type GetHomepageStatsRow struct {

--- a/server-source-code/internal/db/querier.go
+++ b/server-source-code/internal/db/querier.go
@@ -279,6 +279,16 @@ type Querier interface {
 	// that had been created but not yet enrolled. That filter also did not mean
 	// what it appeared to: hosts.status is an enrolment lifecycle column and never
 	// becomes 'inactive', so a host that stopped reporting was counted regardless.
+	// Distinct counts are expressed as GROUP BY subqueries, not COUNT(DISTINCT),
+	// and must stay that way. COUNT(DISTINCT) cannot stream: it sorts the whole
+	// matching set, which at 3.7M host_packages rows spills multiple megabytes to
+	// disk and costs ~3x what the identical aggregates cost in GetDashboardStats,
+	// which already uses this shape. GROUP BY reads straight off the partial
+	// covering indexes (idx_host_packages_needs_update_host_cover and the
+	// _package / _security_package pair) and sorts nothing worth spilling.
+	//
+	// Exact, not approximate: the two forms differ only on NULL handling, and
+	// host_id and package_id are both NOT NULL.
 	GetHomepageStats(ctx context.Context, since pgtype.Timestamp) (GetHomepageStatsRow, error)
 	GetHostByApiID(ctx context.Context, apiID string) (Host, error)
 	GetHostByID(ctx context.Context, id string) (Host, error)

--- a/server-source-code/internal/handler/dashboard.go
+++ b/server-source-code/internal/handler/dashboard.go
@@ -95,7 +95,7 @@ func parseCSVQuery(value string, maxItems int) ([]string, bool) {
 
 func validHostsListFilter(filter string) bool {
 	switch filter {
-	case "", "needsUpdates", "inactive", "upToDate", "stale", "selected", "offline":
+	case "", "needsUpdates", "inactive", "upToDate", "awaitingData", "stale", "selected", "offline":
 		return true
 	default:
 		return false

--- a/server-source-code/internal/sqlc/queries/dashboard.sql
+++ b/server-source-code/internal/sqlc/queries/dashboard.sql
@@ -7,7 +7,19 @@ WITH host_counts AS (
         -- links to disagree.
         COUNT(*) FILTER (WHERE (status = 'active' AND last_update < $1) OR status = 'inactive')::int AS errored_hosts,
         COUNT(*) FILTER (WHERE status = 'active' AND last_update < $2)::int AS offline_hosts,
-        COUNT(*) FILTER (WHERE needs_reboot = true)::int AS hosts_needing_reboot
+        COUNT(*) FILTER (WHERE needs_reboot = true)::int AS hosts_needing_reboot,
+        -- Hosts we have actually received packages from. "Up to date" is
+        -- derived from this, not from total_hosts, so a host we know nothing
+        -- about is never reported as healthy.
+        --
+        -- An EXISTS semi-join, not COUNT(DISTINCT host_id) over host_packages:
+        -- the latter reads every row in the table (1.25M at 1k hosts, 55 ms)
+        -- to rediscover something 1000 index probes answer in 2 ms, and it
+        -- scales with package rows rather than host count. It also rides the
+        -- scan of hosts this CTE is already doing.
+        COUNT(*) FILTER (WHERE EXISTS (
+            SELECT 1 FROM host_packages hp WHERE hp.host_id = hosts.id
+        ))::int AS hosts_with_package_data
     FROM hosts
 ),
 hp_package_counts AS (
@@ -38,13 +50,7 @@ hp_package_counts AS (
                 WHERE hp.needs_update = true AND hp.is_security_update = true
                 GROUP BY hp.package_id
             ) security_packages
-        ), 0)::int AS security_updates,
-        -- Hosts we have actually received packages from. "Up to date" is
-        -- derived from this, not from total_hosts, so a host we know nothing
-        -- about is never reported as healthy.
-        COALESCE((
-            SELECT COUNT(DISTINCT hp.host_id)::int FROM host_packages hp
-        ), 0)::int AS hosts_with_package_data
+        ), 0)::int AS security_updates
 )
 SELECT
     hc.total_hosts,
@@ -57,7 +63,7 @@ SELECT
     (SELECT COUNT(*)::int FROM host_groups),
     (SELECT COUNT(*)::int FROM users),
     (SELECT COUNT(*)::int FROM repositories),
-    hpc.hosts_with_package_data
+    hc.hosts_with_package_data
 FROM host_counts hc
 CROSS JOIN hp_package_counts hpc;
 
@@ -539,7 +545,13 @@ ORDER BY friendly_name ASC;
 -- what it appeared to: hosts.status is an enrolment lifecycle column and never
 -- becomes 'inactive', so a host that stopped reporting was counted regardless.
 WITH host_counts AS (
-    SELECT COUNT(*)::int AS total_hosts FROM hosts
+    SELECT COUNT(*)::int AS total_hosts,
+           -- See GetDashboardStats: semi-join, not COUNT(DISTINCT), and it
+           -- rides the scan of `hosts` already happening here.
+           COUNT(*) FILTER (WHERE EXISTS (
+               SELECT 1 FROM host_packages hp WHERE hp.host_id = hosts.id
+           ))::int AS hosts_with_package_data
+    FROM hosts
 ),
 hosts_needing_updates AS (
     SELECT COUNT(DISTINCT hp.host_id)::int AS cnt
@@ -557,9 +569,6 @@ package_counts AS (
         COUNT(DISTINCT package_id) FILTER (WHERE is_security_update)::int AS security_updates
     FROM host_packages
     WHERE needs_update = true
-),
-hosts_with_data AS (
-    SELECT COUNT(DISTINCT host_id)::int AS cnt FROM host_packages
 )
 SELECT
     hc.total_hosts,
@@ -569,10 +578,9 @@ SELECT
     hws.cnt AS hosts_with_security_updates,
     (SELECT COUNT(*)::int FROM repositories WHERE is_active = true) AS total_repos,
     (SELECT COUNT(*)::int FROM update_history WHERE timestamp >= sqlc.arg('since') AND status = 'success' AND report_type IN ('full', 'partial')) AS recent_updates_24h,
-    hwd.cnt AS hosts_with_package_data
+    hc.hosts_with_package_data
 FROM host_counts hc
 CROSS JOIN hosts_needing_updates hnu
 CROSS JOIN hosts_with_security hws
-CROSS JOIN package_counts pc
-CROSS JOIN hosts_with_data hwd;
+CROSS JOIN package_counts pc;
 

--- a/server-source-code/internal/sqlc/queries/dashboard.sql
+++ b/server-source-code/internal/sqlc/queries/dashboard.sql
@@ -553,22 +553,52 @@ WITH host_counts AS (
            ))::int AS hosts_with_package_data
     FROM hosts
 ),
+-- Distinct counts are expressed as GROUP BY subqueries, not COUNT(DISTINCT),
+-- and must stay that way. COUNT(DISTINCT) cannot stream: it sorts the whole
+-- matching set, which at 3.7M host_packages rows spills multiple megabytes to
+-- disk and costs ~3x what the identical aggregates cost in GetDashboardStats,
+-- which already uses this shape. GROUP BY reads straight off the partial
+-- covering indexes (idx_host_packages_needs_update_host_cover and the
+-- _package / _security_package pair) and sorts nothing worth spilling.
+--
+-- Exact, not approximate: the two forms differ only on NULL handling, and
+-- host_id and package_id are both NOT NULL.
 hosts_needing_updates AS (
-    SELECT COUNT(DISTINCT hp.host_id)::int AS cnt
-    FROM host_packages hp
-    WHERE hp.needs_update = true
+    SELECT COUNT(*)::int AS cnt FROM (
+        SELECT hp.host_id
+        FROM host_packages hp
+        WHERE hp.needs_update = true
+        GROUP BY hp.host_id
+    ) t
 ),
 hosts_with_security AS (
-    SELECT COUNT(DISTINCT hp.host_id)::int AS cnt
-    FROM host_packages hp
-    WHERE hp.needs_update = true AND hp.is_security_update = true
+    SELECT COUNT(*)::int AS cnt FROM (
+        SELECT hp.host_id
+        FROM host_packages hp
+        WHERE hp.needs_update = true AND hp.is_security_update = true
+        GROUP BY hp.host_id
+    ) t
 ),
 package_counts AS (
+    -- Split rather than one pass with FILTER: two passes each driven by their
+    -- own covering index beat one pass that can only use the wider of them.
     SELECT
-        COUNT(DISTINCT package_id)::int AS total_outdated,
-        COUNT(DISTINCT package_id) FILTER (WHERE is_security_update)::int AS security_updates
-    FROM host_packages
-    WHERE needs_update = true
+        COALESCE((
+            SELECT COUNT(*)::int FROM (
+                SELECT hp.package_id
+                FROM host_packages hp
+                WHERE hp.needs_update = true
+                GROUP BY hp.package_id
+            ) t
+        ), 0)::int AS total_outdated,
+        COALESCE((
+            SELECT COUNT(*)::int FROM (
+                SELECT hp.package_id
+                FROM host_packages hp
+                WHERE hp.needs_update = true AND hp.is_security_update = true
+                GROUP BY hp.package_id
+            ) t
+        ), 0)::int AS security_updates
 )
 SELECT
     hc.total_hosts,

--- a/server-source-code/internal/sqlc/queries/dashboard.sql
+++ b/server-source-code/internal/sqlc/queries/dashboard.sql
@@ -38,7 +38,13 @@ hp_package_counts AS (
                 WHERE hp.needs_update = true AND hp.is_security_update = true
                 GROUP BY hp.package_id
             ) security_packages
-        ), 0)::int AS security_updates
+        ), 0)::int AS security_updates,
+        -- Hosts we have actually received packages from. "Up to date" is
+        -- derived from this, not from total_hosts, so a host we know nothing
+        -- about is never reported as healthy.
+        COALESCE((
+            SELECT COUNT(DISTINCT hp.host_id)::int FROM host_packages hp
+        ), 0)::int AS hosts_with_package_data
 )
 SELECT
     hc.total_hosts,
@@ -50,7 +56,8 @@ SELECT
     hc.hosts_needing_reboot,
     (SELECT COUNT(*)::int FROM host_groups),
     (SELECT COUNT(*)::int FROM users),
-    (SELECT COUNT(*)::int FROM repositories)
+    (SELECT COUNT(*)::int FROM repositories),
+    hpc.hosts_with_package_data
 FROM host_counts hc
 CROSS JOIN hp_package_counts hpc;
 
@@ -139,7 +146,10 @@ filtered_hosts AS (
         sqlc.narg('filter')::text IS NULL
         OR (sqlc.narg('filter') = 'needsUpdates' AND updates_count > 0)
         OR (sqlc.narg('filter') = 'inactive' AND effective_status = 'inactive')
-        OR (sqlc.narg('filter') = 'upToDate' AND is_stale = false AND updates_count = 0)
+        -- "Up to date" requires package data. A host we have never received
+        -- packages from is not healthy, it is unknown: see filter 'awaitingData'.
+        OR (sqlc.narg('filter') = 'upToDate' AND is_stale = false AND total_packages_count > 0 AND updates_count = 0)
+        OR (sqlc.narg('filter') = 'awaitingData' AND total_packages_count = 0)
         OR (sqlc.narg('filter') = 'stale' AND is_stale = true)
         OR (sqlc.narg('filter') = 'selected')
     )
@@ -247,8 +257,13 @@ filtered_hosts AS (
             SELECT 1 FROM host_packages hp WHERE hp.host_id = bh.id AND hp.needs_update
         ))
         OR (sqlc.narg('filter') = 'inactive' AND bh.effective_status = 'inactive')
-        OR (sqlc.narg('filter') = 'upToDate' AND bh.is_stale = false AND NOT EXISTS (
+        OR (sqlc.narg('filter') = 'upToDate' AND bh.is_stale = false AND EXISTS (
+            SELECT 1 FROM host_packages hp WHERE hp.host_id = bh.id
+        ) AND NOT EXISTS (
             SELECT 1 FROM host_packages hp WHERE hp.host_id = bh.id AND hp.needs_update
+        ))
+        OR (sqlc.narg('filter') = 'awaitingData' AND NOT EXISTS (
+            SELECT 1 FROM host_packages hp WHERE hp.host_id = bh.id
         ))
         OR (sqlc.narg('filter') = 'stale' AND bh.is_stale = true)
         OR (sqlc.narg('filter') = 'selected')
@@ -391,8 +406,13 @@ WHERE (
         SELECT 1 FROM host_packages hp WHERE hp.host_id = filtered_hosts.id AND hp.needs_update
     ))
     OR (sqlc.narg('filter') = 'inactive' AND effective_status = 'inactive')
-    OR (sqlc.narg('filter') = 'upToDate' AND is_stale = false AND NOT EXISTS (
+    OR (sqlc.narg('filter') = 'upToDate' AND is_stale = false AND EXISTS (
+        SELECT 1 FROM host_packages hp WHERE hp.host_id = filtered_hosts.id
+    ) AND NOT EXISTS (
         SELECT 1 FROM host_packages hp WHERE hp.host_id = filtered_hosts.id AND hp.needs_update
+    ))
+    OR (sqlc.narg('filter') = 'awaitingData' AND NOT EXISTS (
+        SELECT 1 FROM host_packages hp WHERE hp.host_id = filtered_hosts.id
     ))
     OR (sqlc.narg('filter') = 'stale' AND is_stale = true)
     OR (sqlc.narg('filter') = 'selected')
@@ -537,6 +557,9 @@ package_counts AS (
         COUNT(DISTINCT package_id) FILTER (WHERE is_security_update)::int AS security_updates
     FROM host_packages
     WHERE needs_update = true
+),
+hosts_with_data AS (
+    SELECT COUNT(DISTINCT host_id)::int AS cnt FROM host_packages
 )
 SELECT
     hc.total_hosts,
@@ -545,9 +568,11 @@ SELECT
     pc.security_updates AS security_updates,
     hws.cnt AS hosts_with_security_updates,
     (SELECT COUNT(*)::int FROM repositories WHERE is_active = true) AS total_repos,
-    (SELECT COUNT(*)::int FROM update_history WHERE timestamp >= sqlc.arg('since') AND status = 'success' AND report_type IN ('full', 'partial')) AS recent_updates_24h
+    (SELECT COUNT(*)::int FROM update_history WHERE timestamp >= sqlc.arg('since') AND status = 'success' AND report_type IN ('full', 'partial')) AS recent_updates_24h,
+    hwd.cnt AS hosts_with_package_data
 FROM host_counts hc
 CROSS JOIN hosts_needing_updates hnu
 CROSS JOIN hosts_with_security hws
-CROSS JOIN package_counts pc;
+CROSS JOIN package_counts pc
+CROSS JOIN hosts_with_data hwd;
 

--- a/server-source-code/internal/store/dashboard.go
+++ b/server-source-code/internal/store/dashboard.go
@@ -46,12 +46,18 @@ func (s *DashboardStore) withWorkMem(ctx context.Context, fn func(q *db.Queries)
 // Whether the last job succeeded does not enter into it, so a host that patched
 // cleanly and then stopped checking in belongs here, while one whose run failed
 // but is still reporting does not.
-func updateStatusSegments(upToDate, needsUpdates, notReporting int) []map[string]interface{} {
-	return []map[string]interface{}{
+func updateStatusSegments(upToDate, needsUpdates, notReporting, awaitingData int) []map[string]interface{} {
+	segments := []map[string]interface{}{
 		{"name": "Up to date", "filter": "upToDate", "count": upToDate},
 		{"name": "Needs updates", "filter": "needsUpdates", "count": needsUpdates},
 		{"name": "Not reporting", "filter": "inactive", "count": notReporting},
 	}
+	// Only surfaced when it applies. A fleet where every host has reported
+	// should not carry a permanent empty segment.
+	if awaitingData > 0 {
+		segments = append(segments, map[string]interface{}{"name": "Awaiting data", "filter": "awaitingData", "count": awaitingData})
+	}
+	return segments
 }
 
 // GetStats returns dashboard statistics matching Node backend structure for frontend compatibility.
@@ -120,9 +126,16 @@ func (s *DashboardStore) GetStats(ctx context.Context) (map[string]interface{}, 
 	totalUsers := int(stats.Column9)
 	totalRepos := int(stats.Column10)
 
-	upToDateHosts := totalHosts - hostsNeedingUpdates
+	// Derived from hosts we hold package data for, not from every host. A host
+	// that has never reported packages is unknown, not healthy, and folding it
+	// into "up to date" reports silence as good news.
+	upToDateHosts := int(stats.HostsWithPackageData) - hostsNeedingUpdates
 	if upToDateHosts < 0 {
 		upToDateHosts = 0
+	}
+	awaitingDataHosts := totalHosts - int(stats.HostsWithPackageData)
+	if awaitingDataHosts < 0 {
+		awaitingDataHosts = 0
 	}
 
 	osDistribution := make([]map[string]interface{}, len(osRows))
@@ -133,7 +146,7 @@ func (s *DashboardStore) GetStats(ctx context.Context) (map[string]interface{}, 
 		}
 	}
 
-	updateStatusDistribution := updateStatusSegments(upToDateHosts, hostsNeedingUpdates, erroredHosts)
+	updateStatusDistribution := updateStatusSegments(upToDateHosts, hostsNeedingUpdates, erroredHosts, awaitingDataHosts)
 
 	regularUpdates := totalOutdatedPackages - securityUpdates
 	if regularUpdates < 0 {
@@ -181,9 +194,15 @@ func (s *DashboardStore) GetHomepageStats(ctx context.Context) (map[string]inter
 
 	totalHosts := int(stats.TotalHosts)
 	hostsNeedingUpdates := int(stats.HostsNeedingUpdates)
-	upToDateHosts := totalHosts - hostsNeedingUpdates
+	// Same rule as the dashboard card: only hosts we hold package data for can
+	// be called up to date.
+	upToDateHosts := int(stats.HostsWithPackageData) - hostsNeedingUpdates
 	if upToDateHosts < 0 {
 		upToDateHosts = 0
+	}
+	awaitingDataHosts := totalHosts - int(stats.HostsWithPackageData)
+	if awaitingDataHosts < 0 {
+		awaitingDataHosts = 0
 	}
 
 	osRows, _ := d.Queries.GetOSDistributionByTypeAndVersion(ctx)
@@ -221,6 +240,7 @@ func (s *DashboardStore) GetHomepageStats(ctx context.Context) (map[string]inter
 		"total_repos":                 int(stats.TotalRepos),
 		"hosts_needing_updates":       hostsNeedingUpdates,
 		"up_to_date_hosts":            upToDateHosts,
+		"awaiting_data_hosts":         awaitingDataHosts,
 		"security_updates":            int(stats.SecurityUpdates),
 		"hosts_with_security_updates": int(stats.HostsWithSecurityUpdates),
 		"recent_updates_24h":          int(stats.RecentUpdates24h),

--- a/server-source-code/internal/store/dashboard_segments_test.go
+++ b/server-source-code/internal/store/dashboard_segments_test.go
@@ -5,12 +5,12 @@ import "testing"
 // The update-status chart navigates by the filter its segment carries. A
 // segment without one is not a cosmetic problem: the click falls through and
 // lands on an unfiltered host list, which reads as having worked. These tests
-// pin that contract so a fourth segment cannot be added without a filter, and
-// so the three filters stay the ones the Hosts page actually understands.
+// pin that contract so a further segment cannot be added without a filter, and
+// so the filters stay the ones the Hosts page actually understands.
 func TestUpdateStatusSegments_EverySegmentCarriesAFilter(t *testing.T) {
 	t.Parallel()
 
-	for _, seg := range updateStatusSegments(1, 2, 3) {
+	for _, seg := range updateStatusSegments(1, 2, 3, 4) {
 		name, ok := seg["name"].(string)
 		if !ok || name == "" {
 			t.Fatalf("segment %v has no display name", seg)
@@ -29,13 +29,17 @@ func TestUpdateStatusSegments_FiltersMatchTheHostsPage(t *testing.T) {
 	// one whose server-side effective_status predicate the chart's own count is
 	// computed from. The two must stay in step or the count and the list it
 	// links to disagree.
+	//
+	// "awaitingData" is the same contract for hosts we hold no package data
+	// for. It must remain in validHostsListFilter or the click 400s.
 	want := []struct{ name, filter string }{
 		{"Up to date", "upToDate"},
 		{"Needs updates", "needsUpdates"},
 		{"Not reporting", "inactive"},
+		{"Awaiting data", "awaitingData"},
 	}
 
-	got := updateStatusSegments(0, 0, 0)
+	got := updateStatusSegments(0, 0, 0, 1)
 	if len(got) != len(want) {
 		t.Fatalf("expected %d segments, got %d", len(want), len(got))
 	}
@@ -52,10 +56,27 @@ func TestUpdateStatusSegments_FiltersMatchTheHostsPage(t *testing.T) {
 func TestUpdateStatusSegments_CountsLandOnTheRightSegment(t *testing.T) {
 	t.Parallel()
 
-	got := updateStatusSegments(7, 11, 13)
-	for i, want := range []int{7, 11, 13} {
+	got := updateStatusSegments(7, 11, 13, 17)
+	for i, want := range []int{7, 11, 13, 17} {
 		if got[i]["count"] != want {
 			t.Errorf("segment %d (%v): expected count %d, got %v", i, got[i]["name"], want, got[i]["count"])
+		}
+	}
+}
+
+// A fleet where every host has reported should not carry a permanently empty
+// fourth segment, which would render as a dead slice and a click leading to an
+// empty list.
+func TestUpdateStatusSegments_AwaitingDataHiddenWhenZero(t *testing.T) {
+	t.Parallel()
+
+	got := updateStatusSegments(5, 3, 1, 0)
+	if len(got) != 3 {
+		t.Fatalf("expected the awaiting-data segment to be omitted at zero, got %d segments", len(got))
+	}
+	for _, seg := range got {
+		if seg["filter"] == "awaitingData" {
+			t.Errorf("awaiting-data segment present despite a zero count: %v", seg)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #1032
Fixes #1034

Two problems in the same query family, so one review rather than two.

A host we have never had package data from was being counted as **Up to date**, on the dashboard and on the gethomepage widget. That is silence being reported as good news. It now takes actual package data to qualify, and anything without it lands in a new **Awaiting data** slice on the chart with a working filter behind it. Expect "Up to date" to drop on any instance with hosts that have never reported, and those hosts to reappear under the new slice.

The widget query was also doing its distinct counts with `COUNT(DISTINCT)`, which sorts the whole set and spills to disk. The dashboard moved to `GROUP BY` subqueries a while back and this one never did. On a 3000 host fleet that is ~277ms down to ~30ms and no spill. Same numbers out, checked against main on identical data and on an empty database.

Three commits, one per concern. Detail and the measurements are in the commit messages.
