### PR TITLE
fix: migration 42 aborts on a JSON null alert metadata, wedging upgrades to 2.1.0

### DIFF
--- a/docs/patchmon-operator-guide.md
+++ b/docs/patchmon-operator-guide.md
@@ -5450,6 +5450,17 @@ or
 
 PatchMon uses `golang-migrate` with embedded SQL files. On every server start, the server runs pending migrations before opening its HTTP listener. A **dirty** state means a previous migration started and crashed mid-way. The `schema_migrations` table records the version but the `dirty` column is `true`.
 
+From v2.1.1 onwards the server prints the recovery SQL for you, naming the database and the exact statement to run, so in most cases you can follow that block instead of working it out by hand:
+
+```
+[migrate] Migration 42 did not complete on database "patchmon_db", so it is marked dirty and
+[migrate] no further migrations will run against it until that marker is cleared.
+...
+[migrate]   UPDATE schema_migrations SET version = 41, dirty = false;
+```
+
+One exception: if the dirty version is `1`, there is no earlier version to rewind to. Run `DELETE FROM schema_migrations;` instead, which clears the migration marker only and touches no application data, then let the server re-run migrations from the beginning. The server prints this variant automatically.
+
 #### Fix: Stuck on Dirty
 
 When the server logs report `Dirty database version N. Fix and force version.`, the simplest path is to connect directly to Postgres, confirm whether the migration's actual work landed, and either mark the version clean or rewind one step so the migration re-runs. PatchMon's migrations are written to be idempotent, so re-running a clean migration is safe.
@@ -5506,22 +5517,40 @@ After updating `schema_migrations`, exit psql and restart:
 
 You should see migrations advance through 31, 32, 33, then `server starting`.
 
+#### Fix: Stuck on Dirty 42 After Upgrading to v2.1.0
+
+v2.1.0 shipped a migration (`000042`) that failed on a small number of installs with:
+
+```
+cannot set path in scalar (22023)
+```
+
+This happens when the `host_down` row in `alert_config` stores its `metadata` as the JSON value `null` rather than an empty object, which the migration did not allow for. The migration rolls back cleanly when it fails, so nothing is half-applied, but the database is left dirty at 42 and the server crash-loops.
+
+**Upgrade to v2.1.1 or later first.** The migration is fixed there and handles that value correctly. Rewinding on v2.1.0 will just fail the same way on the next boot.
+
+Once you are on the fixed image, connect to the database as shown above and rewind one step:
+
+```sql
+UPDATE schema_migrations SET version = 41, dirty = false;
+```
+
+Then restart. Migration 42 re-runs and succeeds.
+
 > **Only mark a migration clean** after you've verified the schema is actually consistent. Forcing onto an inconsistent schema hides the problem until the next migration.
 
 #### Fix: Run Migrations Manually
 
-The server runs migrations automatically at startup, so you normally never need to run them by hand. If you do (e.g. scripted rollout, debugging):
+The server runs migrations automatically at startup, so you normally never need to run them by hand.
 
