### PR TITLE
ci: pin golangci-lint and clear the findings its 2.13.1 release added

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9
         with:
-          version: latest
+          version: v2.13.1
           working-directory: server-source-code
 
   fmt-check:
@@ -236,7 +236,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9
         with:
-          version: latest
+          version: v2.13.1
           working-directory: agent-source-code
 
   agent-build:
@@ -334,7 +334,7 @@ jobs:
           GOOS: windows
           GOARCH: amd64
         with:
-          version: latest
+          version: v2.13.1
           working-directory: agent-source-code
 
   # Runs the agent on a real Windows host: unit tests compiled for Windows, the

--- a/agent-source-code/.golangci.yml
+++ b/agent-source-code/.golangci.yml
@@ -12,3 +12,11 @@ linters:
     - misspell
     - revive
     # - gosec
+
+  exclusions:
+    rules:
+      # SA4023 here is a non-Windows build artefact: the stub can only return non-nil.
+      - path: cmd/patchmon-agent/commands/(serve|version_update)\.go
+        linters:
+          - staticcheck
+        text: SA4023

--- a/server-source-code/internal/agentregistry/publish_forward_test.go
+++ b/server-source-code/internal/agentregistry/publish_forward_test.go
@@ -84,9 +84,8 @@ func newRecordingRedis(t *testing.T) (*redisclient.Client, func(channel string) 
 	countFor := func(channel string) int {
 		mu.Lock()
 		defer mu.Unlock()
-		ps, ok := subs[channel]
-		if !ok {
-			ps = client.Subscribe(context.Background(), channel)
+		if _, ok := subs[channel]; !ok {
+			ps := client.Subscribe(context.Background(), channel)
 			subs[channel] = ps
 			t.Cleanup(func() { _ = ps.Close() })
 			// Drain in the background, tallying.


### PR DESCRIPTION
## What broke

The three golangci-lint jobs in `test.yml` requested `version: latest`. golangci-lint 2.13.1 was released on 20 August with a newer staticcheck, and it red-lined every open pull request without a line of code changing. Reproduced against a clean `main` with 2.13.1 locally: 8 issues in the agent module, 1 in the server module, entirely in code that no open branch had touched.

## Changes

- Pin golangci-lint in all three lint jobs. Pinned forward to `v2.13.1` rather than back to the version that was passing, so the pin costs no lint coverage
- `publish_forward_test.go`: fix a real SA4006. The value read from the `subs` map is only ever used in the branch that immediately overwrites it, so the read is dead. The subscription is now scoped to that branch
- `agent-source-code/.golangci.yml`: exclude SA4023 for `serve.go` and `version_update.go`

## Why SA4023 is excluded rather than fixed

`secureUpdateDir` and the `WindowsPatcher` methods have non-Windows stubs that can only return a non-nil error, so on the native build staticcheck can prove the nil comparisons at those call sites. The Windows build is correct, and the `GOOS=windows` lint job reports nothing either before or after this change. Contorting the call sites to satisfy the native build would make the Windows path worse, so the two files carry a narrow exclusion for that one check.

There were 16 SA4023 reports in total, not the 8 CI showed. The default `max-same-issues` cap of 3 hid the rest until the first file was excluded.

## Verification

Run locally with golangci-lint 2.13.1, `--max-same-issues=0 --max-issues-per-linter=0`:

| Configuration | Before | After |
|---|---|---|
| agent, native | 16 issues | 0 issues |
| agent, `GOOS=windows` | 0 issues | 0 issues |
| server | 1 issue | 0 issues |

`go test ./internal/agentregistry/` passes and `gofmt` is clean.
