### PR TITLE
ci(release): smoke-test the agent binary before publishing a release

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -613,6 +613,16 @@ jobs:
           done
           file patchmon-*
 
+      # Proves the binaries actually execute, not merely that they are the
+      # right shape. Only the native arch can run on the runner.
+      - name: Smoke-test the native binaries
+        working-directory: dist
+        run: |
+          set -euo pipefail
+          ./patchmon-agent-linux-amd64 --version
+          ./patchmon-agent-linux-amd64 --help > /dev/null
+          echo "agent linux/amd64 runs"
+
       - name: Generate SHA256SUMS
         working-directory: dist
         run: |


### PR DESCRIPTION
Found while porting the what-runs-when matrix into the release diagram and verifying it row by row against the workflows rather than trusting it.

The `agent` job that used to build release binaries ran `--version` and `--help` on `linux/amd64` before uploading. That check did not survive the move of compilation into `docker.yml`: `release-assets` verifies the count, the ELF/PE format and static linking, but nothing established that any binary actually runs.

Restores it for the one binary the runner can execute natively. The server binary has no equivalent, since it exits on missing configuration rather than printing a version.
