### PR TITLE
fix(hosts): show a host that has never reported as awaiting, not healthy

### DIFF
--- a/docs/patchmon-admin-guide.md
+++ b/docs/patchmon-admin-guide.md
@@ -645,9 +645,9 @@ The top of the page has four main areas:
 - **Hostname** and **IP** underneath, both editable inline (clicking shows a text field; Enter to save, Esc to cancel).
 - **Status pills** (four independent indicators, each with a hover tooltip explaining what it means):
   - **WS** — WebSocket control channel state. Green when connected, amber while disconnected within the configured grace window, red once the grace window elapses. The grace window is the `host_down` alert threshold (default 30 seconds, see [Per-alert-type configuration](#per-alert-type-configuration)).
-  - **Reporting** — agent report freshness. Green when the agent has reported within its update interval, amber when overdue but the WebSocket is still connected (agent is alive, just hasn't pushed yet), red ("Stale") when overdue *and* the WebSocket is also disconnected.
+  - **Reporting** — agent report freshness. Grey ("Awaiting report") until the agent sends its very first report, then green when the agent has reported within its update interval, amber when overdue but the WebSocket is still connected (agent is alive, just hasn't pushed yet), red ("Stale") when overdue *and* the WebSocket is also disconnected.
   - **Reboot pending** — only shown when the host has flagged a pending reboot (e.g. `/var/run/reboot-required`, kernel updates).
-  - **Updates** — green "Up to date", amber "Updates pending" (non-security only), red "Security patches required" when one or more security updates are available.
+  - **Updates** — grey "No package data" until the first report arrives, then green "Up to date", amber "Updates pending" (non-security only), red "Security patches required" when one or more security updates are available.
 - **Uptime** and **Last updated** relative timestamps.
 
 If there's a pending patch run awaiting a fresh post-patch report, you'll see an **Awaiting inventory report** chip that links to the run.

--- a/frontend/src/__tests__/utils/hostStatus.test.js
+++ b/frontend/src/__tests__/utils/hostStatus.test.js
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import {
 	deriveReportingState,
 	deriveReportingStateByTime,
+	hasNeverReported,
 } from "../../utils/hostStatus";
 
 // Fixed clock so the tests never depend on wall time.
@@ -117,12 +118,31 @@ describe("deriveReportingState", () => {
 		).toBe(expected);
 	});
 
-	it("does not depend on host.status", () => {
-		// A pending host silent for 19 hours must read as stale, not Reporting,
+	it("does not depend on host.status for hosts that have reported", () => {
+		// An inactive host silent for 19 hours must read as stale, not Reporting,
 		// even though the SQL isStale flag only flips for status='active'.
-		const pending = { status: "pending", last_update: minutesAgo(19 * 60) };
-		expect(deriveReportingState(pending, false, interval, NOW)).toBe("stale");
-		expect(deriveReportingState(pending, true, interval, NOW)).toBe("overdue");
+		const inactive = { status: "inactive", last_update: minutesAgo(19 * 60) };
+		expect(deriveReportingState(inactive, false, interval, NOW)).toBe("stale");
+		expect(deriveReportingState(inactive, true, interval, NOW)).toBe("overdue");
+	});
+
+	it("returns awaiting for a host that has never reported", () => {
+		// last_update is seeded at creation, so a just-added host would otherwise
+		// read as Reporting even though no agent has ever contacted the server.
+		const justAdded = { status: "pending", last_update: minutesAgo(0) };
+		expect(deriveReportingState(justAdded, true, interval, NOW)).toBe(
+			"awaiting",
+		);
+		expect(deriveReportingState(justAdded, false, interval, NOW)).toBe(
+			"awaiting",
+		);
+	});
+
+	it("keeps a never-reported host in awaiting no matter how old it is", () => {
+		const abandoned = { status: "pending", last_update: minutesAgo(19 * 60) };
+		expect(deriveReportingState(abandoned, false, interval, NOW)).toBe(
+			"awaiting",
+		);
 	});
 
 	it("treats a missing host as stale rather than throwing", () => {
@@ -130,5 +150,19 @@ describe("deriveReportingState", () => {
 		expect(deriveReportingState(undefined, true, interval, NOW)).toBe(
 			"overdue",
 		);
+	});
+});
+
+describe("hasNeverReported", () => {
+	it("is true only for the pending status", () => {
+		expect(hasNeverReported({ status: "pending" })).toBe(true);
+		expect(hasNeverReported({ status: "active" })).toBe(false);
+		expect(hasNeverReported({ status: "inactive" })).toBe(false);
+	});
+
+	it("is false for a missing host or missing status", () => {
+		expect(hasNeverReported(null)).toBe(false);
+		expect(hasNeverReported(undefined)).toBe(false);
+		expect(hasNeverReported({})).toBe(false);
 	});
 });

--- a/frontend/src/components/HostStatusPills.jsx
+++ b/frontend/src/components/HostStatusPills.jsx
@@ -1,6 +1,6 @@
 import { Activity, Package, RotateCcw, Wifi, WifiOff } from "lucide-react";
 import { formatRelativeTime } from "../utils/api";
-import { deriveReportingStateByTime } from "../utils/hostStatus";
+import { deriveReportingState } from "../utils/hostStatus";
 import Tooltip from "./ui/Tooltip";
 
 /**
@@ -97,9 +97,12 @@ const HostStatusPills = ({
 		? formatRelativeTime(host.last_update)
 		: "never";
 
+	const wsLoaded = wsStatus !== undefined && wsStatus !== null;
+	const wsConnectedOrUnknown = !wsLoaded || wsStatus.connected === true;
+
 	// ---------- WS pill ----------
 	let wsPill = null;
-	if (wsStatus !== undefined && wsStatus !== null) {
+	if (wsLoaded) {
 		const connected = !!wsStatus.connected;
 		const secure = !!wsStatus.secure;
 		const disconnectedSeconds = wsStatus.disconnected_seconds_ago;
@@ -165,9 +168,9 @@ const HostStatusPills = ({
 	}
 
 	// ---------- Reporting pill ----------
-	// Computed purely from last_update + the configured agent update interval
-	// — not from the backend's pre-computed reportingState/isStale. This is
-	// the single source of truth so the pill always agrees with the operator's
+	// Computed from last_update + the configured agent update interval — not
+	// from the backend's pre-computed reportingState/isStale. This is the
+	// single source of truth so the pill always agrees with the operator's
 	// configured threshold regardless of which API path served the host record
 	// or how the backend's SQL CASE happens to evaluate.
 	//
@@ -175,26 +178,33 @@ const HostStatusPills = ({
 	// "overdue" range (×1 to ×2 of the interval). While `wsStatus` is still
 	// loading, treat it as "assume connected" so a healthy host doesn't briefly
 	// flicker through "Stale" before the WS payload arrives.
-	const reportingState = deriveReportingStateByTime(
-		host.last_update,
+	//
+	// A host that has never reported short-circuits to "awaiting": its
+	// last_update is seeded at creation, so the time comparison alone would
+	// read a host added seconds ago as reporting.
+	const reportingState = deriveReportingState(
+		host,
+		wsConnectedOrUnknown,
 		updateIntervalMinutes,
 	);
-	const wsLoaded = wsStatus !== undefined && wsStatus !== null;
-	const wsConnectedOrUnknown = !wsLoaded || wsStatus.connected === true;
+	const neverReported = reportingState === "awaiting";
 
 	let reportingVariant = "success";
 	let reportingLabel = "Reporting";
 	let reportingTooltip = `Agent reported recently. Last update: ${lastUpdateRel}.`;
-	if (reportingState !== "reporting") {
-		if (wsConnectedOrUnknown) {
-			reportingVariant = "warning";
-			reportingLabel = "Overdue";
-			reportingTooltip = `Agent has not pushed a report yet but the WebSocket is still connected, so this is likely transient. Last update: ${lastUpdateRel}.`;
-		} else {
-			reportingVariant = "danger";
-			reportingLabel = "Stale";
-			reportingTooltip = `Agent has not reported and the WebSocket is disconnected. Last update: ${lastUpdateRel}.`;
-		}
+	if (neverReported) {
+		reportingVariant = "neutral";
+		reportingLabel = "Awaiting report";
+		reportingTooltip =
+			"This host has been added but its agent has not sent a report yet. Install and start the agent on the host to begin monitoring.";
+	} else if (reportingState === "overdue") {
+		reportingVariant = "warning";
+		reportingLabel = "Overdue";
+		reportingTooltip = `Agent has not pushed a report yet but the WebSocket is still connected, so this is likely transient. Last update: ${lastUpdateRel}.`;
+	} else if (reportingState === "stale") {
+		reportingVariant = "danger";
+		reportingLabel = "Stale";
+		reportingTooltip = `Agent has not reported and the WebSocket is disconnected. Last update: ${lastUpdateRel}.`;
 	}
 	const reportingPill = (
 		<Pill
@@ -235,7 +245,15 @@ const HostStatusPills = ({
 	let updatesVariant = "success";
 	let updatesLabel = "Up to date";
 	let updatesTooltip = "All packages up to date.";
-	if (updateState === "security_required" || securityCount > 0) {
+	if (neverReported && securityCount === 0 && updatesCount === 0) {
+		// Zero packages known is not the same as zero updates outstanding.
+		// Claiming "Up to date" for a host that has never sent an inventory
+		// would be the most misleading pill on the page.
+		updatesVariant = "neutral";
+		updatesLabel = "No package data";
+		updatesTooltip =
+			"Package data will appear once the agent sends its first report.";
+	} else if (updateState === "security_required" || securityCount > 0) {
 		updatesVariant = "danger";
 		updatesLabel = "Security patches required";
 		updatesTooltip = `${securityCount} security update${securityCount === 1 ? "" : "s"} available.`;

--- a/frontend/src/pages/Compliance.jsx
+++ b/frontend/src/pages/Compliance.jsx
@@ -49,7 +49,10 @@ import { useTheme } from "../contexts/ThemeContext";
 import { useToast } from "../contexts/ToastContext";
 import { adminHostsAPI, settingsAPI } from "../utils/api";
 import { complianceAPI } from "../utils/complianceApi";
-import { deriveReportingStateByTime } from "../utils/hostStatus";
+import {
+	deriveReportingStateByTime,
+	hasNeverReported,
+} from "../utils/hostStatus";
 
 // Custom tooltip component for consistent styling across all charts
 const CustomTooltip = ({ active, payload, label, type }) => {
@@ -1056,25 +1059,32 @@ const Compliance = () => {
 								</div>
 								<div className="grid grid-cols-1 md:grid-cols-2 gap-2 max-h-[200px] overflow-y-auto">
 									{allHosts.map((host) => {
-										const reportingState = deriveReportingStateByTime(
-											host.last_update,
-											updateIntervalMinutes,
-										);
+										const reportingState = hasNeverReported(host)
+											? "awaiting"
+											: deriveReportingStateByTime(
+													host.last_update,
+													updateIntervalMinutes,
+												);
 										const dotVariant =
-											reportingState === "reporting"
+											reportingState === "awaiting"
 												? {
-														className: "bg-success-500",
-														label: "Reporting",
+														className: "bg-secondary-400",
+														label: "Awaiting first report",
 													}
-												: reportingState === "overdue"
+												: reportingState === "reporting"
 													? {
-															className: "bg-warning-500",
-															label: "Overdue",
+															className: "bg-success-500",
+															label: "Reporting",
 														}
-													: {
-															className: "bg-danger-500",
-															label: "Not reporting",
-														};
+													: reportingState === "overdue"
+														? {
+																className: "bg-warning-500",
+																label: "Overdue",
+															}
+														: {
+																className: "bg-danger-500",
+																label: "Not reporting",
+															};
 										return (
 											<label
 												key={host.id}

--- a/frontend/src/pages/Hosts.jsx
+++ b/frontend/src/pages/Hosts.jsx
@@ -1579,7 +1579,13 @@ const Hosts = () => {
 				let badgeClass;
 				let label;
 				let tooltipText;
-				if (reportingState === "reporting") {
+				if (reportingState === "awaiting") {
+					badgeClass =
+						"badge bg-secondary-100 text-secondary-700 dark:bg-secondary-700 dark:text-secondary-200";
+					label = "Awaiting report";
+					tooltipText =
+						"This host has been added but its agent has not sent a report yet. Install and start the agent on the host to begin monitoring.";
+				} else if (reportingState === "reporting") {
 					badgeClass =
 						"badge bg-success-100 text-success-800 dark:bg-success-900 dark:text-success-200";
 					label = "Reporting";
@@ -2096,6 +2102,7 @@ const Hosts = () => {
 											<option value="reporting">Reporting</option>
 											<option value="overdue">Overdue</option>
 											<option value="stale">Stale</option>
+											<option value="awaiting">Awaiting report</option>
 										</select>
 									</div>
 									<div>

--- a/frontend/src/utils/hostStatus.js
+++ b/frontend/src/utils/hostStatus.js
@@ -6,11 +6,26 @@
 // Mirrors the legacy effectiveStatus / isStale boundary (x2 of update_interval)
 // but adds the intermediate "overdue" amber state between x1 and x2.
 //
-// Deliberately does NOT depend on `host.status` (active/pending/error), unlike
-// the SQL `isStale` flag which only flips for `status='active'` — so a pending
+// The time-based derivation deliberately does NOT depend on `host.status`,
+// unlike the SQL `isStale` flag which only flips for `status='active'` — so a
 // host that has gone silent for 19 hours reads correctly as stale.
+//
+// The one exception is a host that has never reported at all, which gets its
+// own "awaiting" state — see `hasNeverReported`.
 
 const DEFAULT_UPDATE_INTERVAL_MINUTES = 60;
+
+/**
+ * A host that has never sent a report keeps `status = 'pending'`; the first
+ * report flips it to 'active'. Its `last_update` column is seeded with the
+ * creation timestamp, so a purely time-based derivation would read a host
+ * added seconds ago as healthy and "Reporting" when no agent has ever
+ * contacted the server.
+ *
+ * @param {object|null|undefined} host
+ * @returns {boolean}
+ */
+export const hasNeverReported = (host) => host?.status === "pending";
 
 /**
  * @param {string|null|undefined} lastUpdateIso
@@ -43,11 +58,14 @@ export const deriveReportingStateByTime = (
  * "Stale" flicker on healthy hosts during the wsStatusMap loading window: only
  * an explicit `connected: false` from the API downgrades the pill to red.
  *
+ * A host that has never reported returns "awaiting" regardless of elapsed time
+ * or WebSocket state: there is no report to be fresh or stale about.
+ *
  * @param {object|null|undefined} host
  * @param {boolean} wsConnectedOrUnknown
  * @param {number} updateIntervalMinutes
  * @param {number} [nowMs] injectable clock, for tests
- * @returns {"reporting"|"overdue"|"stale"}
+ * @returns {"awaiting"|"reporting"|"overdue"|"stale"}
  */
 export const deriveReportingState = (
 	host,
@@ -55,6 +73,7 @@ export const deriveReportingState = (
 	updateIntervalMinutes,
 	nowMs = Date.now(),
 ) => {
+	if (hasNeverReported(host)) return "awaiting";
 	const timeState = deriveReportingStateByTime(
 		host?.last_update,
 		updateIntervalMinutes,


### PR DESCRIPTION
## The bug

Add a host, do not install the agent, and open its detail page. The status pills claim the host is healthy: a green **Reporting** pill and a green **Up to date** pill, on a host whose agent has never contacted the server.

Two causes, both in the frontend derivation:

1. A new host is created with `status = 'pending'` and its `last_update` seeded to the creation timestamp. The first agent contact flips it to `'active'`. Because the reporting state was derived purely from `last_update` against the agent update interval, a host added seconds ago looked like it had just reported.
2. Zero known packages was treated as zero outstanding updates, so "no inventory yet" rendered as "Up to date".

## The fix

Add a fourth reporting state, `awaiting`, derived from the pending status ahead of any time comparison, and use it everywhere the reporting state is surfaced.

| Surface | Before | After |
|---|---|---|
| Host Detail header | green "Reporting" | grey "Awaiting report" |
| Host Detail header | green "Up to date" | grey "No package data" |
| Hosts table (desktop) | green "Reporting" | grey "Awaiting report" |
| Hosts cards (mobile) | green pills | grey pills, same copy |
| Compliance bulk-scan host picker | green dot, "Reporting" | grey dot, "Awaiting first report" |

The Hosts **Reporting** filter gains an "Awaiting report" option, since pending hosts no longer match reporting, overdue or stale.

Both pills carry a tooltip explaining what to do: install and start the agent, and package data appears after its first report.

## Notes on the behaviour

- A never-enrolled host stays neutral indefinitely rather than escalating to red "Stale". There is no stale data to warn about, and the copy tells the operator what is actually missing. This is the one deliberate behaviour change.
- The Updates pill only goes neutral when both counts are zero, so a real count always wins and nothing is hidden.
- The WS pill is untouched. A pending host with no agent still shows WS offline, which is accurate.
- `deriveReportingStateByTime` stays purely time-based. Only `deriveReportingState`, which already takes the host record, short-circuits on the pending status.

## Tests

The existing `does not depend on host.status` case asserted that a pending host reads as stale or overdue, which is the behaviour that produced this bug. It has been re-pointed at an `inactive` host so it still guards the original intent, and new cases cover the `awaiting` state and the `hasNeverReported` helper.

`npx biome check src/` clean, 193 frontend tests pass, `npm run build` succeeds, pre-commit hooks pass.

## Docs

Admin guide pill descriptions updated for both the Reporting and Updates pills.