-```bash
-# Up (apply all pending)
-docker compose run --rm --entrypoint migrate server up
+The Docker image does not ship a separate migration tool. Migrations are embedded in the server binary and there is no `migrate` command inside the container, so drive them by restarting the server and reading its logs, and inspect or adjust state with SQL as shown above:
 
-# Down one step (rollback the most recent migration)
-docker compose run --rm --entrypoint migrate server down
-
-# Show current version
-docker compose run --rm --entrypoint migrate server version
+```sql
+-- Show current version
+SELECT * FROM schema_migrations;
 ```
+
+If you are building from source, `make build-migrate` in `server-source-code/` produces a standalone `migrate` CLI supporting `up`, `down`, `force VERSION`, and `version`. It needs `DATABASE_URL` set and is not part of any released image.
 
 ### 3. "CORS Error" in the Browser
 

--- a/server-source-code/internal/migrate/migrate.go
+++ b/server-source-code/internal/migrate/migrate.go
@@ -3,11 +3,16 @@
 package migrate
 
 import (
+	"crypto/sha256"
 	"embed"
+	"errors"
 	"fmt"
+	"io"
 	"log/slog"
+	"net/url"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/golang-migrate/migrate/v4"
 	_ "github.com/golang-migrate/migrate/v4/database/postgres"
@@ -42,12 +47,25 @@ func Run(databaseURL string, log *slog.Logger) error {
 	}
 	defer func() { _, _ = m.Close() }()
 
-	if err := m.Up(); err != nil && err != migrate.ErrNoChange {
-		fmt.Fprintf(os.Stderr, "[migrate] failed: %v\n", err)
-		return fmt.Errorf("migration up: %w", err)
+	upErr := m.Up()
+	if upErr != nil && upErr != migrate.ErrNoChange {
+		fmt.Fprintf(os.Stderr, "[migrate] failed: %v\n", upErr)
+		var dirty migrate.ErrDirty
+		if errors.As(upErr, &dirty) {
+			reportDirtyRecovery(os.Stderr, databaseURL, dirty.Version)
+		} else {
+			// A migration actually ran and failed, so the dirty marker was just
+			// set fresh. Forget any earlier report for this database, otherwise
+			// the dirty error on the next attempt is silently deduped away at
+			// exactly the point the operator needs the guidance repeated.
+			forgetDirtyRecovery(databaseURL)
+		}
+		return fmt.Errorf("migration up: %w", upErr)
 	}
 
-	if err == migrate.ErrNoChange {
+	forgetDirtyRecovery(databaseURL)
+
+	if upErr == migrate.ErrNoChange {
 		_, _ = fmt.Fprintln(os.Stdout, "[migrate] already up to date")
 		log.Info("migrations: already up to date")
 		return nil
@@ -75,6 +93,90 @@ func Open(databaseURL string) (*migrate.Migrate, error) {
 	}
 
 	return migrate.NewWithSourceInstance("iofs", source, databaseURL)
+}
+
+// dirtyRecoveryReported tracks the dirty version already reported per database,
+// so a server that retries migrations per request does not reprint the block on
+// every attempt. Keyed by digest, never the DSN itself.
+var (
+	dirtyRecoveryMu       sync.Mutex
+	dirtyRecoveryReported = map[string]int{}
+)
+
+func dirtyRecoveryKey(databaseURL string) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(databaseURL)))
+}
+
+// reportDirtyRecovery turns golang-migrate's "Dirty database version N. Fix and
+// force version." into instructions an operator can act on. The migrate CLI is
+// not shipped in the server image, so the recovery is given as SQL. It reports
+// whether it wrote anything, which is false when the same database is already
+// known to be dirty at the same version.
+func reportDirtyRecovery(w io.Writer, databaseURL string, version int) bool {
+	key := dirtyRecoveryKey(databaseURL)
+
+	dirtyRecoveryMu.Lock()
+	last, seen := dirtyRecoveryReported[key]
+	if seen && last == version {
+		dirtyRecoveryMu.Unlock()
+		return false
+	}
+	dirtyRecoveryReported[key] = version
+	dirtyRecoveryMu.Unlock()
+
+	_, _ = fmt.Fprint(w, dirtyRecoveryMessage(databaseURL, version))
+	return true
+}
+
+// forgetDirtyRecovery drops a database's recorded dirty version once migrations
+// get past it, so a later dirty episode reports again.
+func forgetDirtyRecovery(databaseURL string) {
+	dirtyRecoveryMu.Lock()
+	delete(dirtyRecoveryReported, dirtyRecoveryKey(databaseURL))
+	dirtyRecoveryMu.Unlock()
+}
+
+func dirtyRecoveryMessage(databaseURL string, version int) string {
+	// Version 1 has no predecessor to roll back to, and forcing version 0 leaves
+	// the marker clean but pointing at a migration that does not exist, which is
+	// harder to recover from than the dirty state. Clearing the table is what
+	// `migrate force -1` does and is the only way back from a dirty first migration.
+	recovery := fmt.Sprintf("UPDATE schema_migrations SET version = %d, dirty = false;", version-1)
+	if version <= 1 {
+		recovery = "DELETE FROM schema_migrations;"
+	}
+
+	return fmt.Sprintf(`
+[migrate] Migration %d did not complete on database %q, so it is marked dirty and
+[migrate] no further migrations will run against it until that marker is cleared.
+[migrate]
+[migrate] The error logged above this block, on the run that first failed, is the
+[migrate] cause. Fix that first, then confirm migration %d left nothing behind
+[migrate] (it is applied as a single transaction, so a failed run rolls back, but
+[migrate] a server killed mid-migration can leave partial changes). Then run this
+[migrate] against that database:
+[migrate]
+[migrate]   %s
+[migrate]
+[migrate] and restart the server so migration %d is retried. Make sure the server
+[migrate] is on a build that fixes the cause before retrying, or it will fail again.
+`, version, databaseName(databaseURL), version, recovery, version)
+}
+
+// databaseName extracts just the database name from a DSN so the operator can
+// tell which database is wedged, without putting credentials in the log.
+// Anything that is not a URL-form DSN with a path is reported as unknown rather
+// than echoed: a keyword/value DSN parses with the whole string as the path,
+// which would put the password on stderr.
+func databaseName(databaseURL string) string {
+	u, err := url.Parse(databaseURL)
+	if err != nil || u.Scheme == "" || !strings.HasPrefix(u.Path, "/") {
+		return "unknown"
+	}
+	if name := strings.TrimPrefix(u.Path, "/"); name != "" {
+		return name
+	}
+	return "unknown"
 }
 
 func ensureSSLMode(databaseURL string) string {

--- a/server-source-code/internal/migrate/migrate_test.go
+++ b/server-source-code/internal/migrate/migrate_test.go
@@ -1,0 +1,194 @@
+package migrate
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/golang-migrate/migrate/v4"
+)
+
+func TestDirtyRecoveryMessage(t *testing.T) {
+	tests := []struct {
+		name        string
+		version     int
+		wantSQL     string
+		notWantSQL  string
+		wantDBLabel string
+	}{
+		{
+			name:        "mid-sequence rolls back to the previous version",
+			version:     42,
+			wantSQL:     "UPDATE schema_migrations SET version = 41, dirty = false;",
+			wantDBLabel: `"patchmon_db"`,
+		},
+		{
+			// Forcing version 0 clears the dirty flag but points at a migration
+			// that does not exist, which is harder to recover from than staying
+			// dirty. Clearing the table is the only way back.
+			name:        "first migration clears the table instead of forcing version 0",
+			version:     1,
+			wantSQL:     "DELETE FROM schema_migrations;",
+			notWantSQL:  "version = 0",
+			wantDBLabel: `"patchmon_db"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := dirtyRecoveryMessage("postgres://u:p@host:5432/patchmon_db?sslmode=disable", tt.version)
+			if !strings.Contains(got, tt.wantSQL) {
+				t.Errorf("message missing recovery SQL %q:\n%s", tt.wantSQL, got)
+			}
+			if tt.notWantSQL != "" && strings.Contains(got, tt.notWantSQL) {
+				t.Errorf("message must not contain %q:\n%s", tt.notWantSQL, got)
+			}
+			if !strings.Contains(got, tt.wantDBLabel) {
+				t.Errorf("message missing database label %s:\n%s", tt.wantDBLabel, got)
+			}
+			if strings.Contains(got, "u:p@") {
+				t.Errorf("message leaked DSN credentials:\n%s", got)
+			}
+		})
+	}
+}
+
+func TestDatabaseName(t *testing.T) {
+	tests := []struct {
+		name string
+		dsn  string
+		want string
+	}{
+		{"standard dsn", "postgres://user:pass@localhost:5432/patchmon_db?sslmode=disable", "patchmon_db"},
+		{"postgresql scheme", "postgresql://user:pass@localhost/patchmon_db", "patchmon_db"},
+		{"no database in path", "postgres://user:pass@localhost:5432", "unknown"},
+		{"trailing slash only", "postgres://user:pass@localhost:5432/", "unknown"},
+		{"unparseable", "://not a url", "unknown"},
+		{"empty", "", "unknown"},
+		// url.Parse puts the whole keyword/value DSN in Path, so without a
+		// scheme check this would print the password to stderr.
+		{"keyword value dsn is not echoed", "host=localhost dbname=patchmon_db password=hunter2", "unknown"},
+		{"bare name is not echoed", "patchmon_db", "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := databaseName(tt.dsn)
+			if got != tt.want {
+				t.Errorf("databaseName(%q) = %q, want %q", tt.dsn, got, tt.want)
+			}
+			if strings.Contains(got, "password") || strings.Contains(got, "hunter2") {
+				t.Errorf("databaseName(%q) leaked credentials: %q", tt.dsn, got)
+			}
+		})
+	}
+}
+
+// ErrDirty is returned by value and reaches Run joined with any unlock error, so
+// Run has to unwrap rather than type-assert. This pins the shape Run relies on;
+// it would fail if golang-migrate ever made ErrDirty a pointer type.
+func TestErrDirtyUnwrapsThroughJoin(t *testing.T) {
+	joined := errors.Join(migrate.ErrDirty{Version: 42}, errors.New("unlock failed"))
+
+	var dirty migrate.ErrDirty
+	if !errors.As(joined, &dirty) {
+		t.Fatal("errors.As failed to unwrap ErrDirty from a joined error")
+	}
+	if dirty.Version != 42 {
+		t.Errorf("Version = %d, want 42", dirty.Version)
+	}
+}
+
+func TestReportDirtyRecoveryDedup(t *testing.T) {
+	const dsnA = "postgres://u:p@host/ctx_a?sslmode=disable"
+	const dsnB = "postgres://u:p@host/ctx_b?sslmode=disable"
+
+	t.Cleanup(func() {
+		forgetDirtyRecovery(dsnA)
+		forgetDirtyRecovery(dsnB)
+	})
+
+	var buf strings.Builder
+	if !reportDirtyRecovery(&buf, dsnA, 42) {
+		t.Fatal("first report for a database must print")
+	}
+	if !strings.Contains(buf.String(), "ctx_a") {
+		t.Errorf("report did not name the database:\n%s", buf.String())
+	}
+
+	// A server that retries migrations per request must not reprint per request.
+	for i := 0; i < 3; i++ {
+		if reportDirtyRecovery(io.Discard, dsnA, 42) {
+			t.Fatalf("repeat report %d for the same database and version must be suppressed", i+1)
+		}
+	}
+
+	// Dedup must not be global: another context is a different database.
+	var bufB strings.Builder
+	if !reportDirtyRecovery(&bufB, dsnB, 42) {
+		t.Error("a different database must still print while another is deduped")
+	}
+	if strings.Contains(bufB.String(), "ctx_a") {
+		t.Errorf("report named the wrong database:\n%s", bufB.String())
+	}
+
+	// A different dirty version is new information, so it prints.
+	if !reportDirtyRecovery(io.Discard, dsnA, 43) {
+		t.Error("a new dirty version for the same database must print")
+	}
+}
+
+// After a failed retry the database goes dirty at the same version again, which
+// is exactly when the operator needs the guidance repeated rather than deduped.
+func TestForgetDirtyRecoveryRestoresReporting(t *testing.T) {
+	const dsn = "postgres://u:p@host/ctx_retry?sslmode=disable"
+	t.Cleanup(func() { forgetDirtyRecovery(dsn) })
+
+	if !reportDirtyRecovery(io.Discard, dsn, 42) {
+		t.Fatal("first report must print")
+	}
+	if reportDirtyRecovery(io.Discard, dsn, 42) {
+		t.Fatal("second report must be suppressed before forgetting")
+	}
+
+	forgetDirtyRecovery(dsn)
+
+	if !reportDirtyRecovery(io.Discard, dsn, 42) {
+		t.Error("report must print again after the database is forgotten")
+	}
+}
+
+// The postgres driver can write version -1 when a dirty NilVersion is recorded,
+// and version 0 has no migration to rewind to either.
+func TestDirtyRecoveryMessageNonPositiveVersions(t *testing.T) {
+	for _, version := range []int{0, -1} {
+		got := dirtyRecoveryMessage("postgres://u:p@host/db", version)
+		if !strings.Contains(got, "DELETE FROM schema_migrations;") {
+			t.Errorf("version %d: want the clearing form, got:\n%s", version, got)
+		}
+		if strings.Contains(got, "SET version =") {
+			t.Errorf("version %d: must not tell the operator to force a negative version:\n%s", version, got)
+		}
+	}
+}
+
+func TestEnsureSSLMode(t *testing.T) {
+	tests := []struct {
+		name string
+		dsn  string
+		want string
+	}{
+		{"adds sslmode when absent", "postgres://localhost/db", "postgres://localhost/db?sslmode=disable"},
+		{"appends to existing query", "postgres://localhost/db?connect_timeout=5", "postgres://localhost/db?connect_timeout=5&sslmode=disable"},
+		{"leaves explicit sslmode alone", "postgres://localhost/db?sslmode=require", "postgres://localhost/db?sslmode=require"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ensureSSLMode(tt.dsn); got != tt.want {
+				t.Errorf("ensureSSLMode(%q) = %q, want %q", tt.dsn, got, tt.want)
+			}
+		})
+	}
+}

