### PR TITLE
feat: opt-in SMTP AUTH over an unencrypted connection for trusted internal relays

### DIFF
--- a/docs/patchmon-admin-guide.md
+++ b/docs/patchmon-admin-guide.md
@@ -3602,8 +3602,22 @@ PatchMon offers four TLS modes on every email destination. Pick the one your rel
 
 - **STARTTLS (recommended).** PatchMon connects in plaintext on the SMTP port (typically 587) and then requires the server to advertise `STARTTLS`. The connection is upgraded to TLS before any credentials or message body are sent. If the server does not advertise `STARTTLS`, PatchMon refuses to send and reports the failure. This is the right choice for the vast majority of modern relays (Microsoft 365, Google Workspace, SendGrid, Postmark, Mailgun, Amazon SES on port 587, and most on-prem mail servers).
 - **Implicit TLS / SSL.** PatchMon opens a TLS connection from the very first byte, with no plaintext handshake. The default port for this mode is 465. Use it when your relay only accepts TLS on a dedicated port and does not support `STARTTLS`. Some legacy or appliance-based servers only offer this mode.
-- **None (insecure).** Cleartext SMTP, no TLS at any stage. PatchMon refuses to send if a username or password is set on the destination, because it would otherwise leak credentials onto the wire. Use only for trusted internal relays on a private network where TLS is genuinely unavailable.
+- **None (insecure).** Cleartext SMTP, no TLS at any stage. If a username or password is set on the destination, PatchMon refuses to send unless you also tick **Send credentials over an unencrypted connection**, because authenticating in cleartext puts the credentials on the wire. See **Authenticated relays without TLS** below. Use this mode only for trusted internal relays on a private network where TLS is genuinely unavailable.
 - **Auto.** Legacy opportunistic mode kept for backward compatibility. PatchMon tries `STARTTLS` first and falls back to implicit TLS on the same host and port if `STARTTLS` is not advertised. Existing destinations that were saved before the explicit modes were added load as **Auto** so they keep working unchanged. Open the destination, pick **STARTTLS** or **Implicit TLS / SSL** explicitly once you have confirmed which one your relay supports, and save. New destinations should not be configured as **Auto**.
+
+##### Authenticated relays without TLS
+
+Some internal relays require SMTP AUTH but do not offer TLS at all. By default PatchMon refuses that combination, because PLAIN authentication over cleartext puts the username and password on the wire in a form anyone on the network path can read.
+
+If the relay is on a network you trust and you accept that trade-off, set **TLS mode** to **None (insecure)** and tick **Send credentials over an unencrypted connection** on the destination. PatchMon then authenticates in cleartext for that destination only.
+
+Points worth knowing before you enable it:
+
+- The setting is per destination, not global. Other email destinations are unaffected.
+- It applies only in **None (insecure)** mode. In **STARTTLS**, **Implicit TLS / SSL**, and **Auto** it is ignored, so it can never weaken a mode that does use TLS.
+- It is off by default, including on every destination that already exists.
+- Anyone able to observe traffic between PatchMon and the relay can read the credentials. Use a dedicated relay account with no privileges beyond sending mail, and never reuse a password from elsewhere.
+- The preferred fix remains enabling STARTTLS on the relay, even with a self-signed or internal CA certificate.
 
 > Port and mode are independent. The port field is just the TCP port to connect to; the TLS mode controls how the connection is secured. The defaults (587 for STARTTLS, 465 for implicit TLS) match the conventional ports, but you can override the port if your relay listens elsewhere.
 
@@ -3612,9 +3626,11 @@ PatchMon offers four TLS modes on every email destination. Pick the one your rel
 Saved email destinations have a **Send test email** button next to the standard **Test** action. Unlike **Test**, which enqueues a synthetic notification through the worker, **Send test email** performs a synchronous live SMTP probe directly from the API request and reports the result inline:
 
 - On success the toast confirms delivery and the recipients should receive a short test message.
-- On failure PatchMon reports which stage of the SMTP exchange failed: `validate` (the configuration is rejected before any network activity, for example a missing host or a username set with TLS mode **None**), `dial` (the TCP connection or implicit TLS handshake could not be established), `starttls` (the server did not advertise `STARTTLS` in the chosen mode), `auth` (the relay rejected the credentials), or `send` (the relay accepted the session but rejected the recipients or message). The toast includes the underlying error message returned by the relay.
+- On failure PatchMon reports which stage of the SMTP exchange failed: `validate` (the configuration is rejected before any network activity, for example a missing host, or a username set with TLS mode **None** without the cleartext credentials opt-in), `dial` (the TCP connection or implicit TLS handshake could not be established), `starttls` (the server did not advertise `STARTTLS` in the chosen mode), `auth` (the relay rejected the credentials), or `send` (the relay accepted the session but rejected the recipients or message). The toast includes the underlying error message returned by the relay.
 
 This is the fastest way to diagnose a TLS or auth misconfiguration without trawling through server logs. The probe respects the same `can_manage_notifications` permission as editing the destination.
