### PR TITLE
fix(ui): render release-note tables in the What's New modal

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,7 +39,8 @@
 		"react-is": "18.3.1",
 		"react-markdown": "9.1.0",
 		"react-router-dom": "6.30.4",
-		"recharts": "2.15.4"
+		"recharts": "2.15.4",
+		"remark-gfm": "^4.0.1"
 	},
 	"devDependencies": {
 		"@testing-library/jest-dom": "6.9.1",

--- a/frontend/src/__tests__/components/releaseNotesMarkdown.test.jsx
+++ b/frontend/src/__tests__/components/releaseNotesMarkdown.test.jsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+// Release note bodies are written as GitHub Flavoured Markdown, but
+// react-markdown only implements CommonMark. Without remark-gfm a table renders
+// as literal pipe characters in the What's New modal, which is exactly what
+// happened up to v2.1.1. These tests pin the plugin in place.
+const TABLE_MARKDOWN = [
+	"| Issue | PR | Change |",
+	"|---|---|---|",
+	"| #1049 | #1051 | Windows installer no longer dies on antivirus |",
+].join("\n");
+
+describe("release notes markdown rendering", () => {
+	it("renders a GFM table as a real table when remark-gfm is enabled", () => {
+		const { container } = render(
+			<ReactMarkdown remarkPlugins={[remarkGfm]}>
+				{TABLE_MARKDOWN}
+			</ReactMarkdown>,
+		);
+
+		expect(container.querySelector("table")).not.toBeNull();
+		expect(container.querySelectorAll("th")).toHaveLength(3);
+		expect(container.querySelectorAll("tbody tr")).toHaveLength(1);
+		expect(
+			screen.getByText("Windows installer no longer dies on antivirus"),
+		).toBeInTheDocument();
+	});
+
+	it("renders the same table as literal text without the plugin", () => {
+		// Guards the assertion above: proves the test would actually fail if the
+		// plugin were dropped, rather than passing for some unrelated reason.
+		const { container } = render(
+			<ReactMarkdown>{TABLE_MARKDOWN}</ReactMarkdown>,
+		);
+
+		expect(container.querySelector("table")).toBeNull();
+		expect(container.textContent).toContain("| Issue | PR | Change |");
+	});
+
+	it("renders autolinked issue URLs, also a GFM feature", () => {
+		const { container } = render(
+			<ReactMarkdown remarkPlugins={[remarkGfm]}>
+				{"See https://github.com/PatchMon/PatchMon/issues/1049 for detail."}
+			</ReactMarkdown>,
+		);
+
+		const link = container.querySelector("a");
+		expect(link).not.toBeNull();
+		expect(link.getAttribute("href")).toBe(
+			"https://github.com/PatchMon/PatchMon/issues/1049",
+		);
+	});
+});

--- a/frontend/src/__tests__/components/releaseNotesMarkdown.test.jsx
+++ b/frontend/src/__tests__/components/releaseNotesMarkdown.test.jsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { describe, expect, it } from "vitest";
 
 // Release note bodies are written as GitHub Flavoured Markdown, but
 // react-markdown only implements CommonMark. Without remark-gfm a table renders

--- a/frontend/src/components/ReleaseNotesModal.jsx
+++ b/frontend/src/components/ReleaseNotesModal.jsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useId, useState } from "react";
 import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import { useAuth } from "../contexts/AuthContext";
 import { useSettings } from "../contexts/SettingsContext";
 import { authAPI, versionAPI } from "../utils/api";
