### PR TITLE
Fix stale Docker containers, volumes and networks not being removed

### DIFF
--- a/server-source-code/internal/db/docker.sql.go
+++ b/server-source-code/internal/db/docker.sql.go
@@ -174,6 +174,7 @@ func (q *Queries) DeleteImageUpdatesByImageID(ctx context.Context, imageID strin
 }
 
 const deleteImagesByIDs = `-- name: DeleteImagesByIDs :exec
+
 DELETE FROM docker_images WHERE id = ANY($1::text[])
 `
 
@@ -188,6 +189,55 @@ DELETE FROM docker_networks WHERE id = $1
 
 func (q *Queries) DeleteNetwork(ctx context.Context, id string) error {
 	_, err := q.db.Exec(ctx, deleteNetwork, id)
+	return err
+}
+
+const deleteStaleContainers = `-- name: DeleteStaleContainers :exec
+DELETE FROM docker_containers
+WHERE host_id = $1 AND NOT (container_id = ANY($2::text[]))
+`
+
+type DeleteStaleContainersParams struct {
+	HostID       string   `json:"host_id"`
+	ContainerIds []string `json:"container_ids"`
+}
+
+// Removes containers for a host that were not present in the most recent
+// Docker report. Callers must only invoke this when the report actually
+// contained container data, to avoid wiping inventory on an empty/partial report.
+func (q *Queries) DeleteStaleContainers(ctx context.Context, arg DeleteStaleContainersParams) error {
+	_, err := q.db.Exec(ctx, deleteStaleContainers, arg.HostID, arg.ContainerIds)
+	return err
+}
+
+const deleteStaleNetworks = `-- name: DeleteStaleNetworks :exec
+DELETE FROM docker_networks
+WHERE host_id = $1 AND NOT (network_id = ANY($2::text[]))
+`
+
+type DeleteStaleNetworksParams struct {
+	HostID     string   `json:"host_id"`
+	NetworkIds []string `json:"network_ids"`
+}
+
+func (q *Queries) DeleteStaleNetworks(ctx context.Context, arg DeleteStaleNetworksParams) error {
+	_, err := q.db.Exec(ctx, deleteStaleNetworks, arg.HostID, arg.NetworkIds)
+	return err
+}
+
+const deleteStaleVolumes = `-- name: DeleteStaleVolumes :exec
+
+DELETE FROM docker_volumes
+WHERE host_id = $1 AND NOT (volume_id = ANY($2::text[]))
+`
+
+type DeleteStaleVolumesParams struct {
+	HostID    string   `json:"host_id"`
+	VolumeIds []string `json:"volume_ids"`
+}
+
+func (q *Queries) DeleteStaleVolumes(ctx context.Context, arg DeleteStaleVolumesParams) error {
+	_, err := q.db.Exec(ctx, deleteStaleVolumes, arg.HostID, arg.VolumeIds)
 	return err
 }
 