--- a/server-source-code/internal/migrate/migrations/000042_v2-0-3_host_down_threshold.down.sql
+++ b/server-source-code/internal/migrate/migrations/000042_v2-0-3_host_down_threshold.down.sql
@@ -2,10 +2,14 @@
 -- We can't safely tell whether the operator changed the value after the up
 -- migration, so this strips both keys unconditionally; re-running the up
 -- migration restores the 30-second default.
+--
+-- Guarded on jsonb_typeof rather than IS NOT NULL for the same reason as the up
+-- migration: `?` is true for the string scalar '"threshold"' and for an array
+-- containing it, and the `-` operator then fails on a non-object with 22023.
 
 UPDATE alert_config
 SET metadata = NULLIF(metadata - 'threshold' - 'threshold_unit', '{}'::jsonb),
     updated_at = NOW()
 WHERE alert_type = 'host_down'
-  AND metadata IS NOT NULL
+  AND jsonb_typeof(metadata) = 'object'
   AND (metadata ? 'threshold' OR metadata ? 'threshold_unit');

--- a/server-source-code/internal/migrate/migrations/000042_v2-0-3_host_down_threshold.up.sql
+++ b/server-source-code/internal/migrate/migrations/000042_v2-0-3_host_down_threshold.up.sql
@@ -3,11 +3,20 @@
 -- hardcoding update_interval x 3 minutes. Idempotent: only fills in the
 -- threshold/threshold_unit keys when they are missing, so an operator's
 -- previously-saved value is preserved on re-runs.
