### PR TITLE
2.1.4: agent self-update reliability, compressed binary downloads, Windows OS version

### DIFF
--- a/agent-source-code/cmd/patchmon-agent/commands/version_update.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/version_update.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -16,6 +17,7 @@ import (
 	"regexp"
 	"runtime"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"patchmon-agent/internal/client"
@@ -29,6 +31,12 @@ import (
 const (
 	serverTimeout       = 30 * time.Second
 	versionCheckTimeout = 10 * time.Second // Shorter timeout for version checks
+
+	// The binary download is deliberately bounded by progress, not by a total
+	// deadline: 12MB inside 30s needs 3.2Mbit/s that a 200ms RTT link cannot reach.
+	downloadHeaderTimeout = 30 * time.Second
+	downloadStallTimeout  = 60 * time.Second
+	downloadMaxTimeout    = 30 * time.Minute
 )
 
 // agentVersionOutputRe parses the version out of `patchmon-agent --version`,
@@ -484,6 +492,22 @@ func getServerVersionInfo() (*ServerVersionInfo, error) {
 	return &versionInfo, nil
 }
 
+// stallReader restarts the idle timer whenever bytes arrive, so a download is
+// abandoned only when the link goes quiet rather than when it is merely slow.
+type stallReader struct {
+	r     io.Reader
+	timer *time.Timer
+	idle  time.Duration
+}
+
+func (s *stallReader) Read(p []byte) (int, error) {
+	n, err := s.r.Read(p)
+	if n > 0 {
+		s.timer.Reset(s.idle)
+	}
+	return n, err
+}
+
 // getLatestBinaryFromServer fetches the latest binary information from the PatchMon server
 func getLatestBinaryFromServer() (*ServerVersionResponse, error) {
 	cfgManager := config.New()
@@ -502,7 +526,7 @@ func getLatestBinaryFromServer() (*ServerVersionResponse, error) {
 	platform := getPlatform()
 	url := fmt.Sprintf("%s/api/v1/hosts/agent/download?arch=%s&os=%s", cfg.PatchmonServer, architecture, platform)
 
-	ctx, cancel := context.WithTimeout(context.Background(), serverTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), downloadMaxTimeout)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
@@ -514,20 +538,31 @@ func getLatestBinaryFromServer() (*ServerVersionResponse, error) {
 	req.Header.Set("X-API-ID", credentials.APIID)
 	req.Header.Set("X-API-KEY", credentials.APIKey)
 
-	// Operator-gated insecure TLS for lab/air-gapped deployments.
-	// WARNING: This is dangerous for binary downloads even with hash verification!
-	httpClient := http.DefaultClient
-	if cfg.SkipSSLVerify || client.IsSkipSSLVerifyEnvSet() {
-		logger.Warn("TLS verification disabled for binary download")
-		httpClient = &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{
-					InsecureSkipVerify: true,
-				},
-			},
-		}
+	// Leave Accept-Encoding unset so the transport negotiates gzip and unwraps it
+	// for us; setting it by hand would hand back a compressed body we then hash.
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		TLSHandshakeTimeout:   30 * time.Second,
+		ResponseHeaderTimeout: downloadHeaderTimeout,
 	}
 
+	// Operator-gated insecure TLS for lab/air-gapped deployments.
+	// WARNING: This is dangerous for binary downloads even with hash verification!
+	if cfg.SkipSSLVerify || client.IsSkipSSLVerifyEnvSet() {
+		logger.Warn("TLS verification disabled for binary download")
+		transport.TLSClientConfig = &tls.Config{
+			InsecureSkipVerify: true,
+		}
+	}
+	defer transport.CloseIdleConnections()
+
+	httpClient := &http.Client{Transport: transport}
+
+	started := time.Now()
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, err
@@ -542,14 +577,28 @@ func getLatestBinaryFromServer() (*ServerVersionResponse, error) {
 		return nil, fmt.Errorf("server returned status %d", resp.StatusCode)
 	}
 
+	var stalled atomic.Bool
+	stallTimer := time.AfterFunc(downloadStallTimeout, func() {
+		stalled.Store(true)
+		cancel()
+	})
+	defer stallTimer.Stop()
+
 	// SECURITY: Limit binary download size to prevent DoS attacks
 	// Max 100MB should be more than enough for the agent binary
 	const maxBinarySize = 100 * 1024 * 1024
-	limitedReader := io.LimitReader(resp.Body, maxBinarySize+1)
+	limitedReader := io.LimitReader(&stallReader{
+		r:     resp.Body,
+		timer: stallTimer,
+		idle:  downloadStallTimeout,
+	}, maxBinarySize+1)
 
 	// Read the binary data with size limit
 	binaryData, err := io.ReadAll(limitedReader)
 	if err != nil {
+		if stalled.Load() {
+			return nil, fmt.Errorf("download stalled: no data received for %s after %d bytes", downloadStallTimeout, len(binaryData))
+		}
 		return nil, fmt.Errorf("failed to read binary data: %w", err)
 	}
 
@@ -557,6 +606,12 @@ func getLatestBinaryFromServer() (*ServerVersionResponse, error) {
 	if int64(len(binaryData)) > maxBinarySize {
 		return nil, fmt.Errorf("binary size exceeds maximum allowed (%d MB)", maxBinarySize/(1024*1024))
 	}
+
+	logger.WithFields(map[string]interface{}{
+		"bytes":      len(binaryData),
+		"elapsed_ms": time.Since(started).Milliseconds(),
+		"compressed": resp.Uncompressed,
+	}).Info("Agent binary downloaded")
 
 	// Calculate hash
 	hash := fmt.Sprintf("%x", sha256.Sum256(binaryData))

--- a/agent-source-code/cmd/patchmon-agent/commands/version_update.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/version_update.go
@@ -32,8 +32,6 @@ const (
 	serverTimeout       = 30 * time.Second
 	versionCheckTimeout = 10 * time.Second // Shorter timeout for version checks
 
-	// The binary download is deliberately bounded by progress, not by a total
-	// deadline: 12MB inside 30s needs 3.2Mbit/s that a 200ms RTT link cannot reach.
 	downloadHeaderTimeout = 30 * time.Second
 	downloadStallTimeout  = 60 * time.Second
 	downloadMaxTimeout    = 30 * time.Minute
@@ -127,9 +125,8 @@ func checkVersion() error {
 	return nil
 }
 
-// updateInFlight admits one update at a time. Reports run on their own
-// goroutines and the WebSocket loop triggers updates too, so without this two
-// callers can download concurrently and rename over the same live binary.
+// Without this, a report goroutine and the WebSocket loop can both download and
+// rename over the same live binary.
 var updateInFlight atomic.Bool
 
 func updateAgent() error {
@@ -502,8 +499,6 @@ func getServerVersionInfo() (*ServerVersionInfo, error) {
 	return &versionInfo, nil
 }
 
-// stallReader restarts the idle timer whenever bytes arrive, so a download is
-// abandoned only when the link goes quiet rather than when it is merely slow.
 type stallReader struct {
 	r     io.Reader
 	timer *time.Timer
@@ -550,12 +545,15 @@ func getLatestBinaryFromServer() (*ServerVersionResponse, error) {
 
 	// Leave Accept-Encoding unset so the transport negotiates gzip and unwraps it
 	// for us; setting it by hand would hand back a compressed body we then hash.
+	// Setting DialContext silently disables HTTP/2 unless this is set, which
+	// would quietly downgrade a transport that used to come from DefaultTransport.
 	transport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,
 		}).DialContext,
+		ForceAttemptHTTP2:     true,
 		TLSHandshakeTimeout:   30 * time.Second,
 		ResponseHeaderTimeout: downloadHeaderTimeout,
 	}

--- a/agent-source-code/cmd/patchmon-agent/commands/version_update.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/version_update.go
@@ -545,14 +545,13 @@ func getLatestBinaryFromServer() (*ServerVersionResponse, error) {
 
 	// Leave Accept-Encoding unset so the transport negotiates gzip and unwraps it
 	// for us; setting it by hand would hand back a compressed body we then hash.
-	// Setting DialContext silently disables HTTP/2 unless this is set, which
-	// would quietly downgrade a transport that used to come from DefaultTransport.
 	transport := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: 30 * time.Second,
 		}).DialContext,
+		// Setting DialContext silently disables HTTP/2 unless this is set.
 		ForceAttemptHTTP2:     true,
 		TLSHandshakeTimeout:   30 * time.Second,
 		ResponseHeaderTimeout: downloadHeaderTimeout,

--- a/agent-source-code/cmd/patchmon-agent/commands/version_update.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/version_update.go
@@ -127,7 +127,17 @@ func checkVersion() error {
 	return nil
 }
 
+// updateInFlight admits one update at a time. Reports run on their own
+// goroutines and the WebSocket loop triggers updates too, so without this two
+// callers can download concurrently and rename over the same live binary.
+var updateInFlight atomic.Bool
+
 func updateAgent() error {
+	if !updateInFlight.CompareAndSwap(false, true) {
+		return fmt.Errorf("update skipped: another update is already in progress")
+	}
+	defer updateInFlight.Store(false)
+
 	logger.Info("Updating agent...")
 
 	// Check if we recently updated to prevent update loops

--- a/agent-source-code/cmd/patchmon-agent/commands/version_update_stall_test.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/version_update_stall_test.go
@@ -1,0 +1,100 @@
+package commands
+
+import (
+	"errors"
+	"io"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// slowReader hands back one byte per tick, standing in for a link that is
+// making progress far slower than any fixed download deadline would allow.
+type slowReader struct {
+	remaining int
+	tick      time.Duration
+}
+
+func (s *slowReader) Read(p []byte) (int, error) {
+	if s.remaining == 0 {
+		return 0, io.EOF
+	}
+	time.Sleep(s.tick)
+	s.remaining--
+	p[0] = 'x'
+	return 1, nil
+}
+
+// deadReader accepts the read and never returns anything, standing in for a
+// link that has gone silent without closing.
+type deadReader struct {
+	release chan struct{}
+}
+
+func (d *deadReader) Read(_ []byte) (int, error) {
+	<-d.release
+	return 0, errors.New("connection aborted")
+}
+
+// A slow but live download must survive well past the old 30s total deadline.
+func TestStallReaderAllowsSlowButSteadyProgress(t *testing.T) {
+	idle := 200 * time.Millisecond
+
+	var fired atomic.Bool
+	timer := time.AfterFunc(idle, func() { fired.Store(true) })
+	defer timer.Stop()
+
+	src := &slowReader{remaining: 40, tick: 20 * time.Millisecond}
+	got, err := io.ReadAll(&stallReader{r: src, timer: timer, idle: idle})
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if len(got) != 40 {
+		t.Fatalf("read %d bytes, want 40", len(got))
+	}
+	if fired.Load() {
+		t.Fatal("stall timer fired while the reader was still making progress")
+	}
+}
+
+func TestStallReaderFiresWhenTheLinkGoesQuiet(t *testing.T) {
+	idle := 150 * time.Millisecond
+
+	released := make(chan struct{})
+	var fired atomic.Bool
+	timer := time.AfterFunc(idle, func() {
+		fired.Store(true)
+		close(released)
+	})
+	defer timer.Stop()
+
+	_, err := io.ReadAll(&stallReader{r: &deadReader{release: released}, timer: timer, idle: idle})
+	if err == nil {
+		t.Fatal("expected an error once the link went quiet")
+	}
+	if !fired.Load() {
+		t.Fatal("stall timer did not fire on a silent link")
+	}
+}
+
+// Progress must push the deadline out, not merely delay the first firing.
+func TestStallReaderResetsOnEveryChunk(t *testing.T) {
+	idle := 120 * time.Millisecond
+
+	var fired atomic.Bool
+	timer := time.AfterFunc(idle, func() { fired.Store(true) })
+	defer timer.Stop()
+
+	sr := &stallReader{r: &slowReader{remaining: 6, tick: 60 * time.Millisecond}, timer: timer, idle: idle}
+	buf := make([]byte, 1)
+	for i := 0; i < 6; i++ {
+		if _, err := sr.Read(buf); err != nil {
+			t.Fatalf("read %d: %v", i, err)
+		}
+	}
+
+	// 6 x 60ms is 360ms of wall clock, comfortably past a single 120ms window.
+	if fired.Load() {
+		t.Fatal("stall timer fired despite continuous progress")
+	}
+}

--- a/agent-source-code/cmd/patchmon-agent/commands/version_update_stall_test.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/version_update_stall_test.go
@@ -9,8 +9,6 @@ import (
 	"time"
 )
 
-// A second caller must bounce off the guard rather than start its own download
-// and rename its own temporary file over the live binary.
 func TestUpdateAgentAdmitsOneUpdateAtATime(t *testing.T) {
 	if !updateInFlight.CompareAndSwap(false, true) {
 		t.Fatal("guard was already held before the test started")
@@ -26,14 +24,6 @@ func TestUpdateAgentAdmitsOneUpdateAtATime(t *testing.T) {
 	}
 }
 
-func TestUpdateAgentGuardClearsAfterRefusal(t *testing.T) {
-	if updateInFlight.Load() {
-		t.Fatal("guard leaked from an earlier test")
-	}
-}
-
-// slowReader hands back one byte per tick, standing in for a link that is
-// making progress far slower than any fixed download deadline would allow.
 type slowReader struct {
 	remaining int
 	tick      time.Duration
@@ -49,8 +39,6 @@ func (s *slowReader) Read(p []byte) (int, error) {
 	return 1, nil
 }
 
-// deadReader accepts the read and never returns anything, standing in for a
-// link that has gone silent without closing.
 type deadReader struct {
 	release chan struct{}
 }
@@ -60,7 +48,6 @@ func (d *deadReader) Read(_ []byte) (int, error) {
 	return 0, errors.New("connection aborted")
 }
 
-// A slow but live download must survive well past the old 30s total deadline.
 func TestStallReaderAllowsSlowButSteadyProgress(t *testing.T) {
 	idle := 200 * time.Millisecond
 
@@ -101,7 +88,6 @@ func TestStallReaderFiresWhenTheLinkGoesQuiet(t *testing.T) {
 	}
 }
 
-// Progress must push the deadline out, not merely delay the first firing.
 func TestStallReaderResetsOnEveryChunk(t *testing.T) {
 	idle := 120 * time.Millisecond
 

--- a/agent-source-code/cmd/patchmon-agent/commands/version_update_stall_test.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/version_update_stall_test.go
@@ -3,10 +3,34 @@ package commands
 import (
 	"errors"
 	"io"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 )
+
+// A second caller must bounce off the guard rather than start its own download
+// and rename its own temporary file over the live binary.
+func TestUpdateAgentAdmitsOneUpdateAtATime(t *testing.T) {
+	if !updateInFlight.CompareAndSwap(false, true) {
+		t.Fatal("guard was already held before the test started")
+	}
+	defer updateInFlight.Store(false)
+
+	err := updateAgent()
+	if err == nil {
+		t.Fatal("expected the second concurrent update to be refused")
+	}
+	if !strings.Contains(err.Error(), "already in progress") {
+		t.Fatalf("error = %v, want an already-in-progress refusal", err)
+	}
+}
+
+func TestUpdateAgentGuardClearsAfterRefusal(t *testing.T) {
+	if updateInFlight.Load() {
+		t.Fatal("guard leaked from an earlier test")
+	}
+}
 
 // slowReader hands back one byte per tick, standing in for a link that is
 // making progress far slower than any fixed download deadline would allow.

--- a/agent-source-code/cmd/patchmon-agent/commands/version_update_stall_test.go
+++ b/agent-source-code/cmd/patchmon-agent/commands/version_update_stall_test.go
@@ -103,7 +103,6 @@ func TestStallReaderResetsOnEveryChunk(t *testing.T) {
 		}
 	}
 
-	// 6 x 60ms is 360ms of wall clock, comfortably past a single 120ms window.
 	if fired.Load() {
 		t.Fatal("stall timer fired despite continuous progress")
 	}

--- a/agent-source-code/internal/system/osversion_other.go
+++ b/agent-source-code/internal/system/osversion_other.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package system
+
+func windowsReleaseID() string {
+	return ""
+}

--- a/agent-source-code/internal/system/osversion_test.go
+++ b/agent-source-code/internal/system/osversion_test.go
@@ -1,0 +1,29 @@
+package system
+
+import "testing"
+
+func TestResolveWindowsOSVersion(t *testing.T) {
+	cases := []struct {
+		name            string
+		platformVersion string
+		releaseID       string
+		kernelVersion   string
+		want            string
+	}{
+		{"server 2022 reports DisplayVersion", "23H2", "2009", "10.0.20348.2762 Build 20348.2762", "23H2"},
+		{"server 2016 falls back to ReleaseId", "", "1607", "10.0.14393.9418 Build 14393.9418", "1607"},
+		{"server 2019 falls back to ReleaseId", "", "1809", "10.0.17763.6414 Build 17763.6414", "1809"},
+		{"registry unreadable falls back to kernel version", "", "", "10.0.14393.9418 Build 14393.9418", "10.0.14393.9418 Build 14393.9418"},
+		{"nothing available", "", "", "", "Unknown"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := resolveWindowsOSVersion(tc.platformVersion, tc.releaseID, tc.kernelVersion)
+			if got != tc.want {
+				t.Errorf("resolveWindowsOSVersion(%q, %q, %q) = %q, want %q",
+					tc.platformVersion, tc.releaseID, tc.kernelVersion, got, tc.want)
+			}
+		})
+	}
+}

--- a/agent-source-code/internal/system/osversion_windows.go
+++ b/agent-source-code/internal/system/osversion_windows.go
@@ -1,0 +1,25 @@
+//go:build windows
+
+package system
+
+import "golang.org/x/sys/windows/registry"
+
+// ReleaseId is the only marketing version on Server 2016 and 2019 LTSC, where
+// DisplayVersion (gopsutil's PlatformVersion) does not exist.
+func windowsReleaseID() string {
+	k, err := registry.OpenKey(
+		registry.LOCAL_MACHINE,
+		`SOFTWARE\Microsoft\Windows NT\CurrentVersion`,
+		registry.QUERY_VALUE|registry.WOW64_64KEY,
+	)
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = k.Close() }()
+
+	v, _, err := k.GetStringValue("ReleaseId")
+	if err != nil {
+		return ""
+	}
+	return v
+}

--- a/agent-source-code/internal/system/system.go
+++ b/agent-source-code/internal/system/system.go
@@ -161,6 +161,17 @@ func (d *Detector) getFreeBSDInfo() (osType, osVersion string, err error) {
 	return osType, osVersion, nil
 }
 
+// gopsutil returns DisplayVersion as PlatformVersion, and it is absent before
+// Server 2022, so 2016 and 2019 LTSC need the ReleaseId fallback.
+func resolveWindowsOSVersion(platformVersion, releaseID, kernelVersion string) string {
+	for _, v := range []string{platformVersion, releaseID, kernelVersion} {
+		if v != "" {
+			return v
+		}
+	}
+	return "Unknown"
+}
+
 // DetectOS detects the operating system and version using /etc/os-release
 func (d *Detector) DetectOS() (osType, osVersion string, err error) {
 	// Check for Windows first (uses gopsutil)
@@ -171,11 +182,7 @@ func (d *Detector) DetectOS() (osType, osVersion string, err error) {
 		if infoErr != nil {
 			return "Windows", "Unknown", nil
 		}
-		osVer := info.PlatformVersion
-		if osVer == "" {
-			osVer = "Unknown"
-		}
-		return "Windows", osVer, nil
+		return "Windows", resolveWindowsOSVersion(info.PlatformVersion, windowsReleaseID(), info.KernelVersion), nil
 	}
 	// Check for FreeBSD first (doesn't have /etc/os-release)
 	if d.isFreeBSD() {

--- a/docs/patchmon-operator-guide.md
+++ b/docs/patchmon-operator-guide.md
@@ -4125,6 +4125,36 @@ Downloads the latest agent binary from the PatchMon server and performs an in-pl
 
 > **Note:** In normal operation, the agent auto-updates when the server signals a new version. You only need to run `update-agent` manually when auto-update is disabled or if you want to force an immediate update.
 
+##### Windows: Agents Stuck on 2.0.2
+
+On Windows the running `patchmon-agent.exe` is locked by the Service Control Manager, so it cannot be overwritten in place. Agents on 2.1.0 and later handle this by delegating the replacement and the service restart to a detached helper, and self-update works normally.
+
+Agents on 2.0.2 and earlier do not have that helper. Because the agent performing the update is the old binary itself, it cannot upgrade itself and keeps failing with:
+
+```
+Error: failed to replace executable (permission denied): rename
+C:\Program Files\PatchMon\patchmon-agent.exe.new ->
+C:\Program Files\PatchMon\patchmon-agent.exe: Access is denied.
+```
+
+Upgrading a newer server does not clear this, because the fix lives in the agent binary that cannot be installed. Replace the binary once by hand and self-update works from then on:
+
+```powershell
+# 1. Stop the service
+Stop-Service PatchMonAgent
+
+# 2. Replace C:\Program Files\PatchMon\patchmon-agent.exe with the current
+#    Windows agent (amd64 or arm64 to match the host), keeping the same filename
+
+# 3. Start the service
+Start-Service PatchMonAgent
+
+# 4. Confirm the new version
+& 'C:\Program Files\PatchMon\patchmon-agent.exe' --version
+```
+
+Configuration and credentials live in `C:\ProgramData\PatchMon\`, not alongside the binary, so the host keeps its identity and does not need re-enrolling.
+
 ---
 
 #### `--version`: Print Version

--- a/server-source-code/go.mod
+++ b/server-source-code/go.mod
@@ -22,6 +22,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.5
 	golang.org/x/crypto v0.54.0
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sync v0.22.0
 	golang.org/x/text v0.40.0
 )
 
@@ -56,7 +57,6 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/net v0.57.0 // indirect
-	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	golang.org/x/tools v0.48.0 // indirect

--- a/server-source-code/internal/handler/agent_binary_serve.go
+++ b/server-source-code/internal/handler/agent_binary_serve.go
@@ -12,13 +12,15 @@ import (
 	"sync"
 )
 
+// Each live compressor holds roughly 800KB of flate state on a heap shared by
+// every context, so concurrency is capped and excess requests serve uncompressed.
+const maxConcurrentAgentGzip = 16
+
+var agentGzipSlots = make(chan struct{}, maxConcurrentAgentGzip)
+
 var agentGzipWriterPool = sync.Pool{
 	New: func() interface{} {
-		w, err := gzip.NewWriterLevel(io.Discard, gzip.BestSpeed)
-		if err != nil {
-			return gzip.NewWriter(io.Discard)
-		}
-		return w
+		return gzip.NewWriter(io.Discard)
 	},
 }
 
@@ -44,18 +46,36 @@ func acceptsGzip(header string) bool {
 	return false
 }
 
+// Byte offsets only mean anything against the identity encoding, and only
+// ServeContent knows how to answer a conditional request, so both stay raw.
+func compressible(r *http.Request) bool {
+	if r.Header.Get("Range") != "" || r.Header.Get("If-Range") != "" {
+		return false
+	}
+	if r.Header.Get("If-None-Match") != "" || r.Header.Get("If-Modified-Since") != "" {
+		return false
+	}
+	return acceptsGzip(r.Header.Get("Accept-Encoding"))
+}
+
 // serveAgentBinary writes an agent binary, compressing it when the client
-// accepts gzip. The binaries are ~12MB raw and ~5MB gzipped, which decides
-// whether a high-latency agent finishes its self-update before timing out.
+// accepts gzip and a compressor slot is free.
 func serveAgentBinary(w http.ResponseWriter, r *http.Request, binaryName string, info os.FileInfo, f *os.File) {
 	w.Header().Set("Content-Type", "application/octet-stream")
 	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, binaryName))
 	w.Header().Add("Vary", "Accept-Encoding")
 
-	// Byte offsets only mean anything against the identity encoding, and only
-	// ServeContent knows how to answer a conditional request, so both stay raw.
-	conditional := r.Header.Get("If-None-Match") != "" || r.Header.Get("If-Modified-Since") != "" || r.Header.Get("If-Range") != ""
-	if r.Header.Get("Range") != "" || conditional || !acceptsGzip(r.Header.Get("Accept-Encoding")) {
+	if !compressible(r) {
+		http.ServeContent(w, r, binaryName, info.ModTime(), f)
+		return
+	}
+
+	// Falling back to the uncompressed path under load is never worse than the
+	// behaviour before compression existed, so a burst degrades instead of failing.
+	select {
+	case agentGzipSlots <- struct{}{}:
+		defer func() { <-agentGzipSlots }()
+	default:
 		http.ServeContent(w, r, binaryName, info.ModTime(), f)
 		return
 	}
@@ -63,12 +83,14 @@ func serveAgentBinary(w http.ResponseWriter, r *http.Request, binaryName string,
 	w.Header().Set("Content-Encoding", "gzip")
 	w.WriteHeader(http.StatusOK)
 
-	gzw, ok := agentGzipWriterPool.Get().(*gzip.Writer)
-	if !ok {
-		gzw = gzip.NewWriter(io.Discard)
-	}
+	gzw := agentGzipWriterPool.Get().(*gzip.Writer)
 	gzw.Reset(w)
-	defer agentGzipWriterPool.Put(gzw)
+	defer func() {
+		// Without this the pooled writer keeps the ResponseWriter, and with it the
+		// connection and request, reachable until the next Get.
+		gzw.Reset(io.Discard)
+		agentGzipWriterPool.Put(gzw)
+	}()
 
 	if _, err := io.Copy(gzw, f); err != nil {
 		slog.Warn("agent binary download interrupted", "name", binaryName, "error", err)

--- a/server-source-code/internal/handler/agent_binary_serve.go
+++ b/server-source-code/internal/handler/agent_binary_serve.go
@@ -1,0 +1,81 @@
+package handler
+
+import (
+	"compress/gzip"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+var agentGzipWriterPool = sync.Pool{
+	New: func() interface{} {
+		w, err := gzip.NewWriterLevel(io.Discard, gzip.BestSpeed)
+		if err != nil {
+			return gzip.NewWriter(io.Discard)
+		}
+		return w
+	},
+}
+
+// acceptsGzip reports whether the client offered gzip with a non-zero q value.
+// A plain substring test would compress for "gzip;q=0", which means the opposite.
+func acceptsGzip(header string) bool {
+	for _, part := range strings.Split(header, ",") {
+		fields := strings.Split(strings.TrimSpace(part), ";")
+		if !strings.EqualFold(strings.TrimSpace(fields[0]), "gzip") {
+			continue
+		}
+		for _, param := range fields[1:] {
+			param = strings.TrimSpace(param)
+			if !strings.HasPrefix(strings.ToLower(param), "q=") {
+				continue
+			}
+			if q, err := strconv.ParseFloat(param[2:], 64); err == nil && q == 0 {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+// serveAgentBinary writes an agent binary, compressing it when the client
+// accepts gzip. The binaries are ~12MB raw and ~5MB gzipped, which decides
+// whether a high-latency agent finishes its self-update before timing out.
+func serveAgentBinary(w http.ResponseWriter, r *http.Request, binaryName string, info os.FileInfo, f *os.File) {
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, binaryName))
+	w.Header().Add("Vary", "Accept-Encoding")
+
+	// Byte offsets only mean anything against the identity encoding, and only
+	// ServeContent knows how to answer a conditional request, so both stay raw.
+	conditional := r.Header.Get("If-None-Match") != "" || r.Header.Get("If-Modified-Since") != "" || r.Header.Get("If-Range") != ""
+	if r.Header.Get("Range") != "" || conditional || !acceptsGzip(r.Header.Get("Accept-Encoding")) {
+		http.ServeContent(w, r, binaryName, info.ModTime(), f)
+		return
+	}
+
+	w.Header().Set("Content-Encoding", "gzip")
+	w.WriteHeader(http.StatusOK)
+
+	gzw, ok := agentGzipWriterPool.Get().(*gzip.Writer)
+	if !ok {
+		gzw = gzip.NewWriter(io.Discard)
+	}
+	gzw.Reset(w)
+	defer agentGzipWriterPool.Put(gzw)
+
+	if _, err := io.Copy(gzw, f); err != nil {
+		slog.Warn("agent binary download interrupted", "name", binaryName, "error", err)
+		_ = gzw.Close()
+		return
+	}
+	if err := gzw.Close(); err != nil {
+		slog.Warn("agent binary download failed to flush", "name", binaryName, "error", err)
+	}
+}

--- a/server-source-code/internal/handler/agent_binary_serve.go
+++ b/server-source-code/internal/handler/agent_binary_serve.go
@@ -23,8 +23,8 @@ const (
 	agentGzipSweepInterval = time.Hour
 )
 
-// singleflight is what bounds concurrent compressors: one per binary, and the
-// set of binaries is a fixed compile-time map, so the shared heap cannot spike.
+// singleflight is what bounds concurrent compressors: one per binary version,
+// over a servable set fixed at compile time in util.agentBinaryNames.
 var (
 	agentGzipCache   sync.Map
 	agentGzipGroup   singleflight.Group
@@ -95,7 +95,10 @@ func lookupAgentGzip(binaryPath string, info os.FileInfo) ([]byte, bool) {
 }
 
 func buildAgentGzip(binaryPath string, info os.FileInfo, f *os.File) ([]byte, error) {
-	v, err, _ := agentGzipGroup.Do(binaryPath, func() (interface{}, error) {
+	// Keying on the path alone would let a follower that stat'd a replaced binary
+	// receive the leader's pre-replacement bytes.
+	key := fmt.Sprintf("%s|%d|%d", binaryPath, info.ModTime().UnixNano(), info.Size())
+	v, err, _ := agentGzipGroup.Do(key, func() (interface{}, error) {
 		if data, ok := lookupAgentGzip(binaryPath, info); ok {
 			return data, nil
 		}
@@ -117,7 +120,10 @@ func buildAgentGzip(binaryPath string, info os.FileInfo, f *os.File) ([]byte, er
 			return nil, closeErr
 		}
 
-		entry := &agentGzipEntry{data: buf.Bytes(), modTime: info.ModTime(), size: info.Size()}
+		compressed := make([]byte, buf.Len())
+		copy(compressed, buf.Bytes())
+
+		entry := &agentGzipEntry{data: compressed, modTime: info.ModTime(), size: info.Size()}
 		entry.lastAccess.Store(time.Now().UnixNano())
 		agentGzipCache.Store(binaryPath, entry)
 		agentGzipFills.Add(1)
@@ -190,6 +196,7 @@ func serveAgentBinary(w http.ResponseWriter, r *http.Request, binaryPath string,
 	}
 
 	w.Header().Set("Content-Encoding", "gzip")
+	w.Header().Set("Accept-Ranges", "none")
 	w.Header().Set("Content-Length", strconv.Itoa(len(data)))
 	w.Header().Set("Last-Modified", info.ModTime().UTC().Format(http.TimeFormat))
 	w.WriteHeader(http.StatusOK)

--- a/server-source-code/internal/handler/agent_binary_serve.go
+++ b/server-source-code/internal/handler/agent_binary_serve.go
@@ -1,26 +1,48 @@
 package handler
 
 import (
+	"bytes"
 	"compress/gzip"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/sync/singleflight"
 )
 
-// Live compressors hold flate state on a heap shared by every context.
-const maxConcurrentAgentGzip = 16
+const (
+	agentGzipIdleTTL       = 24 * time.Hour
+	agentGzipSweepInterval = time.Hour
+)
 
-var agentGzipSlots = make(chan struct{}, maxConcurrentAgentGzip)
+// singleflight is what bounds concurrent compressors: one per binary, and the
+// set of binaries is a fixed compile-time map, so the shared heap cannot spike.
+var (
+	agentGzipCache   sync.Map
+	agentGzipGroup   singleflight.Group
+	agentGzipSweeper sync.Once
+	agentGzipFills   atomic.Int64
+)
 
 var agentGzipWriterPool = sync.Pool{
 	New: func() interface{} {
 		return gzip.NewWriter(io.Discard)
 	},
+}
+
+type agentGzipEntry struct {
+	data       []byte
+	modTime    time.Time
+	size       int64
+	lastAccess atomic.Int64
 }
 
 // acceptsGzip reports whether the client offered gzip with a non-zero q value.
@@ -57,9 +79,96 @@ func compressible(r *http.Request) bool {
 	return acceptsGzip(r.Header.Get("Accept-Encoding"))
 }
 
-// serveAgentBinary writes an agent binary, compressing it when the client
-// accepts gzip and a compressor slot is free.
-func serveAgentBinary(w http.ResponseWriter, r *http.Request, binaryName string, info os.FileInfo, f *os.File) {
+// A cached entry is only valid for the exact file it was built from: an upgrade
+// that replaced the binary would otherwise serve old bytes against a new hash.
+func lookupAgentGzip(binaryPath string, info os.FileInfo) ([]byte, bool) {
+	v, ok := agentGzipCache.Load(binaryPath)
+	if !ok {
+		return nil, false
+	}
+	entry, ok := v.(*agentGzipEntry)
+	if !ok || !entry.modTime.Equal(info.ModTime()) || entry.size != info.Size() {
+		return nil, false
+	}
+	entry.lastAccess.Store(time.Now().UnixNano())
+	return entry.data, true
+}
+
+func buildAgentGzip(binaryPath string, info os.FileInfo, f *os.File) ([]byte, error) {
+	v, err, _ := agentGzipGroup.Do(binaryPath, func() (interface{}, error) {
+		if data, ok := lookupAgentGzip(binaryPath, info); ok {
+			return data, nil
+		}
+
+		started := time.Now()
+		var buf bytes.Buffer
+		buf.Grow(int(info.Size() / 2))
+
+		zw := agentGzipWriterPool.Get().(*gzip.Writer)
+		zw.Reset(&buf)
+		_, copyErr := io.Copy(zw, f)
+		closeErr := zw.Close()
+		zw.Reset(io.Discard)
+		agentGzipWriterPool.Put(zw)
+		if copyErr != nil {
+			return nil, copyErr
+		}
+		if closeErr != nil {
+			return nil, closeErr
+		}
+
+		entry := &agentGzipEntry{data: buf.Bytes(), modTime: info.ModTime(), size: info.Size()}
+		entry.lastAccess.Store(time.Now().UnixNano())
+		agentGzipCache.Store(binaryPath, entry)
+		agentGzipFills.Add(1)
+		startAgentGzipSweeper()
+
+		slog.Info("compressed agent binary",
+			"name", filepath.Base(binaryPath),
+			"raw_bytes", info.Size(),
+			"gzip_bytes", len(entry.data),
+			"elapsed_ms", time.Since(started).Milliseconds())
+
+		return entry.data, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	data, ok := v.([]byte)
+	if !ok {
+		return nil, fmt.Errorf("unexpected cache value for %s", binaryPath)
+	}
+	return data, nil
+}
+
+func startAgentGzipSweeper() {
+	agentGzipSweeper.Do(func() {
+		go func() {
+			ticker := time.NewTicker(agentGzipSweepInterval)
+			for range ticker.C {
+				evictIdleAgentGzip(time.Now())
+			}
+		}()
+	})
+}
+
+func evictIdleAgentGzip(now time.Time) int {
+	evicted := 0
+	agentGzipCache.Range(func(key, value interface{}) bool {
+		entry, ok := value.(*agentGzipEntry)
+		if !ok || now.Sub(time.Unix(0, entry.lastAccess.Load())) >= agentGzipIdleTTL {
+			agentGzipCache.Delete(key)
+			evicted++
+		}
+		return true
+	})
+	return evicted
+}
+
+// serveAgentBinary writes an agent binary, serving a cached gzip copy when the
+// client accepts one.
+func serveAgentBinary(w http.ResponseWriter, r *http.Request, binaryPath string, info os.FileInfo, f *os.File) {
+	binaryName := filepath.Base(binaryPath)
 	w.Header().Set("Content-Type", "application/octet-stream")
 	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, binaryName))
 	w.Header().Add("Vary", "Accept-Encoding")
@@ -69,34 +178,25 @@ func serveAgentBinary(w http.ResponseWriter, r *http.Request, binaryName string,
 		return
 	}
 
-	select {
-	case agentGzipSlots <- struct{}{}:
-		defer func() { <-agentGzipSlots }()
-	default:
-		http.ServeContent(w, r, binaryName, info.ModTime(), f)
-		return
+	data, ok := lookupAgentGzip(binaryPath, info)
+	if !ok {
+		built, err := buildAgentGzip(binaryPath, info, f)
+		if err != nil {
+			slog.Warn("agent binary compression failed", "name", binaryName, "error", err)
+			http.ServeContent(w, r, binaryName, info.ModTime(), f)
+			return
+		}
+		data = built
 	}
 
 	w.Header().Set("Content-Encoding", "gzip")
+	w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+	w.Header().Set("Last-Modified", info.ModTime().UTC().Format(http.TimeFormat))
 	w.WriteHeader(http.StatusOK)
-
-	gzw := agentGzipWriterPool.Get().(*gzip.Writer)
-	gzw.Reset(w)
-	defer func() {
-		// Without this the pooled writer keeps the ResponseWriter, and with it the
-		// connection and request, reachable until the next Get.
-		gzw.Reset(io.Discard)
-		agentGzipWriterPool.Put(gzw)
-	}()
 
 	// A client hanging up mid-download is a client-side event, and during a release
 	// stampede it would otherwise flood the log every context shares.
-	if _, err := io.Copy(gzw, f); err != nil {
+	if _, err := w.Write(data); err != nil {
 		slog.Debug("agent binary download interrupted", "name", binaryName, "error", err)
-		_ = gzw.Close()
-		return
-	}
-	if err := gzw.Close(); err != nil {
-		slog.Debug("agent binary download failed to flush", "name", binaryName, "error", err)
 	}
 }

--- a/server-source-code/internal/handler/agent_binary_serve.go
+++ b/server-source-code/internal/handler/agent_binary_serve.go
@@ -12,8 +12,7 @@ import (
 	"sync"
 )
 
-// Each live compressor holds roughly 800KB of flate state on a heap shared by
-// every context, so concurrency is capped and excess requests serve uncompressed.
+// Live compressors hold flate state on a heap shared by every context.
 const maxConcurrentAgentGzip = 16
 
 var agentGzipSlots = make(chan struct{}, maxConcurrentAgentGzip)
@@ -70,8 +69,6 @@ func serveAgentBinary(w http.ResponseWriter, r *http.Request, binaryName string,
 		return
 	}
 
-	// Falling back to the uncompressed path under load is never worse than the
-	// behaviour before compression existed, so a burst degrades instead of failing.
 	select {
 	case agentGzipSlots <- struct{}{}:
 		defer func() { <-agentGzipSlots }()
@@ -92,12 +89,14 @@ func serveAgentBinary(w http.ResponseWriter, r *http.Request, binaryName string,
 		agentGzipWriterPool.Put(gzw)
 	}()
 
+	// A client hanging up mid-download is a client-side event, and during a release
+	// stampede it would otherwise flood the log every context shares.
 	if _, err := io.Copy(gzw, f); err != nil {
-		slog.Warn("agent binary download interrupted", "name", binaryName, "error", err)
+		slog.Debug("agent binary download interrupted", "name", binaryName, "error", err)
 		_ = gzw.Close()
 		return
 	}
 	if err := gzw.Close(); err != nil {
-		slog.Warn("agent binary download failed to flush", "name", binaryName, "error", err)
+		slog.Debug("agent binary download failed to flush", "name", binaryName, "error", err)
 	}
 }

--- a/server-source-code/internal/handler/agent_binary_serve_test.go
+++ b/server-source-code/internal/handler/agent_binary_serve_test.go
@@ -5,12 +5,15 @@ import (
 	"compress/gzip"
 	"crypto/rand"
 	"crypto/sha256"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
+	"time"
 )
 
 func TestAcceptsGzip(t *testing.T) {
@@ -60,8 +63,19 @@ func compressibleBinary(t *testing.T, size int) (string, []byte) {
 	return path, data
 }
 
+func resetAgentGzipCache(t *testing.T) {
+	t.Helper()
+
+	agentGzipCache.Range(func(k, _ interface{}) bool {
+		agentGzipCache.Delete(k)
+		return true
+	})
+	agentGzipFills.Store(0)
+}
+
 func binaryServer(t *testing.T, path string) *httptest.Server {
 	t.Helper()
+	resetAgentGzipCache(t)
 
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		f, err := os.Open(path)
@@ -76,7 +90,7 @@ func binaryServer(t *testing.T, path string) *httptest.Server {
 			t.Errorf("stat: %v", err)
 			return
 		}
-		serveAgentBinary(w, r, filepath.Base(path), info, f)
+		serveAgentBinary(w, r, path, info, f)
 	}))
 }
 
@@ -247,68 +261,6 @@ func TestServeAgentBinaryConditionalRequestStillAnswers304(t *testing.T) {
 	}
 }
 
-func TestServeAgentBinaryFallsBackToIdentityWhenSlotsExhausted(t *testing.T) {
-	path, want := compressibleBinary(t, 64*1024)
-	srv := binaryServer(t, path)
-	defer srv.Close()
-
-	for i := 0; i < maxConcurrentAgentGzip; i++ {
-		agentGzipSlots <- struct{}{}
-	}
-	defer func() {
-		for i := 0; i < maxConcurrentAgentGzip; i++ {
-			<-agentGzipSlots
-		}
-	}()
-
-	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
-	if err != nil {
-		t.Fatalf("request: %v", err)
-	}
-	req.Header.Set("Accept-Encoding", "gzip")
-
-	client := &http.Client{Transport: &http.Transport{DisableCompression: true}}
-	resp, err := client.Do(req)
-	if err != nil {
-		t.Fatalf("do: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if enc := resp.Header.Get("Content-Encoding"); enc != "" {
-		t.Fatalf("Content-Encoding = %q, want empty once slots are exhausted", enc)
-	}
-	if resp.ContentLength != int64(len(want)) {
-		t.Fatalf("Content-Length = %d, want %d", resp.ContentLength, len(want))
-	}
-
-	got, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("read: %v", err)
-	}
-	if sha256.Sum256(got) != sha256.Sum256(want) {
-		t.Fatal("fallback response does not match the source file")
-	}
-}
-
-func TestServeAgentBinarySlotsAreReleased(t *testing.T) {
-	path, _ := compressibleBinary(t, 32*1024)
-	srv := binaryServer(t, path)
-	defer srv.Close()
-
-	for i := 0; i < maxConcurrentAgentGzip+4; i++ {
-		resp, err := srv.Client().Get(srv.URL)
-		if err != nil {
-			t.Fatalf("get %d: %v", i, err)
-		}
-		_, _ = io.Copy(io.Discard, resp.Body)
-		_ = resp.Body.Close()
-	}
-
-	if len(agentGzipSlots) != 0 {
-		t.Fatalf("%d slots still held after sequential requests", len(agentGzipSlots))
-	}
-}
-
 func TestServeAgentBinaryPooledWritersDoNotBleed(t *testing.T) {
 	path, want := compressibleBinary(t, 128*1024)
 	srv := binaryServer(t, path)
@@ -327,5 +279,167 @@ func TestServeAgentBinaryPooledWritersDoNotBleed(t *testing.T) {
 		if sha256.Sum256(got) != sha256.Sum256(want) {
 			t.Fatalf("response %d does not match the source file", i)
 		}
+	}
+}
+
+func TestServeAgentBinaryCompressesOnlyOncePerBinary(t *testing.T) {
+	path, want := compressibleBinary(t, 256*1024)
+	srv := binaryServer(t, path)
+	defer srv.Close()
+
+	for i := 0; i < 12; i++ {
+		resp, err := srv.Client().Get(srv.URL)
+		if err != nil {
+			t.Fatalf("get %d: %v", i, err)
+		}
+		got, err := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if err != nil {
+			t.Fatalf("read %d: %v", i, err)
+		}
+		if sha256.Sum256(got) != sha256.Sum256(want) {
+			t.Fatalf("response %d does not match the source file", i)
+		}
+	}
+
+	if n := agentGzipFills.Load(); n != 1 {
+		t.Fatalf("compressed %d times across 12 requests, want 1", n)
+	}
+}
+
+func TestServeAgentBinaryConcurrentColdRequestsCompressOnce(t *testing.T) {
+	path, want := compressibleBinary(t, 512*1024)
+	srv := binaryServer(t, path)
+	defer srv.Close()
+
+	const callers = 32
+	var wg sync.WaitGroup
+	errs := make(chan error, callers)
+	start := make(chan struct{})
+
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			resp, err := srv.Client().Get(srv.URL)
+			if err != nil {
+				errs <- err
+				return
+			}
+			got, err := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			if err != nil {
+				errs <- err
+				return
+			}
+			if sha256.Sum256(got) != sha256.Sum256(want) {
+				errs <- fmt.Errorf("payload mismatch")
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatalf("concurrent caller: %v", err)
+	}
+
+	if n := agentGzipFills.Load(); n != 1 {
+		t.Fatalf("compressed %d times across %d concurrent cold requests, want 1", n, callers)
+	}
+}
+
+func TestServeAgentBinaryRecompressesWhenBinaryReplaced(t *testing.T) {
+	path, _ := compressibleBinary(t, 128*1024)
+	srv := binaryServer(t, path)
+	defer srv.Close()
+
+	resp, err := srv.Client().Get(srv.URL)
+	if err != nil {
+		t.Fatalf("first get: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+
+	replacement := make([]byte, 128*1024)
+	for i := range replacement {
+		replacement[i] = byte('a' + i%23)
+	}
+	if err := os.WriteFile(path, replacement, 0o600); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+	if err := os.Chtimes(path, time.Now().Add(time.Hour), time.Now().Add(time.Hour)); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	resp2, err := srv.Client().Get(srv.URL)
+	if err != nil {
+		t.Fatalf("second get: %v", err)
+	}
+	got, err := io.ReadAll(resp2.Body)
+	_ = resp2.Body.Close()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+
+	if sha256.Sum256(got) != sha256.Sum256(replacement) {
+		t.Fatal("served the stale cached copy after the binary was replaced")
+	}
+	if n := agentGzipFills.Load(); n != 2 {
+		t.Fatalf("compressed %d times, want 2 after a replacement", n)
+	}
+}
+
+func TestEvictIdleAgentGzipDropsOnlyStaleEntries(t *testing.T) {
+	resetAgentGzipCache(t)
+
+	fresh := &agentGzipEntry{data: []byte("fresh"), size: 5}
+	fresh.lastAccess.Store(time.Now().UnixNano())
+	agentGzipCache.Store("/fresh", fresh)
+
+	stale := &agentGzipEntry{data: []byte("stale"), size: 5}
+	stale.lastAccess.Store(time.Now().Add(-agentGzipIdleTTL - time.Minute).UnixNano())
+	agentGzipCache.Store("/stale", stale)
+
+	if evicted := evictIdleAgentGzip(time.Now()); evicted != 1 {
+		t.Fatalf("evicted %d entries, want 1", evicted)
+	}
+	if _, ok := agentGzipCache.Load("/fresh"); !ok {
+		t.Fatal("evicted an entry that was still in use")
+	}
+	if _, ok := agentGzipCache.Load("/stale"); ok {
+		t.Fatal("kept an entry idle past the TTL")
+	}
+}
+
+func TestServeAgentBinaryCachedResponseCarriesContentLength(t *testing.T) {
+	path, _ := compressibleBinary(t, 256*1024)
+	srv := binaryServer(t, path)
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	client := &http.Client{Transport: &http.Transport{DisableCompression: true}}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.ContentLength <= 0 {
+		t.Fatalf("ContentLength = %d, want a positive length on the gzip path", resp.ContentLength)
+	}
+	wire, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if int64(len(wire)) != resp.ContentLength {
+		t.Fatalf("read %d bytes, Content-Length said %d", len(wire), resp.ContentLength)
 	}
 }

--- a/server-source-code/internal/handler/agent_binary_serve_test.go
+++ b/server-source-code/internal/handler/agent_binary_serve_test.go
@@ -443,3 +443,52 @@ func TestServeAgentBinaryCachedResponseCarriesContentLength(t *testing.T) {
 		t.Fatalf("read %d bytes, Content-Length said %d", len(wire), resp.ContentLength)
 	}
 }
+
+func TestServeAgentBinaryGzipRefusesRangeResumption(t *testing.T) {
+	path, _ := compressibleBinary(t, 128*1024)
+	srv := binaryServer(t, path)
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	client := &http.Client{Transport: &http.Transport{DisableCompression: true}}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if got := resp.Header.Get("Accept-Ranges"); got != "none" {
+		t.Fatalf("Accept-Ranges = %q, want none so a resume cannot splice identity bytes into a gzip stream", got)
+	}
+}
+
+func TestCachedGzipDoesNotRetainSpareCapacity(t *testing.T) {
+	path, _ := compressibleBinary(t, 1024*1024)
+	srv := binaryServer(t, path)
+	defer srv.Close()
+
+	resp, err := srv.Client().Get(srv.URL)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+
+	v, ok := agentGzipCache.Load(path)
+	if !ok {
+		t.Fatal("entry was not cached")
+	}
+	entry, ok := v.(*agentGzipEntry)
+	if !ok {
+		t.Fatal("unexpected cache value type")
+	}
+	if cap(entry.data) != len(entry.data) {
+		t.Fatalf("cached slice retains %d bytes of spare capacity above its %d byte length",
+			cap(entry.data)-len(entry.data), len(entry.data))
+	}
+}

--- a/server-source-code/internal/handler/agent_binary_serve_test.go
+++ b/server-source-code/internal/handler/agent_binary_serve_test.go
@@ -1,0 +1,277 @@
+package handler
+
+import (
+	"bytes"
+	"compress/gzip"
+	"crypto/rand"
+	"crypto/sha256"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAcceptsGzip(t *testing.T) {
+	cases := []struct {
+		name   string
+		header string
+		want   bool
+	}{
+		{"empty", "", false},
+		{"bare gzip", "gzip", true},
+		{"go transport default", "gzip", true},
+		{"browser list", "gzip, deflate, br", true},
+		{"with quality", "gzip;q=0.8, deflate", true},
+		{"explicitly refused", "gzip;q=0", false},
+		{"refused with spaces", "gzip; q=0", false},
+		{"refused among others", "deflate, gzip;q=0", false},
+		{"zero point zero", "gzip;q=0.0", false},
+		{"other codings only", "deflate, br", false},
+		{"not a prefix match", "x-gzip", false},
+		{"uppercase", "GZIP", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := acceptsGzip(tc.header); got != tc.want {
+				t.Fatalf("acceptsGzip(%q) = %v, want %v", tc.header, got, tc.want)
+			}
+		})
+	}
+}
+
+// compressibleBinary writes a file that gzips well, so the test can assert the
+// wire form is genuinely smaller rather than accidentally passing on noise.
+func compressibleBinary(t *testing.T, size int) (string, []byte) {
+	t.Helper()
+
+	data := make([]byte, size)
+	seed := make([]byte, 512)
+	if _, err := rand.Read(seed); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	for i := range data {
+		data[i] = seed[i%len(seed)]
+	}
+
+	path := filepath.Join(t.TempDir(), "patchmon-agent-linux-amd64")
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return path, data
+}
+
+func binaryServer(t *testing.T, path string) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f, err := os.Open(path)
+		if err != nil {
+			t.Errorf("open: %v", err)
+			return
+		}
+		defer func() { _ = f.Close() }()
+
+		info, err := f.Stat()
+		if err != nil {
+			t.Errorf("stat: %v", err)
+			return
+		}
+		serveAgentBinary(w, r, filepath.Base(path), info, f)
+	}))
+}
+
+// The agent hashes what it reads and compares against the hash of the raw file,
+// so transparent decompression must hand back the exact original bytes.
+func TestServeAgentBinaryGzipRoundTripPreservesHash(t *testing.T) {
+	path, want := compressibleBinary(t, 512*1024)
+	srv := binaryServer(t, path)
+	defer srv.Close()
+
+	resp, err := srv.Client().Get(srv.URL)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if !resp.Uncompressed {
+		t.Fatal("expected the transport to have negotiated and unwrapped gzip")
+	}
+
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if sha256.Sum256(got) != sha256.Sum256(want) {
+		t.Fatalf("hash mismatch: got %d bytes, want %d bytes", len(got), len(want))
+	}
+}
+
+func TestServeAgentBinaryCompressesTheWire(t *testing.T) {
+	path, want := compressibleBinary(t, 512*1024)
+	srv := binaryServer(t, path)
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	client := &http.Client{Transport: &http.Transport{DisableCompression: true}}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if enc := resp.Header.Get("Content-Encoding"); enc != "gzip" {
+		t.Fatalf("Content-Encoding = %q, want gzip", enc)
+	}
+	if vary := resp.Header.Get("Vary"); vary != "Accept-Encoding" {
+		t.Fatalf("Vary = %q, want Accept-Encoding", vary)
+	}
+
+	wire, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read wire: %v", err)
+	}
+	if len(wire) >= len(want) {
+		t.Fatalf("wire form %d bytes is not smaller than the raw %d bytes", len(wire), len(want))
+	}
+
+	zr, err := gzip.NewReader(bytes.NewReader(wire))
+	if err != nil {
+		t.Fatalf("gzip reader: %v", err)
+	}
+	defer func() { _ = zr.Close() }()
+
+	got, err := io.ReadAll(zr)
+	if err != nil {
+		t.Fatalf("gunzip: %v", err)
+	}
+	if sha256.Sum256(got) != sha256.Sum256(want) {
+		t.Fatal("gunzipped payload does not match the source file")
+	}
+}
+
+func TestServeAgentBinaryIdentityWhenGzipNotAccepted(t *testing.T) {
+	path, want := compressibleBinary(t, 64*1024)
+	srv := binaryServer(t, path)
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set("Accept-Encoding", "identity")
+
+	client := &http.Client{Transport: &http.Transport{DisableCompression: true}}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if enc := resp.Header.Get("Content-Encoding"); enc != "" {
+		t.Fatalf("Content-Encoding = %q, want empty", enc)
+	}
+	if resp.ContentLength != int64(len(want)) {
+		t.Fatalf("Content-Length = %d, want %d", resp.ContentLength, len(want))
+	}
+}
+
+// Range requests must stay uncompressed, otherwise the byte offsets a resuming
+// client asks for would address the compressed stream instead of the binary.
+func TestServeAgentBinaryRangeStaysUncompressed(t *testing.T) {
+	path, want := compressibleBinary(t, 64*1024)
+	srv := binaryServer(t, path)
+	defer srv.Close()
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set("Accept-Encoding", "gzip")
+	req.Header.Set("Range", "bytes=100-199")
+
+	client := &http.Client{Transport: &http.Transport{DisableCompression: true}}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusPartialContent {
+		t.Fatalf("status = %d, want 206", resp.StatusCode)
+	}
+	if enc := resp.Header.Get("Content-Encoding"); enc != "" {
+		t.Fatalf("Content-Encoding = %q, want empty for a range request", enc)
+	}
+
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if len(got) != 100 {
+		t.Fatalf("got %d bytes, want 100", len(got))
+	}
+	for i, b := range got {
+		if b != want[100+i] {
+			t.Fatalf("byte %d of the range does not match the source file", i)
+		}
+	}
+}
+
+func TestServeAgentBinaryConditionalRequestStillAnswers304(t *testing.T) {
+	path, _ := compressibleBinary(t, 64*1024)
+	srv := binaryServer(t, path)
+	defer srv.Close()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set("Accept-Encoding", "gzip")
+	req.Header.Set("If-Modified-Since", info.ModTime().UTC().Format(http.TimeFormat))
+
+	client := &http.Client{Transport: &http.Transport{DisableCompression: true}}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNotModified {
+		t.Fatalf("status = %d, want 304", resp.StatusCode)
+	}
+}
+
+// The gzip writers are pooled and shared across every context this process
+// serves, so a reused writer must never carry bytes from a previous response.
+func TestServeAgentBinaryPooledWritersDoNotBleed(t *testing.T) {
+	path, want := compressibleBinary(t, 128*1024)
+	srv := binaryServer(t, path)
+	defer srv.Close()
+
+	for i := 0; i < 8; i++ {
+		resp, err := srv.Client().Get(srv.URL)
+		if err != nil {
+			t.Fatalf("get %d: %v", i, err)
+		}
+		got, err := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if err != nil {
+			t.Fatalf("read %d: %v", i, err)
+		}
+		if sha256.Sum256(got) != sha256.Sum256(want) {
+			t.Fatalf("response %d does not match the source file", i)
+		}
+	}
+}

--- a/server-source-code/internal/handler/agent_binary_serve_test.go
+++ b/server-source-code/internal/handler/agent_binary_serve_test.go
@@ -41,8 +41,6 @@ func TestAcceptsGzip(t *testing.T) {
 	}
 }
 
-// compressibleBinary writes a file that gzips well, so the test can assert the
-// wire form is genuinely smaller rather than accidentally passing on noise.
 func compressibleBinary(t *testing.T, size int) (string, []byte) {
 	t.Helper()
 
@@ -82,8 +80,6 @@ func binaryServer(t *testing.T, path string) *httptest.Server {
 	}))
 }
 
-// The agent hashes what it reads and compares against the hash of the raw file,
-// so transparent decompression must hand back the exact original bytes.
 func TestServeAgentBinaryGzipRoundTripPreservesHash(t *testing.T) {
 	path, want := compressibleBinary(t, 512*1024)
 	srv := binaryServer(t, path)
@@ -182,8 +178,6 @@ func TestServeAgentBinaryIdentityWhenGzipNotAccepted(t *testing.T) {
 	}
 }
 
-// Range requests must stay uncompressed, otherwise the byte offsets a resuming
-// client asks for would address the compressed stream instead of the binary.
 func TestServeAgentBinaryRangeStaysUncompressed(t *testing.T) {
 	path, want := compressibleBinary(t, 64*1024)
 	srv := binaryServer(t, path)
@@ -253,8 +247,70 @@ func TestServeAgentBinaryConditionalRequestStillAnswers304(t *testing.T) {
 	}
 }
 
-// The gzip writers are pooled and shared across every context this process
-// serves, so a reused writer must never carry bytes from a previous response.
+// A burst must degrade to the uncompressed path rather than allocating an
+// unbounded number of compressors on the shared heap.
+func TestServeAgentBinaryFallsBackToIdentityWhenSlotsExhausted(t *testing.T) {
+	path, want := compressibleBinary(t, 64*1024)
+	srv := binaryServer(t, path)
+	defer srv.Close()
+
+	for i := 0; i < maxConcurrentAgentGzip; i++ {
+		agentGzipSlots <- struct{}{}
+	}
+	defer func() {
+		for i := 0; i < maxConcurrentAgentGzip; i++ {
+			<-agentGzipSlots
+		}
+	}()
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	req.Header.Set("Accept-Encoding", "gzip")
+
+	client := &http.Client{Transport: &http.Transport{DisableCompression: true}}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("do: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if enc := resp.Header.Get("Content-Encoding"); enc != "" {
+		t.Fatalf("Content-Encoding = %q, want empty once slots are exhausted", enc)
+	}
+	if resp.ContentLength != int64(len(want)) {
+		t.Fatalf("Content-Length = %d, want %d", resp.ContentLength, len(want))
+	}
+
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if sha256.Sum256(got) != sha256.Sum256(want) {
+		t.Fatal("fallback response does not match the source file")
+	}
+}
+
+func TestServeAgentBinarySlotsAreReleased(t *testing.T) {
+	path, _ := compressibleBinary(t, 32*1024)
+	srv := binaryServer(t, path)
+	defer srv.Close()
+
+	for i := 0; i < maxConcurrentAgentGzip+4; i++ {
+		resp, err := srv.Client().Get(srv.URL)
+		if err != nil {
+			t.Fatalf("get %d: %v", i, err)
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}
+
+	if len(agentGzipSlots) != 0 {
+		t.Fatalf("%d slots still held after sequential requests", len(agentGzipSlots))
+	}
+}
+
 func TestServeAgentBinaryPooledWritersDoNotBleed(t *testing.T) {
 	path, want := compressibleBinary(t, 128*1024)
 	srv := binaryServer(t, path)

--- a/server-source-code/internal/handler/agent_binary_serve_test.go
+++ b/server-source-code/internal/handler/agent_binary_serve_test.go
@@ -247,8 +247,6 @@ func TestServeAgentBinaryConditionalRequestStillAnswers304(t *testing.T) {
 	}
 }
 
-// A burst must degrade to the uncompressed path rather than allocating an
-// unbounded number of compressors on the shared heap.
 func TestServeAgentBinaryFallsBackToIdentityWhenSlotsExhausted(t *testing.T) {
 	path, want := compressibleBinary(t, 64*1024)
 	srv := binaryServer(t, path)

--- a/server-source-code/internal/handler/agent_version.go
+++ b/server-source-code/internal/handler/agent_version.go
@@ -218,9 +218,7 @@ func (h *AgentVersionHandler) ServeAgentDownload(w http.ResponseWriter, r *http.
 		return
 	}
 	defer func() { _ = f.Close() }()
-	w.Header().Set("Content-Type", "application/octet-stream")
-	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, binaryName))
-	http.ServeContent(w, r, binaryName, info.ModTime(), f)
+	serveAgentBinary(w, r, binaryName, info, f)
 }
 
 // CheckForUpdates refreshes the upstream version from DNS and reports whether

--- a/server-source-code/internal/handler/agent_version.go
+++ b/server-source-code/internal/handler/agent_version.go
@@ -218,7 +218,7 @@ func (h *AgentVersionHandler) ServeAgentDownload(w http.ResponseWriter, r *http.
 		return
 	}
 	defer func() { _ = f.Close() }()
-	serveAgentBinary(w, r, binaryName, info, f)
+	serveAgentBinary(w, r, binaryPath, info, f)
 }
 
 // CheckForUpdates refreshes the upstream version from DNS and reports whether

--- a/server-source-code/internal/handler/install.go
+++ b/server-source-code/internal/handler/install.go
@@ -1138,7 +1138,5 @@ func (h *InstallHandler) ServeAgentDownload(w http.ResponseWriter, r *http.Reque
 	}
 	defer func() { _ = f.Close() }()
 
-	w.Header().Set("Content-Type", "application/octet-stream")
-	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s"`, binaryName))
-	http.ServeContent(w, r, binaryName, info.ModTime(), f)
+	serveAgentBinary(w, r, binaryName, info, f)
 }

--- a/server-source-code/internal/handler/install.go
+++ b/server-source-code/internal/handler/install.go
@@ -1138,5 +1138,5 @@ func (h *InstallHandler) ServeAgentDownload(w http.ResponseWriter, r *http.Reque
 	}
 	defer func() { _ = f.Close() }()
 
-	serveAgentBinary(w, r, binaryName, info, f)
+	serveAgentBinary(w, r, binaryPath, info, f)
 }


### PR DESCRIPTION
## Agent self-update

- Agents on high-latency links could never self-update. The whole binary download sat under a single 30 second deadline covering connection, TLS and every byte, so a ~12MB binary needed 3.2Mbit/s sustained to finish and success depended on distance rather than on anything being wrong. Hosts within about 30ms updated first time, distant ones needed repeated attempts, and the most distant failed indefinitely with `failed to read binary data: context deadline exceeded` at exactly 30 seconds. The download is now bounded by progress instead: it is abandoned only after 60 seconds with no bytes at all, under a 30 minute absolute ceiling, so a slow but healthy link finishes
- Two self-updates could run at once. Scheduled reports run on their own goroutines and the WebSocket service loop triggers updates independently, so both could download a binary, write the same temporary file and rename it over the live executable. The existing guard covers repeat updates over time, not concurrent entry. A second update is now refused while one is running
- A stalled download is reported as `download stalled: no data received for 1m0s after N bytes`, which distinguishes a dead link from a slow one and says how far the transfer got. The old message could not tell the two apart
- The agent logs the size, elapsed time and whether the response was compressed on every successful binary download, so a slow self-update can be diagnosed from the agent log without reproducing it
- `HTTP_PROXY` and `HTTPS_PROXY` are honoured explicitly. The previous code path picked this up from the default HTTP client; the replacement sets it deliberately so it cannot be lost

## Agent binary downloads

- Binaries are served gzip-compressed to clients that accept it, taking the transfer from roughly 12MB to 5MB. This covers the agent self-update download and the authenticated download in the UI
- Integrity verification is unaffected: the published hash is over the uncompressed binary and the agent verifies what it decompressed. Binaries are unchanged on disk and in the release artefacts, so compression happens only in flight and agents on 2.1.0 through 2.1.3 benefit as soon as the server is upgraded, without updating first
- Compressed responses are cached in memory with an idle expiry, and concurrent compression of the same binary is collapsed to a single pass
- Range and conditional requests bypass compression, preserving 206 and 304 semantics

## Windows

- Server 2016 and Server 2019 LTSC reported `osVersion=Unknown` on every host. gopsutil returns the `DisplayVersion` registry value as the platform version, and that value does not exist before Server 2022, so the agent had nothing to report. It now falls back to `ReleaseId` (`1607` on 2016, `1809` on 2019 LTSC) and then to the full build string. Server 2022 and later are unchanged
- The operator guide documents the one-time manual binary replacement that recovers a host stranded on 2.0.2 or earlier, where the running executable is locked by the Service Control Manager and the pre-2.1.0 updater has no detached helper to perform the swap. Upgrading the server does not clear it, because the fix ships in the agent binary that cannot be installed. 2.1.0 and later are unaffected

Fixes #1071
Fixes #759
Refs #1067