+
+> The probe always uses the **last saved** configuration, not what is currently on screen. Save the destination before testing, otherwise you are testing the previous settings. This matters most when you have just ticked **Send credentials over an unencrypted connection**: until you save, the probe still fails at the `validate` stage.
 
 #### ntfy
 

--- a/frontend/src/__tests__/pages/hydrateTLSMode.test.js
+++ b/frontend/src/__tests__/pages/hydrateTLSMode.test.js
@@ -1,10 +1,14 @@
 /**
- * Unit tests for hydrateTLSMode, which maps a stored SMTP destination config
- * back onto the TLS mode dropdown when an existing channel is reopened.
+ * Unit tests for hydrateTLSMode and hydrateAllowInsecureAuth, which map a
+ * stored SMTP destination config back onto the TLS controls when an existing
+ * channel is reopened.
  */
 
 import { describe, expect, it } from "vitest";
-import { hydrateTLSMode } from "../../pages/settings/AlertChannels";
+import {
+	hydrateAllowInsecureAuth,
+	hydrateTLSMode,
+} from "../../pages/settings/AlertChannels";
 
 describe("hydrateTLSMode", () => {
 	it("defaults to starttls when there is no config", () => {
@@ -40,5 +44,31 @@ describe("hydrateTLSMode", () => {
 		// a falsy-but-absent value.
 		expect(hydrateTLSMode({ use_tls: undefined })).toBe("auto");
 		expect(hydrateTLSMode({ smtp_host: "mail.example.com" })).toBe("auto");
+	});
+});
+
+describe("hydrateAllowInsecureAuth", () => {
+	it("returns false when there is no config", () => {
+		expect(hydrateAllowInsecureAuth(null)).toBe(false);
+		expect(hydrateAllowInsecureAuth(undefined)).toBe(false);
+		expect(hydrateAllowInsecureAuth("")).toBe(false);
+		expect(hydrateAllowInsecureAuth(0)).toBe(false);
+	});
+
+	it("returns false when the field is absent, as on older rows", () => {
+		expect(hydrateAllowInsecureAuth({})).toBe(false);
+		expect(hydrateAllowInsecureAuth({ tls_mode: "none" })).toBe(false);
+	});
+
+	it("returns true only on an exact boolean true", () => {
+		expect(hydrateAllowInsecureAuth({ allow_insecure_auth: true })).toBe(true);
+		expect(hydrateAllowInsecureAuth({ allow_insecure_auth: false })).toBe(
+			false,
+		);
+		expect(hydrateAllowInsecureAuth({ allow_insecure_auth: "true" })).toBe(
+			false,
+		);
+		expect(hydrateAllowInsecureAuth({ allow_insecure_auth: 1 })).toBe(false);
+		expect(hydrateAllowInsecureAuth({ allow_insecure_auth: null })).toBe(false);
 	});
 });

--- a/frontend/src/pages/settings/AlertChannels.jsx
+++ b/frontend/src/pages/settings/AlertChannels.jsx
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
 	Bell,
 	Check,
+	CheckSquare,
 	ChevronLeft,
 	ChevronRight,
 	Clock,
@@ -14,6 +15,7 @@ import {
 	RefreshCw,
 	Send,
 	Slack,
+	Square,
 	Trash2,
 	X,
 } from "lucide-react";
@@ -151,7 +153,7 @@ const TLS_MODE_HELP = {
 	starttls:
 		"Connect in plaintext on the submission port, then upgrade to TLS via the STARTTLS command. Typical port: 587.",
 	tls: "Open a TLS connection from the start (sometimes called SMTPS). Typical port: 465.",
-	none: "Send mail in plaintext. Credentials will be rejected by the server. Use only for local relays you trust.",
+	none: "Send mail in plaintext. Credentials are only sent if you enable the unencrypted credentials option below. Use only for local relays you trust.",
 	auto: "Try STARTTLS first, then fall back to implicit TLS on the same host and port. Mail is never sent in plaintext in this mode; if neither works, sending fails.",
 };
 
@@ -173,6 +175,11 @@ export const hydrateTLSMode = (cfg) => {
 	}
 	if (cfg.use_tls === false) return "none";
 	return "auto";
+};
+
+export const hydrateAllowInsecureAuth = (cfg) => {
+	if (!cfg || typeof cfg !== "object") return false;
+	return cfg.allow_insecure_auth === true;
 };
 
 const buildCron = (frequency, time, days, monthDay) => {
@@ -279,6 +286,9 @@ const DestinationModal = ({
 	const [tlsMode, setTlsMode] = useState(
 		editingDest ? hydrateTLSMode(editingDest._loadedConfig || {}) : "starttls",
 	);
+	const [allowInsecureAuth, setAllowInsecureAuth] = useState(
+		hydrateAllowInsecureAuth(editingDest?._loadedConfig),
+	);
 	const [isTestingSMTP, setIsTestingSMTP] = useState(false);
 	const toast = useToast();
 
@@ -288,8 +298,9 @@ const DestinationModal = ({
 		(config.username && String(config.username).length > 0) ||
 			(config.password && String(config.password).length > 0),
 	);
-	const showPlainAuthWarning =
+	const insecureAuthApplies =
 		channelType === "email" && tlsMode === "none" && credentialsSet;
+	const insecureAuthBlocked = insecureAuthApplies && !allowInsecureAuth;
 
 	const handleSave = () => {
 		if (!displayName.trim()) {
@@ -307,9 +318,9 @@ const DestinationModal = ({
 			toast.warning("SMTP host, from, and to are required");
 			return;
 		}
-		if (channelType === "email" && showPlainAuthWarning) {
+		if (channelType === "email" && insecureAuthBlocked) {
 			toast.warning(
-				"Clear the credentials or pick STARTTLS / Implicit TLS before saving",
+				"Tick the unencrypted credentials option, clear the credentials, or pick STARTTLS / Implicit TLS before saving",
 			);
 			return;
 		}
@@ -325,6 +336,7 @@ const DestinationModal = ({
 				...config,
 				tls_mode: tlsMode,
 				use_tls: tlsMode !== "none",
+				allow_insecure_auth: insecureAuthApplies && allowInsecureAuth,
 			};
 		}
 		onSave({
@@ -518,11 +530,34 @@ const DestinationModal = ({
 								{TLS_MODE_HELP[tlsMode]}
 							</p>
 						</div>
-						{showPlainAuthWarning && (
-							<div className="bg-danger-50 dark:bg-danger-900/30 border border-danger-200 dark:border-danger-700 rounded-md p-3 text-sm text-danger-700 dark:text-danger-300">
-								PLAIN authentication over an unencrypted connection will be
-								rejected by the server. Either clear the credentials or choose
-								STARTTLS / Implicit TLS.
+						{insecureAuthApplies && (
+							<div className="bg-danger-50 dark:bg-danger-900/30 border border-danger-200 dark:border-danger-700 rounded-md p-3">
+								<p className="text-sm text-danger-700 dark:text-danger-300">
+									This connection is not encrypted, so the username and password
+									are sent in cleartext. Anyone on the network path between
+									PatchMon and this relay can read them. Only do this on a
+									trusted local network.
+								</p>
+								<button
+									type="button"
+									aria-pressed={allowInsecureAuth}
+									onClick={() => setAllowInsecureAuth((v) => !v)}
+									className="mt-2 flex w-full items-center gap-2 min-h-[44px] text-left text-sm font-medium text-danger-800 dark:text-danger-200"
+								>
+									{allowInsecureAuth ? (
+										<CheckSquare className="h-5 w-5 flex-shrink-0 text-danger-600 dark:text-danger-400" />
+									) : (
+										<Square className="h-5 w-5 flex-shrink-0 text-danger-500 dark:text-danger-400" />
+									)}
+									Send credentials over an unencrypted connection
+								</button>
+								{insecureAuthBlocked && (
+									<p className="mt-2 text-sm text-danger-700 dark:text-danger-300">
+										Until this is ticked, PatchMon will not authenticate over an
+										unencrypted connection and sending will fail. Alternatively,
+										clear the credentials or choose STARTTLS / Implicit TLS.
+									</p>
+								)}
 							</div>
 						)}
 					</div>
@@ -715,13 +750,13 @@ const DestinationModal = ({
 									!editingDest?.id ||
 									isPending ||
 									isTestingSMTP ||
-									showPlainAuthWarning
+									insecureAuthBlocked
 								}
 								onClick={handleSendTestEmail}
 								title={
 									!editingDest?.id
 										? "Save the destination first to send a test email"
-										: "Send a test email using the saved configuration"
+										: "Sends using the last saved configuration. Save first to test unsaved changes."
 								}
 							>
 								{isTestingSMTP ? (
@@ -746,7 +781,7 @@ const DestinationModal = ({
 							<button
 								type="button"
 								className="btn-primary flex items-center gap-1"
-								disabled={isPending || isTestingSMTP || showPlainAuthWarning}
+								disabled={isPending || isTestingSMTP || insecureAuthBlocked}
 								onClick={handleSave}
 							>
 								{isPending ? (

--- a/server-source-code/internal/handler/notifications.go
+++ b/server-source-code/internal/handler/notifications.go
@@ -481,6 +481,9 @@ type testSMTPRequest struct {
 	To       string `json:"to"`
 	UseTLS   *bool  `json:"use_tls"`
 	TLSMode  string `json:"tls_mode"`
+	// AllowInsecureAuth permits PLAIN auth over cleartext. Only meaningful
+	// with tls_mode=none; see mailer.Config.AllowInsecureAuth.
+	AllowInsecureAuth bool `json:"allow_insecure_auth"`
 }
 
 // TestSMTP POST /notifications/destinations/{id}/test-smtp
@@ -500,6 +503,10 @@ func (h *NotificationsHandler) TestSMTP(w http.ResponseWriter, r *http.Request) 
 	if r.Body != nil && r.ContentLength != 0 {
 		dec := json.NewDecoder(r.Body)
 		if err := dec.Decode(&override); err == nil {
+			// AllowInsecureAuth is deliberately absent from this list. Including it would
+			// let a caller post {"allow_insecure_auth":true} alone to flip hasOverride and
+			// probe a saved destination with cleartext auth it never opted in to. Leaving
+			// it out means such a body is ignored and the stored config is used instead.
 			hasOverride = override.SMTPHost != "" || override.From != "" || override.To != "" ||
 				override.SMTPPort != 0 || override.TLSMode != "" || override.UseTLS != nil ||
 				override.Username != "" || override.Password != "" || override.FromName != ""
@@ -553,6 +560,9 @@ func (h *NotificationsHandler) TestSMTP(w http.ResponseWriter, r *http.Request) 
 		From:     cfg.From,
 		FromName: cfg.FromName,
 		TLSMode:  mode,
+		// Only honoured for tls_mode=none; mailer.validate() rejects the
+		// combination when this is false.
+		AllowInsecureAuth: cfg.AllowInsecureAuth,
 	}
 	msg := mailer.Message{
 		To:       cfg.To,

--- a/server-source-code/internal/mailer/insecure_auth_test.go
+++ b/server-source-code/internal/mailer/insecure_auth_test.go
@@ -1,0 +1,178 @@
+package mailer
+
+import (
+	"context"
+	"encoding/base64"
+	"net/smtp"
+	"strings"
+	"testing"
+	"time"
+)
+
+// The whole point of the opt-in: a trusted internal relay that requires AUTH but
+// offers no TLS. Without AllowInsecureAuth this combination is refused, which is
+// what issue #817 reported.
+func TestSend_None_WithCreds_AllowInsecureAuth_Succeeds(t *testing.T) {
+	srv := newFakeServer(t, false, false)
+	host, port := hostPort(t, srv.addr)
+
+	err := Send(context.Background(), Config{
+		Host:              host,
+		Port:              port,
+		From:              "alerts@example.com",
+		Username:          "relay-user",
+		Password:          "relay-pass",
+		TLSMode:           TLSModeNone,
+		AllowInsecureAuth: true,
+	}, Message{To: "ops@example.com", Subject: "x", HTMLBody: "<p>x</p>"})
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	if srv.gotStartTLS {
+		t.Error("server should not have seen STARTTLS in tls_mode=none")
+	}
+	if !srv.gotAuth {
+		t.Fatal("server never saw AUTH")
+	}
+
+	// Verify what actually went on the wire is well-formed SASL PLAIN.
+	fields := strings.Fields(srv.authLine)
+	if len(fields) != 3 || !strings.EqualFold(fields[0], "AUTH") || !strings.EqualFold(fields[1], "PLAIN") {
+		t.Fatalf("unexpected AUTH line %q", srv.authLine)
+	}
+	decoded, decErr := base64.StdEncoding.DecodeString(fields[2])
+	if decErr != nil {
+		t.Fatalf("AUTH payload is not base64: %v", decErr)
+	}
+	if want := "\x00relay-user\x00relay-pass"; string(decoded) != want {
+		t.Errorf("PLAIN payload = %q, want %q", decoded, want)
+	}
+}
+
+// The opt-in must not become a general "skip TLS" switch. It is scoped to
+// tls_mode=none, so every other mode keeps the stdlib handle and its refusal to
+// send PLAIN over an unencrypted connection.
+func TestPlainAuthSelection(t *testing.T) {
+	tests := []struct {
+		name         string
+		mode         TLSMode
+		allow        bool
+		wantInsecure bool
+	}{
+		{"none with opt-in uses the insecure handle", TLSModeNone, true, true},
+		{"none without opt-in uses the stdlib", TLSModeNone, false, false},
+		{"starttls ignores the opt-in", TLSModeStartTLS, true, false},
+		{"implicit tls ignores the opt-in", TLSModeTLS, true, false},
+		{"auto ignores the opt-in", TLSModeAuto, true, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := plainAuth(Config{
+				Host:              "relay.internal",
+				Username:          "u",
+				Password:          "p",
+				TLSMode:           tt.mode,
+				AllowInsecureAuth: tt.allow,
+			})
+			_, isInsecure := got.(insecurePlainAuth)
+			if isInsecure != tt.wantInsecure {
+				t.Errorf("insecure handle = %v, want %v (%T)", isInsecure, tt.wantInsecure, got)
+			}
+		})
+	}
+}
+
+// Guard the mode scoping at the validate layer too, so a caller that sets the
+// flag on a TLS mode cannot slip past into an unintended code path.
+func TestValidate_AllowInsecureAuthIsScopedToNone(t *testing.T) {
+	msg := Message{To: "ops@example.com", Subject: "x", HTMLBody: "x"}
+	base := Config{Host: "relay.internal", Port: 25, From: "alerts@example.com", Username: "u", Password: "p"}
+
+	cfg := base
+	cfg.TLSMode = TLSModeNone
+	if err := validate(cfg, msg); err == nil {
+		t.Error("tls_mode=none with creds and no opt-in must be refused")
+	}
+
+	cfg.AllowInsecureAuth = true
+	if err := validate(cfg, msg); err != nil {
+		t.Errorf("tls_mode=none with creds and the opt-in must pass validate: %v", err)
+	}
+
+	// TLS modes were never blocked by this rule, and enabling the flag must not
+	// change that either way.
+	for _, mode := range []TLSMode{TLSModeStartTLS, TLSModeTLS, TLSModeAuto} {
+		cfg.TLSMode = mode
+		if err := validate(cfg, msg); err != nil {
+			t.Errorf("mode %q with the opt-in should still validate: %v", mode, err)
+		}
+	}
+}
+
+func TestInsecurePlainAuth_Start(t *testing.T) {
+	a := insecurePlainAuth{username: "user", password: "pass"}
+	proto, resp, err := a.Start(&smtp.ServerInfo{Name: "relay.internal", TLS: false})
+	if err != nil {
+		t.Fatalf("Start on an unencrypted connection must not error: %v", err)
+	}
+	if proto != "PLAIN" {
+		t.Errorf("proto = %q, want PLAIN", proto)
+	}
+	if want := "\x00user\x00pass"; string(resp) != want {
+		t.Errorf("resp = %q, want %q", resp, want)
+	}
+}
+
+func TestInsecurePlainAuth_NextRejectsChallenge(t *testing.T) {
+	a := insecurePlainAuth{username: "user", password: "pass"}
+
+	if _, err := a.Next(nil, false); err != nil {
+		t.Errorf("Next without more must succeed: %v", err)
+	}
+
+	resp, err := a.Next([]byte("challenge"), true)
+	if err == nil {
+		t.Fatal("Next must reject an unexpected server challenge")
+	}
+	if resp != nil {
+		t.Errorf("Next must not return a response alongside an error, got %q", resp)
+	}
+}
+
+// The scenario an operator creates when they enable the opt-in and then "fix"
+// the mode: the flag is still set, but the relay offers neither STARTTLS nor
+// implicit TLS. Every TLS mode must fail closed, and crucially must not put the
+// credentials on the wire on the way out.
+func TestSend_TLSModes_WithOptIn_FailClosedWithoutSendingCreds(t *testing.T) {
+	for _, mode := range []TLSMode{TLSModeStartTLS, TLSModeTLS, TLSModeAuto} {
+		t.Run(string(mode), func(t *testing.T) {
+			srv := newFakeServer(t, false, false) // no STARTTLS, no implicit TLS
+			host, port := hostPort(t, srv.addr)
+
+			err := Send(context.Background(), Config{
+				Host:              host,
+				Port:              port,
+				From:              "alerts@example.com",
+				Username:          "relay-user",
+				Password:          "relay-pass",
+				TLSMode:           mode,
+				AllowInsecureAuth: true,
+				DialTimeout:       2 * time.Second,
+				SendTimeout:       2 * time.Second,
+			}, Message{To: "ops@example.com", Subject: "x", HTMLBody: "<p>x</p>"})
+			if err == nil {
+				t.Fatalf("mode %q must not deliver against a relay with no TLS", mode)
+			}
+
+			srv.mu.Lock()
+			defer srv.mu.Unlock()
+			if srv.gotAuth {
+				t.Errorf("mode %q sent AUTH to a server with no TLS: %q", mode, srv.authLine)
+			}
+		})
+	}
+}

--- a/server-source-code/internal/mailer/mailer.go
+++ b/server-source-code/internal/mailer/mailer.go
@@ -22,7 +22,8 @@ type TLSMode string
 
 const (
 	// TLSModeNone dials cleartext and never upgrades. Reject if credentials are
-	// set (PLAIN over cleartext leaks them on the wire).
+	// set (PLAIN over cleartext leaks them on the wire) unless the operator has
+	// explicitly set Config.AllowInsecureAuth.
 	TLSModeNone TLSMode = "none"
 	// TLSModeStartTLS dials cleartext then mandates STARTTLS. If the server
 	// does not advertise STARTTLS the dial fails closed.
@@ -46,6 +47,12 @@ type Config struct {
 	TLSMode     TLSMode
 	DialTimeout time.Duration
 	SendTimeout time.Duration
+	// AllowInsecureAuth permits PLAIN authentication over an unencrypted
+	// connection. It applies only to TLSModeNone and is an explicit per
+	// destination opt-in for trusted internal relays that require AUTH but do
+	// not offer TLS. It sends the credentials in the clear, so it stays false
+	// unless the operator sets it.
+	AllowInsecureAuth bool
 }
 
 // Message is one outbound email.
@@ -242,10 +249,10 @@ func validate(cfg Config, msg Message) *SendError {
 	if _, err := mail.ParseAddress(msg.To); err != nil {
 		return newSendError(StageValidate, fmt.Errorf("invalid to %q: %w", msg.To, err))
 	}
-	if cfg.TLSMode == TLSModeNone &&
+	if cfg.TLSMode == TLSModeNone && !cfg.AllowInsecureAuth &&
 		(strings.TrimSpace(cfg.Username) != "" || strings.TrimSpace(cfg.Password) != "") {
 		return newSendError(StageValidate,
-			errors.New("refusing PLAIN auth over cleartext: tls_mode=none with credentials would leak them on the wire"))
+			errors.New("refusing PLAIN auth over cleartext: tls_mode=none with credentials would leak them on the wire. Enable allow_insecure_auth on the destination if the relay is on a trusted network"))
 	}
 	return nil
 }

--- a/server-source-code/internal/mailer/mailer_test.go
+++ b/server-source-code/internal/mailer/mailer_test.go
@@ -30,6 +30,7 @@ type fakeSMTPServer struct {
 	mu          sync.Mutex
 	gotStartTLS bool
 	gotAuth     bool
+	authLine    string
 	body        string
 	listener    net.Listener
 	addr        string
@@ -141,6 +142,7 @@ func (s *fakeSMTPServer) handle(c net.Conn) {
 		case strings.HasPrefix(upper, "AUTH"):
 			s.mu.Lock()
 			s.gotAuth = true
+			s.authLine = line
 			s.mu.Unlock()
 			if !write("235 2.7.0 Authentication successful") {
 				return

--- a/server-source-code/internal/mailer/tls.go
+++ b/server-source-code/internal/mailer/tls.go
@@ -2,6 +2,7 @@ package mailer
 
 import (
 	"crypto/tls"
+	"errors"
 	"net/smtp"
 )
 
@@ -26,9 +27,45 @@ func tlsClientConfig(host string) *tls.Config {
 
 // plainAuth returns a PLAIN auth handle bound to the configured host. The
 // stdlib refuses to send PLAIN to anything that isn't TLS-wrapped or localhost,
-// which is what we want — TLSModeNone with creds is already rejected upstream
+// which is what we want by default — TLSModeNone with creds is rejected upstream
 // in validate(), and TLSModeAuto with creds will only authenticate after a
 // successful upgrade.
+//
+// The one exception is an operator who has explicitly opted in to cleartext auth
+// for a trusted internal relay. The stdlib gives no way to waive its check, so
+// that path uses insecurePlainAuth instead.
 func plainAuth(cfg Config) smtp.Auth {
+	if cfg.TLSMode == TLSModeNone && cfg.AllowInsecureAuth {
+		return insecurePlainAuth{username: cfg.Username, password: cfg.Password}
+	}
 	return smtp.PlainAuth("", cfg.Username, cfg.Password, cfg.Host)
+}
+
+// insecurePlainAuth implements SASL PLAIN (RFC 4616) without the stdlib's
+// refusal to run over an unencrypted connection. Reached only when the operator
+// has set AllowInsecureAuth on a tls_mode=none destination; validate() rejects
+// the combination otherwise.
+//
+// It also drops the stdlib's server.Name != host check. That check guards
+// against sending credentials to a server other than the configured one, and is
+// a tautology here: every dial passes cfg.Host to smtp.NewClient, so ServerInfo
+// carries the same value it would be compared against.
+type insecurePlainAuth struct {
+	username string
+	password string
+}
+
+func (a insecurePlainAuth) Start(_ *smtp.ServerInfo) (string, []byte, error) {
+	// authzid NUL authcid NUL passwd, with an empty authzid.
+	resp := []byte("\x00" + a.username + "\x00" + a.password)
+	return "PLAIN", resp, nil
+}
+
+func (a insecurePlainAuth) Next(_ []byte, more bool) ([]byte, error) {
+	if more {
+		// PLAIN is a single round trip; a challenge means the server is not
+		// speaking the mechanism we agreed.
+		return nil, errors.New("unexpected server challenge during PLAIN auth")
+	}
+	return nil, nil
 }

--- a/server-source-code/internal/queue/email_tls_mode_test.go
+++ b/server-source-code/internal/queue/email_tls_mode_test.go
@@ -108,3 +108,65 @@ func TestEmailConfig_SendPathsAgreeWithTestPath(t *testing.T) {
 		t.Errorf("scheduled report worker resolved %q but the test-email path resolves %q", got, want)
 	}
 }
+
+// allow_insecure_auth is the fourth key to live in this blob, and it is decoded
+// by the same three structs. A tag typo in any one of them compiles, passes
+// every other test, and fails silently in production: the operator ticks the
+// box, "send test email" succeeds via the handler path, and scheduled reports
+// still refuse to authenticate. That is the same class of bug this file exists
+// to catch, so pin all three against one raw string.
+func TestEmailConfig_AllowInsecureAuthAgreesAcrossPaths(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want bool
+	}{
+		{
+			name: "absent key means no consent",
+			raw:  `{"smtp_host":"relay.internal","smtp_port":25,"from":"a@b.c","to":"d@e.f","tls_mode":"none"}`,
+			want: false,
+		},
+		{
+			name: "explicit false means no consent",
+			raw:  `{"smtp_host":"relay.internal","smtp_port":25,"from":"a@b.c","to":"d@e.f","tls_mode":"none","allow_insecure_auth":false}`,
+			want: false,
+		},
+		{
+			name: "explicit true is carried on every path",
+			raw:  `{"smtp_host":"relay.internal","smtp_port":25,"from":"a@b.c","to":"d@e.f","tls_mode":"none","username":"u","password":"p","allow_insecure_auth":true}`,
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Mirrors testSMTPRequest in internal/handler/notifications.go, which
+			// lives in another package and cannot be referenced from here.
+			var handlerSide struct {
+				TLSMode           string `json:"tls_mode"`
+				AllowInsecureAuth bool   `json:"allow_insecure_auth"`
+			}
+			if err := json.Unmarshal([]byte(tt.raw), &handlerSide); err != nil {
+				t.Fatal(err)
+			}
+			var alert emailConfig
+			if err := json.Unmarshal([]byte(tt.raw), &alert); err != nil {
+				t.Fatal(err)
+			}
+			var report scheduledEmailConfig
+			if err := json.Unmarshal([]byte(tt.raw), &report); err != nil {
+				t.Fatal(err)
+			}
+
+			if handlerSide.AllowInsecureAuth != tt.want {
+				t.Errorf("test-email path decoded %v, want %v", handlerSide.AllowInsecureAuth, tt.want)
+			}
+			if alert.AllowInsecureAuth != tt.want {
+				t.Errorf("alert worker decoded %v, want %v", alert.AllowInsecureAuth, tt.want)
+			}
+			if report.AllowInsecureAuth != tt.want {
+				t.Errorf("scheduled report worker decoded %v, want %v", report.AllowInsecureAuth, tt.want)
+			}
+		})
+	}
+}

--- a/server-source-code/internal/queue/notification_worker.go
+++ b/server-source-code/internal/queue/notification_worker.go
@@ -633,6 +633,9 @@ type emailConfig struct {
 	// mailer.ResolveMode pick the effective policy.
 	UseTLS  *bool  `json:"use_tls"`
 	TLSMode string `json:"tls_mode"`
+	// AllowInsecureAuth permits PLAIN auth over cleartext. Only meaningful
+	// with tls_mode=none; see mailer.Config.AllowInsecureAuth.
+	AllowInsecureAuth bool `json:"allow_insecure_auth"`
 }
 
 func (h *NotificationDeliverHandler) sendWebhook(ctx context.Context, plain string, p notifications.NotificationDeliverPayload) error {
@@ -799,6 +802,9 @@ func (h *NotificationDeliverHandler) sendEmail(ctx context.Context, plain string
 		From:     cfg.From,
 		FromName: cfg.FromName,
 		TLSMode:  mode,
+		// Only honoured for tls_mode=none; mailer.validate() rejects the
+		// combination when this is false.
+		AllowInsecureAuth: cfg.AllowInsecureAuth,
 	}
 	if err := mailer.Send(ctx, mc, mailer.Message{To: cfg.To, Subject: subject, HTMLBody: htmlBody}); err != nil {
 		var se *mailer.SendError

--- a/server-source-code/internal/queue/scheduled_report_worker.go
+++ b/server-source-code/internal/queue/scheduled_report_worker.go
@@ -364,6 +364,9 @@ type scheduledEmailConfig struct {
 	// mailer.ResolveMode pick the effective policy.
 	UseTLS  *bool  `json:"use_tls"`
 	TLSMode string `json:"tls_mode"`
+	// AllowInsecureAuth permits PLAIN auth over cleartext. Only meaningful
+	// with tls_mode=none; see mailer.Config.AllowInsecureAuth.
+	AllowInsecureAuth bool `json:"allow_insecure_auth"`
 }
 
 func sendScheduledEmail(ctx context.Context, log *slog.Logger, plain, subject, html, _csv string) error {
@@ -387,6 +390,9 @@ func sendScheduledEmail(ctx context.Context, log *slog.Logger, plain, subject, h
 		From:     cfg.From,
 		FromName: cfg.FromName,
 		TLSMode:  mode,
+		// Only honoured for tls_mode=none; mailer.validate() rejects the
+		// combination when this is false.
+		AllowInsecureAuth: cfg.AllowInsecureAuth,
 	}
 	if err := mailer.Send(ctx, mc, mailer.Message{To: cfg.To, Subject: subject, HTMLBody: html}); err != nil {
 		var se *mailer.SendError


### PR DESCRIPTION
Fixes #817

## The problem

An internal relay that requires SMTP AUTH but offers no TLS had no working configuration at all. Every mode failed:

| Mode | Result |
|---|---|
| `none` + credentials | Refused before dialling, to avoid putting credentials on the wire |
| `starttls` | Fails closed, the relay does not advertise STARTTLS |
| `tls` | Handshake fails, the relay is not TLS |
| `auto` | Tries STARTTLS, then falls back to implicit TLS, which also fails |

The refusal was deliberate, but it left operators on a trusted LAN with no way through and an error that did not say what to do.

## The change

An explicit per-destination opt-in, off by default, permitting PLAIN authentication over cleartext.

- `mailer.Config.AllowInsecureAuth`, honoured **only** when `tls_mode = none`.
- Two independent gates gate it: `validate()` stops refusing the combination, and `plainAuth()` selects a different auth handle. Neither alone is load-bearing.
- In `starttls`, `tls` and `auto` the flag is inert, so it can never weaken a mode that does negotiate TLS.
- Go's `smtp.PlainAuth` refuses to run unencrypted and offers no waiver, so the opt-in path uses its own SASL PLAIN (RFC 4616). It is confined to a small isolated type rather than threaded through the dial path, so the divergence from the stdlib stays auditable at a glance.
- No migration. `tls_mode` already lives in the encrypted destination config blob, so `allow_insecure_auth` rides alongside it. Absent means false, which is what every existing destination keeps.

The refusal message now names the setting that unblocks it, rather than only saying no.

## UI

The existing warning said the server would reject PLAIN auth over an unencrypted connection. That stops being true, so it becomes a consent control in the same danger panel, stating that anyone on the network path can read the credentials.

Consent is persisted on the same predicate that renders the tick, so clearing the credentials also clears the stored consent. Gating those differently would let a destination come back later with the box already ticked, and a second operator adding credentials would never have to make the choice.

## Testing

- `make check` clean, tests pass under `-race`. Frontend: biome clean, 196 tests pass.
- The main test decodes the base64 `AUTH PLAIN` line the fake relay actually received and asserts the exact SASL payload, rather than just that auth happened.
- Fail-closed test: flag set but a TLS mode chosen, against a relay offering no TLS, asserts every mode fails **and** that no AUTH reached the wire.
- Mode scoping pinned at both the `plainAuth` and `validate` layers.
- `allow_insecure_auth` added to the existing three-struct agreement test. That test exists because `use_tls` once decoded differently in the test-email handler than in the two workers, so a destination could pass its test over STARTTLS and then deliver real alerts in the clear. A key added to only some of the three fails silently in production.

## Security notes

- Off by default on every existing destination, and a malformed value fails the decode rather than opening.
- The field is deliberately excluded from the test-email override detection, so a caller cannot post it alone to probe a saved destination with cleartext auth it never opted in to.
- No credential reaches logs, error strings, or any API response as a result of this change.
- Reviewed for privilege, scope escape, downgrade paths, and RFC compliance before merge.

## Docs

Admin guide gains an "Authenticated relays without TLS" section. The "None (insecure)" bullet and the `validate` failure-stage description both described the old unconditional refusal and are corrected.