+--
+-- metadata may hold the JSON scalar null rather than SQL NULL on older installs.
+-- COALESCE does not catch that, `? 'threshold'` returns false for it so the row
+-- still matches, and jsonb_set then fails with 22023 "cannot set path in scalar",
+-- aborting the migration. Normalise anything that is not a JSON object to '{}'
+-- and match on jsonb_typeof rather than IS NULL.
 
 UPDATE alert_config
 SET metadata = jsonb_set(
         jsonb_set(
-            COALESCE(metadata, '{}'::jsonb),
+            CASE
+                WHEN jsonb_typeof(metadata) = 'object' THEN metadata
+                ELSE '{}'::jsonb
+            END,
             '{threshold}',
             '30'::jsonb,
             true
@@ -18,4 +27,4 @@ SET metadata = jsonb_set(
     ),
     updated_at = NOW()
 WHERE alert_type = 'host_down'
-  AND (metadata IS NULL OR NOT (metadata ? 'threshold'));
+  AND (jsonb_typeof(metadata) IS DISTINCT FROM 'object' OR NOT (metadata ? 'threshold'));


### PR DESCRIPTION
Fixes #1042

## The problem

Upgrading to 2.1.0 crash-looped on some installs:

```
[migrate] failed: migration failed: cannot set path in scalar ... (details: pq: cannot set path in scalar (22023))
[fatal] migrations failed: migration up: Dirty database version 42. Fix and force version.
```

Migration `000042` seeds a default `host_down` threshold into `alert_config.metadata`. It assumed that column was either SQL `NULL` or a JSON object. Some installs store the JSON value `null`, which is not SQL `NULL`, and all three defences missed it:

- `COALESCE(metadata, '{}')` does not convert it, because it is not SQL NULL
- `metadata ? 'threshold'` returns false for it, so the row still matched the `WHERE`
- `jsonb_set` then hit a scalar and threw `22023`

The migration aborted, `schema_migrations` was left dirty at 42, and every later boot refused to migrate. Reproduced against Postgres 17.

## The fix

Normalise anything that is not a JSON object to `{}` before writing into it, and match on `jsonb_typeof` rather than `IS NULL`.

The down migration carried the same fault: `?` returns true for the string scalar `"threshold"` and for an array containing it, and `-` then rejects the non-object. Guarded the same way.

Verified across SQL NULL, JSON null, empty object, an operator-set threshold, an object without the key, string and number scalars, and arrays. Both directions are idempotent, an operator's own value is preserved, and other alert types are untouched.

## Recovery guidance

golang-migrate reports only `Dirty database version N. Fix and force version.`, and no `migrate` binary is shipped in the server image, so an operator hitting this had nothing to act on. The server now prints the exact SQL, names the affected database, and warns that it must be on a build fixing the cause before retrying, otherwise the retry re-dirties.

Version 1 is special-cased: forcing version 0 clears the marker but points it at a migration that does not exist, which is harder to recover from than the dirty state it replaced.

The block prints once per database per dirty version rather than on every attempt, and is forgotten once migrations get past that version so a later episode reports again. Only the database name is printed, never the DSN.

Also fixes an `ErrNoChange` check that compared the outer `err` shadowed by `m.Up()`, so "already up to date" could never log.

## Docs

Adds a worked example for the dirty-42 case, and corrects the manual migration section, which told operators to run `docker compose run --rm --entrypoint migrate server up`. The runtime image copies only `patchmon-server` and embeds the migrations in it, so no `migrate` command exists in the container and that has never worked.

## Operator note for the release

Anyone currently stuck must be on the fixed image **before** rewinding to 41, or migration 42 fails again and re-dirties.

## Testing

- `make check` clean, tests pass under `-race`
- New `internal/migrate/migrate_test.go` covers the version-1 case, the dedup and its reset, DSN handling, and non-positive versions
- Both migration directions exercised against Postgres 17 over twelve metadata shapes