### PR TITLE
ci: rebuild the website docs on release

### DIFF
--- a/.github/workflows/notify-website.yml
+++ b/.github/workflows/notify-website.yml
@@ -1,0 +1,25 @@
+name: Rebuild website docs
+
+on:
+  release:
+    types: [published]
+
+permissions: {}
+
+concurrency:
+  group: notify-website
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    if: github.event.release.prerelease == false
+    runs-on: ubuntu-latest
+    steps:
+      - env:
+          GH_TOKEN: ${{ secrets.WEBSITE_DISPATCH_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          gh api repos/PatchMon/patchmon.net-site/dispatches \
+            -f event_type=docs-updated \
+            -f "client_payload[docs_ref]=${TAG}"
+          echo "Asked the website to rebuild its docs from ${TAG}." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Publishing a release now tells the website repository to rebuild, passing the release tag so the published documentation matches what shipped rather than whatever `main` holds at build time.

Previously the website only picked up documentation changes when someone rebuilt it by hand, which meant the docs on patchmon.net could lag a release indefinitely.

Pre-releases are excluded, so an `-rc` tag will not push documentation live. The workflow holds no permissions of its own and calls out with a fine-grained token scoped to that one repository.