@@ -179,7 +180,9 @@ const ReleaseNotesModal = ({ isOpen, onAccept }) => {
 					aria-label="Close modal"
 				/>
 
-				<div className="inline-block align-bottom bg-white dark:bg-secondary-800 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-2xl sm:w-full">
+				{/* Wider than the standard max-w-2xl modal: release notes are a
+				    document, not a form, and the tables need the room. */}
+				<div className="inline-block align-bottom bg-white dark:bg-secondary-800 rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-4xl sm:w-full">
 					<div className="bg-white dark:bg-secondary-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
 						{/* Header */}
 						<div className="flex items-center justify-between mb-4">
@@ -225,6 +228,10 @@ const ReleaseNotesModal = ({ isOpen, onAccept }) => {
 								) : hasReleaseNotes ? (
 									<div className="prose prose-sm dark:prose-invert max-w-none">
 										<ReactMarkdown
+											// Tables, strikethrough and autolinks are GitHub
+											// Flavoured Markdown, not CommonMark. Without this the
+											// release-note tables render as literal pipe characters.
+											remarkPlugins={[remarkGfm]}
 											components={{
 												h1: ({ node, ...props }) => (
 													<h1
@@ -274,6 +281,80 @@ const ReleaseNotesModal = ({ isOpen, onAccept }) => {
 												hr: ({ node, ...props }) => (
 													<hr
 														className="my-4 border-secondary-200 dark:border-secondary-600"
+														{...props}
+													/>
+												),
+												h4: ({ node, ...props }) => (
+													<h4
+														className="text-sm font-semibold text-secondary-900 dark:text-white mt-3 mb-1.5"
+														{...props}
+													/>
+												),
+												ol: ({ node, ...props }) => (
+													<ol
+														className="list-decimal list-inside text-sm text-secondary-600 dark:text-white mb-3 space-y-1.5 ml-2"
+														{...props}
+													/>
+												),
+												a: ({ node, ...props }) => (
+													<a
+														className="text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300 underline"
+														target="_blank"
+														rel="noopener noreferrer"
+														{...props}
+													/>
+												),
+												blockquote: ({ node, ...props }) => (
+													<blockquote
+														className="border-l-4 border-secondary-300 dark:border-secondary-600 pl-3 my-3 text-sm text-secondary-600 dark:text-secondary-300 italic"
+														{...props}
+													/>
+												),
+												// The inline `code` styling above would double up
+												// inside a fenced block, so it is neutralised here.
+												pre: ({ node, ...props }) => (
+													<pre
+														className="bg-secondary-100 dark:bg-secondary-900 rounded-md p-3 mb-3 overflow-x-auto text-xs font-mono text-secondary-800 dark:text-secondary-100 [&>code]:bg-transparent [&>code]:p-0"
+														{...props}
+													/>
+												),
+												// Wide tables scroll inside their own container
+												// rather than stretching the modal.
+												table: ({ node, ...props }) => (
+													<div className="overflow-x-auto mb-4 rounded-md border border-secondary-200 dark:border-secondary-600">
+														<table
+															className="min-w-full divide-y divide-secondary-200 dark:divide-secondary-600"
+															{...props}
+														/>
+													</div>
+												),
+												thead: ({ node, ...props }) => (
+													<thead
+														className="bg-secondary-50 dark:bg-secondary-700"
+														{...props}
+													/>
+												),
+												tbody: ({ node, ...props }) => (
+													<tbody
+														className="bg-white dark:bg-secondary-800 divide-y divide-secondary-200 dark:divide-secondary-600"
+														{...props}
+													/>
+												),
+												tr: ({ node, ...props }) => (
+													<tr
+														className="hover:bg-secondary-50 dark:hover:bg-secondary-700 transition-colors"
+														{...props}
+													/>
+												),
+												th: ({ node, ...props }) => (
+													<th
+														className="px-3 sm:px-4 py-2 text-left text-xs font-medium text-secondary-500 dark:text-white uppercase tracking-wider"
+														{...props}
+													/>
+												),
+												td: ({ node, ...props }) => (
+													<td
+														className="px-3 sm:px-4 py-2 align-top text-sm text-secondary-900 dark:text-white"
 														{...props}
 													/>
 												),

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,8 @@
 				"react-is": "18.3.1",
 				"react-markdown": "9.1.0",
 				"react-router-dom": "6.30.4",
-				"recharts": "2.15.4"
+				"recharts": "2.15.4",
+				"remark-gfm": "^4.0.1"
 			},
 			"devDependencies": {
 				"@testing-library/jest-dom": "6.9.1",
@@ -3400,6 +3401,18 @@
 			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
 			"license": "MIT"
 		},
+		"node_modules/escape-string-regexp": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+			"integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/estree-util-is-identifier-name": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
@@ -4519,6 +4532,16 @@
 				"@jridgewell/sourcemap-codec": "^1.5.5"
 			}
 		},
+		"node_modules/markdown-table": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+			"integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/math-intrinsics": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4526,6 +4549,22 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/mdast-util-find-and-replace": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+			"integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"escape-string-regexp": "^5.0.0",
+				"unist-util-is": "^6.0.0",
+				"unist-util-visit-parents": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
 			}
 		},
 		"node_modules/mdast-util-from-markdown": {
@@ -4546,6 +4585,107 @@
 				"micromark-util-symbol": "^2.0.0",
 				"micromark-util-types": "^2.0.0",
 				"unist-util-stringify-position": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-gfm": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+			"integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+			"license": "MIT",
+			"dependencies": {
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-gfm-autolink-literal": "^2.0.0",
+				"mdast-util-gfm-footnote": "^2.0.0",
+				"mdast-util-gfm-strikethrough": "^2.0.0",
+				"mdast-util-gfm-table": "^2.0.0",
+				"mdast-util-gfm-task-list-item": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-gfm-autolink-literal": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+			"integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"ccount": "^2.0.0",
+				"devlop": "^1.0.0",
+				"mdast-util-find-and-replace": "^3.0.0",
+				"micromark-util-character": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-gfm-footnote": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+			"integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"devlop": "^1.1.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-gfm-strikethrough": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+			"integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-gfm-table": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+			"integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"devlop": "^1.0.0",
+				"markdown-table": "^3.0.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/mdast-util-gfm-task-list-item": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+			"integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"devlop": "^1.0.0",
+				"mdast-util-from-markdown": "^2.0.0",
+				"mdast-util-to-markdown": "^2.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -4792,6 +4932,127 @@
 				"micromark-util-subtokenize": "^2.0.0",
 				"micromark-util-symbol": "^2.0.0",
 				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-extension-gfm": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+			"integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+			"license": "MIT",
+			"dependencies": {
+				"micromark-extension-gfm-autolink-literal": "^2.0.0",
+				"micromark-extension-gfm-footnote": "^2.0.0",
+				"micromark-extension-gfm-strikethrough": "^2.0.0",
+				"micromark-extension-gfm-table": "^2.0.0",
+				"micromark-extension-gfm-tagfilter": "^2.0.0",
+				"micromark-extension-gfm-task-list-item": "^2.0.0",
+				"micromark-util-combine-extensions": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-gfm-autolink-literal": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+			"integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-sanitize-uri": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-gfm-footnote": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+			"integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-core-commonmark": "^2.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0",
+				"micromark-util-sanitize-uri": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-gfm-strikethrough": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+			"integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-classify-character": "^2.0.0",
+				"micromark-util-resolve-all": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-gfm-table": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+			"integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-gfm-tagfilter": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+			"integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-gfm-task-list-item": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+			"integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
 			}
 		},
 		"node_modules/micromark-factory-destination": {
@@ -6030,6 +6291,24 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/remark-gfm": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+			"integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-gfm": "^3.0.0",
+				"micromark-extension-gfm": "^3.0.0",
+				"remark-parse": "^11.0.0",
+				"remark-stringify": "^11.0.0",
+				"unified": "^11.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
 		"node_modules/remark-parse": {
 			"version": "11.0.0",
 			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
@@ -6057,6 +6336,21 @@
 				"mdast-util-to-hast": "^13.0.0",
 				"unified": "^11.0.0",
 				"vfile": "^6.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/remark-stringify": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+			"integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/mdast": "^4.0.0",
+				"mdast-util-to-markdown": "^2.0.0",
+				"unified": "^11.0.0"
 			},
 			"funding": {
 				"type": "opencollective",


### PR DESCRIPTION
Tables in a release body never reached the user as tables. Frontend only.

## The bug

`ReleaseNotesModal` renders release notes with `react-markdown` 9.1.0 and **no `remark-gfm`**. Tables, strikethrough and autolinks are GitHub Flavoured Markdown extensions, not CommonMark, so `react-markdown` does not parse them. Every table in a release body rendered as literal `| Issue | PR | Change |` text in the What's New modal.

This matters now because the v2.1.1 notes are the first to lean on tables.

## Also fixed, same `components` map

Three gaps that were invisible until you look for them:

| Gap | Effect |
|---|---|
| No `a` override | Links were unstyled and **navigated away from the app** instead of opening a new tab |
| No `pre` override | Fenced code blocks got the inline `code` background applied twice |
| No `h4`, `ol`, `blockquote` | Fell through to browser defaults, ignoring the design system |

## Width

`sm:max-w-2xl` to `sm:max-w-4xl` (672px to 896px). Release notes are a document, not a form, and the tables need the room.

That exceeded the documented modal size scale, which topped out at `max-w-2xl`, so `UI_DESIGN_SYSTEM.md` gains a **Document** size row and a new 9.5 section on rendering markdown in a modal, covering the three gotchas above.

## Deliberate departures from section 4.2

Table cells here hold prose, not field values, so they **wrap** and use `align-top` rather than the canonical `whitespace-nowrap`. The table is wrapped in `overflow-x-auto` so a wide one scrolls inside itself instead of stretching the modal.

## Verification

`src/__tests__/components/releaseNotesMarkdown.test.jsx` has three tests, including a **negative control** that renders the same table without the plugin and asserts it comes out as literal text. That proves the positive assertion would actually fail if the dependency were dropped later, rather than passing for an unrelated reason.

- `npx vitest run`: 199 passed, 3 skipped, 14 files
- `npx biome check src/`: clean
- `npm run build`: passes
- `npm audit --audit-level=high`: clean, so the new dependency introduces nothing

`remark-gfm@4.0.1` is the official plugin from the `remarkjs` org and is the correct major for react-markdown 9.