--- a/server-source-code/internal/db/querier.go
+++ b/server-source-code/internal/db/querier.go
@@ -225,6 +225,12 @@ type Querier interface {
 	DeleteRolePermissions(ctx context.Context, role string) error
 	DeleteRunningComplianceScansByHost(ctx context.Context, hostID string) error
 	DeleteScheduledReport(ctx context.Context, id string) error
+	// Removes containers for a host that were not present in the most recent
+	// Docker report. Callers must only invoke this when the report actually
+	// contained container data, to avoid wiping inventory on an empty/partial report.
+	DeleteStaleContainers(ctx context.Context, arg DeleteStaleContainersParams) error
+	DeleteStaleNetworks(ctx context.Context, arg DeleteStaleNetworksParams) error
+	DeleteStaleVolumes(ctx context.Context, arg DeleteStaleVolumesParams) error
 	DeleteUser(ctx context.Context, id string) error
 	DeleteVolume(ctx context.Context, id string) error
 	DisableTfa(ctx context.Context, id string) error

--- a/server-source-code/internal/sqlc/queries/docker.sql
+++ b/server-source-code/internal/sqlc/queries/docker.sql
@@ -50,7 +50,15 @@ WHERE NOT EXISTS (SELECT 1 FROM docker_containers dc WHERE dc.image_id = di.id);
 DELETE FROM docker_containers WHERE id = ANY($1::text[]);
 
 -- name: DeleteImagesByIDs :exec
+
 DELETE FROM docker_images WHERE id = ANY($1::text[]);
+
+-- name: DeleteStaleContainers :exec
+-- Removes containers for a host that were not present in the most recent
+-- Docker report. Callers must only invoke this when the report actually
+-- contained container data, to avoid wiping inventory on an empty/partial report.
+DELETE FROM docker_containers
+WHERE host_id = $1 AND NOT (container_id = ANY(sqlc.arg(container_ids)::text[]));
 
 -- name: GetContainersByImageID :many
 SELECT * FROM docker_containers WHERE image_id = $1 AND id != $2 LIMIT 10;
@@ -150,6 +158,11 @@ AND (sqlc.narg('search')::text IS NULL OR name ILIKE '%' || sqlc.narg('search') 
 -- name: DeleteVolume :exec
 DELETE FROM docker_volumes WHERE id = $1;
 
+-- name: DeleteStaleVolumes :exec
+
+DELETE FROM docker_volumes
+WHERE host_id = $1 AND NOT (volume_id = ANY(sqlc.arg(volume_ids)::text[]));
+
 -- name: GetVolumesByHostID :many
 SELECT * FROM docker_volumes WHERE host_id = $1 ORDER BY name ASC;
 
@@ -174,6 +187,10 @@ AND (sqlc.narg('search')::text IS NULL OR name ILIKE '%' || sqlc.narg('search') 
 
 -- name: DeleteNetwork :exec
 DELETE FROM docker_networks WHERE id = $1;
+
+-- name: DeleteStaleNetworks :exec
+DELETE FROM docker_networks
+WHERE host_id = $1 AND NOT (network_id = ANY(sqlc.arg(network_ids)::text[]));
 
 -- name: GetNetworksByHostID :many
 SELECT * FROM docker_networks WHERE host_id = $1 ORDER BY name ASC;

--- a/server-source-code/internal/store/docker_integration.go
+++ b/server-source-code/internal/store/docker_integration.go
@@ -293,6 +293,20 @@ func (s *DockerStore) ReceiveDockerData(ctx context.Context, hostID string, payl
 		}
 	}
 
+	// Remove containers no longer reported by the agent.
+	if len(payload.Containers) > 0 {
+		reportedContainerIDs := make([]string, 0, len(payload.Containers))
+		for _, c := range payload.Containers {
+			reportedContainerIDs = append(reportedContainerIDs, c.ContainerID)
+		}
+		if err := d.Queries.DeleteStaleContainers(ctx, db.DeleteStaleContainersParams{
+			HostID:       hostID,
+			ContainerIds: reportedContainerIDs,
+		}); err != nil {
+			return nil, err
+		}
+	}
+
 	// 4. Process volumes
 	for _, v := range payload.Volumes {
 		scope := v.Scope
@@ -334,6 +348,20 @@ func (s *DockerStore) ReceiveDockerData(ctx context.Context, hostID string, payl
 	}
 	result.VolumesReceived = len(payload.Volumes)
 
+	// Remove volumes no longer reported by the agent.
+	if len(payload.Volumes) > 0 {
+		reportedVolumeIDs := make([]string, 0, len(payload.Volumes))
+		for _, v := range payload.Volumes {
+			reportedVolumeIDs = append(reportedVolumeIDs, v.VolumeID)
+		}
+		if err := d.Queries.DeleteStaleVolumes(ctx, db.DeleteStaleVolumesParams{
+			HostID:    hostID,
+			VolumeIds: reportedVolumeIDs,
+		}); err != nil {
+			return nil, err
+		}
+	}
+
 	// 5. Process networks
 	for _, n := range payload.Networks {
 		scope := n.Scope
@@ -366,6 +394,20 @@ func (s *DockerStore) ReceiveDockerData(ctx context.Context, hostID string, payl
 		}
 	}
 	result.NetworksReceived = len(payload.Networks)
+
+	// Remove networks no longer reported by the agent.
+	if len(payload.Networks) > 0 {
+		reportedNetworkIDs := make([]string, 0, len(payload.Networks))
+		for _, n := range payload.Networks {
+			reportedNetworkIDs = append(reportedNetworkIDs, n.NetworkID)
+		}
+		if err := d.Queries.DeleteStaleNetworks(ctx, db.DeleteStaleNetworksParams{
+			HostID:     hostID,
+			NetworkIds: reportedNetworkIDs,
+		}); err != nil {
+			return nil, err
+		}
+	}
 
 	// 6. Process updates (need to resolve image_id UUID from repository+current_tag+image_id)
 	for _, u := range payload.Updates {


### PR DESCRIPTION
## Summary
Fixes #639 (and the duplicate #735 / #734) — the Docker tab kept
showing containers, images, volumes and networks that no longer
existed on the host.

## Root cause
`ReceiveDockerData` (internal/store/docker_integration.go) only ever
upserted containers, volumes and networks reported by the agent. There
was no reconciliation step: entries the agent stopped reporting (e.g.
a container that was stopped and removed on the host) were never
deleted from the database, so they stayed visible in the UI
indefinitely.

## Fix
Adds three new host-scoped queries:
- `DeleteStaleContainers`
- `DeleteStaleVolumes`
- `DeleteStaleNetworks`

Each is called at the end of processing its respective section in
`ReceiveDockerData`, removing rows for the host whose ID was not
present in the current report.

**Safety:** each cleanup only runs when `len(payload.X) > 0`, i.e. the
report actually contained data for that section. This avoids wiping a
host's entire Docker inventory if a single report comes back empty or
partial (e.g. Docker daemon briefly unreachable, agent error).

Images are intentionally not touched directly — they're already
cleaned up via the existing `ListOrphanedImages` mechanism once no
container references them.

## Changes
- `internal/sqlc/queries/docker.sql`: three new queries
- `internal/db/docker.sql.go`, `internal/db/querier.go`: sqlc-generated
- `internal/store/docker_integration.go`: three cleanup calls

## Testing
- `go build ./internal/...` passes
- `gofmt` clean on the changed file
- Not tested end-to-end against a live agent/host; relying on CI +
  review for that. Happy to add a unit test around `ReceiveDockerData`
  if useful — let me know the preferred pattern for this codebase.

Fixes #639